### PR TITLE
Fix release APK crash: add ProGuard rules for JNI

### DIFF
--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -35,6 +35,7 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = false
+            consumerProguardFiles("consumer-rules.pro")
         }
     }
 

--- a/sdk/consumer-rules.pro
+++ b/sdk/consumer-rules.pro
@@ -1,0 +1,13 @@
+# Keep JNI callback interfaces — native code looks up methods by name
+-keep class audio.soniqo.speech.NativeBridge { *; }
+-keep class audio.soniqo.speech.NativeBridge$EventCallback { *; }
+-keep class audio.soniqo.speech.NativeBridge$LlmCallback { *; }
+
+# Keep all public SDK classes
+-keep class audio.soniqo.speech.SpeechPipeline { *; }
+-keep class audio.soniqo.speech.SpeechConfig { *; }
+-keep class audio.soniqo.speech.SpeechEvent { *; }
+-keep class audio.soniqo.speech.SpeechEvent$* { *; }
+-keep class audio.soniqo.speech.ModelManager { *; }
+-keep class audio.soniqo.speech.ModelPrecision { *; }
+-keep class audio.soniqo.speech.PipelineState { *; }


### PR DESCRIPTION
## Summary

Release APK crashes with `NoSuchMethodError` on all devices because R8 renames JNI callback methods that native code looks up by name.

## Root cause

`NativeBridge.EventCallback.onEvent()` and `LlmCallback.chat()/cancel()` are called from C++ via `env->GetMethodID(cls, "onEvent", ...)`. R8 renames these in the release build, so the native lookup fails.

## Fix

Add `consumer-rules.pro` that keeps all JNI-facing interfaces and public SDK classes. Consumer rules are bundled with the AAR so any app using the SDK gets them automatically.

## Test plan

- [x] `./gradlew :app:assembleRelease` builds successfully
- [x] 15/15 unit tests pass

Reported by: UnexploredEnigma (Pixel 8, GrapheneOS)