### PR TITLE
Add streaming partial transcription

### DIFF
--- a/app/src/main/kotlin/com/soniqo/speech/demo/MainActivity.kt
+++ b/app/src/main/kotlin/com/soniqo/speech/demo/MainActivity.kt
@@ -207,6 +207,7 @@ class MainActivity : ComponentActivity() {
                     modelDir = modelDir,
                     useNnapi = false,
                     precision = ModelPrecision.INT8,
+                    emitPartialTranscriptions = true,
                 )
 
                 val p = SpeechPipeline(config)
@@ -227,6 +228,10 @@ class MainActivity : ComponentActivity() {
                                 val speechDur = System.currentTimeMillis() - speechStartTime
                                 setStatus("transcribing... (${"%.1f".format(speechDur / 1000f)}s)")
                                 setMicColor("#FF9800")
+                            }
+
+                            is SpeechEvent.PartialTranscription -> {
+                                setStatus("hearing: ${event.text}")
                             }
 
                             is SpeechEvent.TranscriptionCompleted -> {

--- a/sdk/src/main/cpp/jni_bridge.cpp
+++ b/sdk/src/main/cpp/jni_bridge.cpp
@@ -108,6 +108,48 @@ static int stt_sample_rate(void* ctx) {
     return static_cast<ParakeetStt*>(ctx)->input_sample_rate();
 }
 
+static void stt_begin_stream(void* ctx, int sample_rate) {
+    static_cast<ParakeetStt*>(ctx)->begin_stream(sample_rate);
+}
+
+static sc_partial_result_t stt_push_chunk(void* ctx, const float* audio, size_t len) {
+    auto* stt = static_cast<ParakeetStt*>(ctx);
+    auto r = stt->push_chunk(audio, len);
+    static thread_local std::string text_buf;
+    static thread_local std::string lang_buf;
+    text_buf = std::move(r.text);
+    lang_buf = std::move(r.language);
+    return {
+        .text = text_buf.c_str(),
+        .language = lang_buf.empty() ? nullptr : lang_buf.c_str(),
+        .confidence = r.confidence,
+    };
+}
+
+static void stt_flush_stream(void* ctx) {
+    static_cast<ParakeetStt*>(ctx)->flush_stream();
+}
+
+static sc_transcription_result_t stt_end_stream(void* ctx) {
+    auto* stt = static_cast<ParakeetStt*>(ctx);
+    auto r = stt->end_stream();
+    static thread_local std::string text_buf;
+    static thread_local std::string lang_buf;
+    text_buf = std::move(r.text);
+    lang_buf = std::move(r.language);
+    return {
+        .text = text_buf.c_str(),
+        .language = lang_buf.empty() ? nullptr : lang_buf.c_str(),
+        .confidence = r.confidence,
+        .start_time = 0.0f,
+        .end_time = 0.0f,
+    };
+}
+
+static void stt_cancel_stream(void* ctx) {
+    static_cast<ParakeetStt*>(ctx)->cancel_stream();
+}
+
 // --- TTS ---
 
 static void tts_synthesize(
@@ -237,7 +279,8 @@ JNIEXPORT jlong JNICALL
 Java_audio_soniqo_speech_NativeBridge_nativeCreate(
     JNIEnv* env, jobject /*thiz*/,
     jstring modelDir, jboolean useNnapi, jboolean useInt8,
-    jobject callback, jobject llmCallback)
+    jobject callback, jobject llmCallback,
+    jboolean emitPartialTranscriptions, jfloat partialTranscriptionInterval)
 {
     auto dir = jstring_to_string(env, modelDir);
     bool nnapi = useNnapi;
@@ -290,6 +333,11 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
         stt_vt.context = h->stt;
         stt_vt.transcribe = stt_transcribe;
         stt_vt.input_sample_rate = stt_sample_rate;
+        stt_vt.begin_stream = stt_begin_stream;
+        stt_vt.push_chunk = stt_push_chunk;
+        stt_vt.flush_stream = stt_flush_stream;
+        stt_vt.end_stream = stt_end_stream;
+        stt_vt.cancel_stream = stt_cancel_stream;
 
         sc_tts_vtable_t tts_vt = {};
         tts_vt.context = h->tts;
@@ -299,10 +347,12 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
 
         // Pipeline config
         sc_config_t config = sc_config_default();
-        config.min_silence_duration = 0.5f;  // 500ms — balance: avoid word splits, catch short phrases
-        config.eager_stt = false;              // wait for full silence confirmation
-        config.min_speech_duration = 0.15f;    // 150ms — catch short words like "hi", "yes"
-        config.post_playback_guard = 0.15f;    // 150ms — shorter guard for faster response after TTS
+        config.min_silence_duration = 0.5f;
+        config.eager_stt = false;
+        config.min_speech_duration = 0.15f;
+        config.post_playback_guard = 0.15f;
+        config.emit_partial_transcriptions = emitPartialTranscriptions;
+        config.partial_transcription_interval = partialTranscriptionInterval;
 
         if (h->llm) {
             // Full agent mode: STT → LLM → TTS

--- a/sdk/src/main/cpp/models/parakeet_stt.cpp
+++ b/sdk/src/main/cpp/models/parakeet_stt.cpp
@@ -371,3 +371,42 @@ ParakeetStt::Result ParakeetStt::tdt_decode(
 
     return result;
 }
+
+// ---------------------------------------------------------------------------
+// Streaming: accumulate audio and re-transcribe
+// ---------------------------------------------------------------------------
+
+void ParakeetStt::begin_stream(int sample_rate) {
+    stream_buffer_.clear();
+    stream_sample_rate_ = sample_rate;
+    streaming_ = true;
+}
+
+ParakeetStt::Result ParakeetStt::push_chunk(const float* audio, size_t length) {
+    stream_buffer_.insert(stream_buffer_.end(), audio, audio + length);
+
+    // Need at least 0.5s of audio for meaningful transcription
+    if (stream_buffer_.size() < static_cast<size_t>(stream_sample_rate_ / 2)) {
+        return {};
+    }
+
+    return transcribe(stream_buffer_.data(), stream_buffer_.size(), stream_sample_rate_);
+}
+
+ParakeetStt::Result ParakeetStt::end_stream() {
+    streaming_ = false;
+    if (stream_buffer_.empty()) return {};
+
+    auto result = transcribe(stream_buffer_.data(), stream_buffer_.size(), stream_sample_rate_);
+    stream_buffer_.clear();
+    return result;
+}
+
+void ParakeetStt::cancel_stream() {
+    stream_buffer_.clear();
+    streaming_ = false;
+}
+
+void ParakeetStt::flush_stream() {
+    // No-op — single-utterance sessions only
+}

--- a/sdk/src/main/cpp/models/parakeet_stt.h
+++ b/sdk/src/main/cpp/models/parakeet_stt.h
@@ -46,6 +46,14 @@ public:
     Result transcribe(const float* audio, size_t length, int sample_rate);
     int input_sample_rate() const { return cfg_.sample_rate; }
 
+    // Streaming: accumulate audio and re-transcribe on each push_chunk call
+    bool supports_streaming() const { return true; }
+    void begin_stream(int sample_rate);
+    Result push_chunk(const float* audio, size_t length);
+    Result end_stream();
+    void cancel_stream();
+    void flush_stream();
+
 private:
     bool load_vocab(const std::string& path);
     std::vector<float> compute_mel(const float* audio, size_t length);
@@ -62,4 +70,9 @@ private:
 
     // Language tokens: token ID → ISO 639-1 code (e.g. 64 → "en", 71 → "fr")
     std::unordered_map<int, std::string> lang_tokens_;
+
+    // Streaming state
+    std::vector<float> stream_buffer_;
+    int stream_sample_rate_ = 16000;
+    bool streaming_ = false;
 };

--- a/sdk/src/main/kotlin/com/soniqo/speech/NativeBridge.kt
+++ b/sdk/src/main/kotlin/com/soniqo/speech/NativeBridge.kt
@@ -12,6 +12,8 @@ internal object NativeBridge {
         useInt8: Boolean,
         callback: EventCallback,
         llmCallback: LlmCallback?,
+        emitPartialTranscriptions: Boolean,
+        partialTranscriptionInterval: Float,
     ): Long
 
     external fun nativeNnapiFallbackReason(): String?

--- a/sdk/src/main/kotlin/com/soniqo/speech/SpeechConfig.kt
+++ b/sdk/src/main/kotlin/com/soniqo/speech/SpeechConfig.kt
@@ -23,4 +23,10 @@ data class SpeechConfig(
 
     /** Claude model to use for LLM inference. */
     val llmModel: String = "claude-sonnet-4-6",
+
+    /** Emit partial transcription events during speech (words appear as you speak). */
+    val emitPartialTranscriptions: Boolean = false,
+
+    /** Interval between partial transcriptions in seconds. */
+    val partialTranscriptionInterval: Float = 0.5f,
 )

--- a/sdk/src/main/kotlin/com/soniqo/speech/SpeechPipeline.kt
+++ b/sdk/src/main/kotlin/com/soniqo/speech/SpeechPipeline.kt
@@ -73,9 +73,20 @@ class SpeechPipeline(private val config: SpeechConfig) : AutoCloseable {
     }
 
     init {
-        val rt = Runtime.getRuntime()
-        val availableMb = (rt.maxMemory() - rt.totalMemory() + rt.freeMemory()) / 1_048_576
-        if (availableMb < 300) {
+        val memInfo = android.app.ActivityManager.MemoryInfo()
+        val am = config.modelDir.let {
+            // Use app context from model dir parent to get ActivityManager
+            // Falls back to JVM check if context unavailable
+            null as? android.app.ActivityManager
+        }
+        // Check native available memory via /proc/meminfo
+        val availableMb = try {
+            val meminfo = java.io.File("/proc/meminfo").readText()
+            val match = Regex("""MemAvailable:\s+(\d+)\s+kB""").find(meminfo)
+            (match?.groupValues?.get(1)?.toLongOrNull() ?: 0L) / 1024
+        } catch (_: Exception) { Long.MAX_VALUE }
+
+        if (availableMb < 1200) {
             throw IllegalStateException(
                 "Not enough memory to load models. Available: ${availableMb}MB, " +
                 "required: ~1.2GB. Close other apps and try again."
@@ -89,6 +100,8 @@ class SpeechPipeline(private val config: SpeechConfig) : AutoCloseable {
         config.precision == ModelPrecision.INT8,
         nativeCallback,
         llmCallback,
+        config.emitPartialTranscriptions,
+        config.partialTranscriptionInterval,
     )
 
     val state: PipelineState


### PR DESCRIPTION
## Summary

- Implement incremental streaming for Parakeet TDT STT
- Words appear in real-time as the user speaks (every 500ms)
- Configurable via `SpeechConfig.emitPartialTranscriptions`
- Demo app shows partial text in status bar

## Changes

- `ParakeetStt`: streaming methods (begin_stream, push_chunk, end_stream, cancel_stream)
- `jni_bridge.cpp`: wire 5 streaming vtable slots to speech-core pipeline
- `SpeechConfig.kt`: add `emitPartialTranscriptions` and `partialTranscriptionInterval`
- `NativeBridge.kt` + `SpeechPipeline.kt`: pass config to JNI
- `MainActivity.kt`: display partial transcription in status bar
- Fix memory check to use `/proc/meminfo` instead of JVM heap

## Test plan

- [x] 15/15 unit tests pass
- [x] 31/31 e2e tests pass on arm64 emulator (API 35, 4GB RAM)
- [ ] Manual test on physical device with real speech