### PR TITLE
Enable NNAPI auto-detection for real devices

### DIFF
--- a/app/src/main/kotlin/com/soniqo/speech/demo/MainActivity.kt
+++ b/app/src/main/kotlin/com/soniqo/speech/demo/MainActivity.kt
@@ -205,7 +205,7 @@ class MainActivity : ComponentActivity() {
 
                 val config = SpeechConfig(
                     modelDir = modelDir,
-                    useNnapi = false,
+                    useNnapi = !isEmulator,
                     precision = ModelPrecision.INT8,
                     emitPartialTranscriptions = true,
                 )

--- a/sdk/src/main/cpp/CMakeLists.txt
+++ b/sdk/src/main/cpp/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(speech_android SHARED
     audio/mel.cpp
     audio/fft.cpp
     audio/stft.cpp
+    models/soc_detect.cpp
     models/silero_vad.cpp
     models/parakeet_stt.cpp
     models/kokoro_tts.cpp

--- a/sdk/src/main/cpp/models/inference_engine.h
+++ b/sdk/src/main/cpp/models/inference_engine.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+/// Supported inference backends.
+enum class Backend { ONNX, LITERT, AUTO };
+
+/// Tensor element data types.
+enum class DType { FLOAT32, INT64, INT32, INT8 };
+
+/// Describes a tensor's data, shape, and type for passing to inference.
+struct TensorInfo {
+    const void* data;
+    std::vector<int64_t> shape;
+    DType dtype;
+
+    size_t byte_size() const {
+        size_t elems = 1;
+        for (auto d : shape) elems *= static_cast<size_t>(d);
+        switch (dtype) {
+            case DType::FLOAT32: return elems * 4;
+            case DType::INT64:   return elems * 8;
+            case DType::INT32:   return elems * 4;
+            case DType::INT8:    return elems * 1;
+        }
+        return elems * 4;
+    }
+};
+
+/// Wraps a single output tensor from an inference call.
+/// Owns the backend-specific memory — valid until destroyed or next run().
+class OutputTensor {
+public:
+    virtual ~OutputTensor() = default;
+
+    virtual float* data_float() = 0;
+    virtual int64_t* data_int64() = 0;
+    virtual std::vector<int64_t> shape() = 0;
+    virtual size_t element_count() = 0;
+};
+
+/// A loaded model session — run inference with named inputs/outputs.
+class InferenceSession {
+public:
+    virtual ~InferenceSession() = default;
+
+    /// Run inference. Outputs are returned as owned OutputTensor objects.
+    virtual std::vector<std::unique_ptr<OutputTensor>> run(
+        const std::vector<const char*>& input_names,
+        const std::vector<TensorInfo>& inputs,
+        const std::vector<const char*>& output_names) = 0;
+};
+
+/// Factory for loading models. Each backend implements this.
+class InferenceBackend {
+public:
+    virtual ~InferenceBackend() = default;
+
+    virtual std::unique_ptr<InferenceSession> load(
+        const std::string& path, bool hw_accel = true) = 0;
+
+    virtual Backend type() const = 0;
+};
+
+/// Detect the optimal backend for the current device's SoC.
+Backend detect_optimal_backend();
+
+/// Create a backend instance. AUTO resolves via detect_optimal_backend().
+std::unique_ptr<InferenceBackend> create_backend(Backend preference);

--- a/sdk/src/main/cpp/models/onnx_backend.h
+++ b/sdk/src/main/cpp/models/onnx_backend.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "inference_engine.h"
+#include "onnx_engine.h"
+#include <memory>
+#include <string>
+#include <vector>
+
+/// ONNX Runtime output tensor — wraps OrtValue*.
+class OnnxOutputTensor : public OutputTensor {
+public:
+    OnnxOutputTensor(const OrtApi* api, OrtValue* value) : api_(api), value_(value) {}
+
+    ~OnnxOutputTensor() override {
+        if (value_) api_->ReleaseValue(value_);
+    }
+
+    float* data_float() override {
+        float* data = nullptr;
+        ort_check(api_, api_->GetTensorMutableData(value_, (void**)&data));
+        return data;
+    }
+
+    int64_t* data_int64() override {
+        int64_t* data = nullptr;
+        ort_check(api_, api_->GetTensorMutableData(value_, (void**)&data));
+        return data;
+    }
+
+    std::vector<int64_t> shape() override {
+        OrtTensorTypeAndShapeInfo* info = nullptr;
+        ort_check(api_, api_->GetTensorTypeAndShape(value_, &info));
+        size_t dim_count = 0;
+        api_->GetDimensionsCount(info, &dim_count);
+        std::vector<int64_t> dims(dim_count);
+        api_->GetDimensions(info, dims.data(), dim_count);
+        api_->ReleaseTensorTypeAndShapeInfo(info);
+        return dims;
+    }
+
+    size_t element_count() override {
+        auto s = shape();
+        size_t n = 1;
+        for (auto d : s) n *= static_cast<size_t>(d);
+        return n;
+    }
+
+private:
+    const OrtApi* api_;
+    OrtValue* value_;
+};
+
+/// ONNX Runtime session — wraps OrtSession*.
+class OnnxSession : public InferenceSession {
+public:
+    OnnxSession(const OrtApi* api, OrtSession* session)
+        : api_(api), session_(session) {}
+
+    ~OnnxSession() override {
+        if (session_) api_->ReleaseSession(session_);
+    }
+
+    std::vector<std::unique_ptr<OutputTensor>> run(
+        const std::vector<const char*>& input_names,
+        const std::vector<TensorInfo>& inputs,
+        const std::vector<const char*>& output_names) override
+    {
+        auto* mem = OnnxEngine::get().cpu_memory();
+        size_t num_in = inputs.size();
+        size_t num_out = output_names.size();
+
+        // Create input OrtValues
+        std::vector<OrtValue*> ort_inputs(num_in, nullptr);
+        for (size_t i = 0; i < num_in; i++) {
+            auto& t = inputs[i];
+            ONNXTensorElementDataType ort_dtype;
+            switch (t.dtype) {
+                case DType::FLOAT32: ort_dtype = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT; break;
+                case DType::INT64:   ort_dtype = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64; break;
+                case DType::INT32:   ort_dtype = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32; break;
+                case DType::INT8:    ort_dtype = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8; break;
+            }
+            ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+                mem,
+                const_cast<void*>(t.data),
+                t.byte_size(),
+                t.shape.data(),
+                t.shape.size(),
+                ort_dtype,
+                &ort_inputs[i]));
+        }
+
+        // Prepare output array
+        std::vector<OrtValue*> ort_outputs(num_out, nullptr);
+
+        // Run
+        ort_check(api_, api_->Run(
+            session_, nullptr,
+            input_names.data(), ort_inputs.data(), num_in,
+            output_names.data(), num_out, ort_outputs.data()));
+
+        // Release inputs
+        for (auto* v : ort_inputs) api_->ReleaseValue(v);
+
+        // Wrap outputs
+        std::vector<std::unique_ptr<OutputTensor>> results;
+        results.reserve(num_out);
+        for (auto* v : ort_outputs) {
+            results.push_back(std::make_unique<OnnxOutputTensor>(api_, v));
+        }
+        return results;
+    }
+
+private:
+    const OrtApi* api_;
+    OrtSession* session_;
+};
+
+/// ONNX Runtime backend — delegates to OnnxEngine singleton.
+class OnnxBackend : public InferenceBackend {
+public:
+    std::unique_ptr<InferenceSession> load(
+        const std::string& path, bool hw_accel = true) override
+    {
+        auto& engine = OnnxEngine::get();
+        OrtSession* session = engine.load(path, hw_accel);
+        return std::make_unique<OnnxSession>(engine.api(), session);
+    }
+
+    Backend type() const override { return Backend::ONNX; }
+};

--- a/sdk/src/main/cpp/models/onnx_engine.h
+++ b/sdk/src/main/cpp/models/onnx_engine.h
@@ -46,6 +46,8 @@ public:
         api_->SetIntraOpNumThreads(opts, 2);
 
         if (nnapi) {
+            LOGI("Loading model with hardware acceleration: %s",
+                 path.substr(path.find_last_of('/') + 1).c_str());
 #ifdef __ANDROID__
             const char* keys[] = {"nnapi_flags"};
             const char* values[] = {"0"};

--- a/sdk/src/main/cpp/models/soc_detect.cpp
+++ b/sdk/src/main/cpp/models/soc_detect.cpp
@@ -1,0 +1,88 @@
+#include "inference_engine.h"
+#include "onnx_backend.h"
+
+#ifdef __ANDROID__
+#include <sys/system_properties.h>
+#include <android/log.h>
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, "Speech", __VA_ARGS__)
+#else
+#include <cstdio>
+#define LOGI(...) do { fprintf(stderr, "[speech] "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); } while(0)
+#endif
+
+#include <string>
+
+enum class SocVendor { GOOGLE_TENSOR, QUALCOMM, SAMSUNG, MEDIATEK, UNKNOWN };
+
+static SocVendor detect_soc() {
+#ifdef __ANDROID__
+    char value[92] = {};
+
+    // Google Tensor: ro.hardware.chipname starts with "gs" or "zuma"
+    __system_property_get("ro.hardware.chipname", value);
+    std::string chipname(value);
+    if (chipname.find("gs") == 0 || chipname.find("zuma") == 0) {
+        LOGI("SoC: Google Tensor (%s)", chipname.c_str());
+        return SocVendor::GOOGLE_TENSOR;
+    }
+
+    // Qualcomm: ro.board.platform starts with "msm", "sm", "sdm"
+    __system_property_get("ro.board.platform", value);
+    std::string platform(value);
+    if (platform.find("msm") == 0 || platform.find("sm") == 0 ||
+        platform.find("sdm") == 0 || platform.find("lahaina") != std::string::npos ||
+        platform.find("taro") != std::string::npos || platform.find("kalama") != std::string::npos ||
+        platform.find("pineapple") != std::string::npos || platform.find("sun") != std::string::npos) {
+        LOGI("SoC: Qualcomm (%s)", platform.c_str());
+        return SocVendor::QUALCOMM;
+    }
+
+    // Samsung Exynos
+    __system_property_get("ro.hardware", value);
+    std::string hardware(value);
+    if (hardware.find("exynos") != std::string::npos) {
+        LOGI("SoC: Samsung Exynos (%s)", hardware.c_str());
+        return SocVendor::SAMSUNG;
+    }
+
+    LOGI("SoC: Unknown (chipname=%s, platform=%s, hardware=%s)",
+         chipname.c_str(), platform.c_str(), hardware.c_str());
+#endif
+    return SocVendor::UNKNOWN;
+}
+
+Backend detect_optimal_backend() {
+    SocVendor soc = detect_soc();
+    switch (soc) {
+#ifdef SPEECH_LITERT
+        case SocVendor::GOOGLE_TENSOR:
+            return Backend::LITERT;
+#endif
+        default:
+            return Backend::ONNX;
+    }
+}
+
+std::unique_ptr<InferenceBackend> create_backend(Backend preference) {
+    Backend actual = preference;
+    if (actual == Backend::AUTO) {
+        actual = detect_optimal_backend();
+    }
+
+#ifdef SPEECH_LITERT
+    if (actual == Backend::LITERT) {
+        // LiteRT backend will be implemented in litert_backend.cpp
+        // For now, fall back to ONNX
+        LOGI("LiteRT backend not yet available, using ONNX");
+        actual = Backend::ONNX;
+    }
+#endif
+
+    if (actual == Backend::LITERT) {
+        LOGI("LiteRT requested but not compiled in, using ONNX");
+        actual = Backend::ONNX;
+    }
+
+    LOGI("Inference backend: ONNX Runtime");
+    return std::make_unique<OnnxBackend>();
+}


### PR DESCRIPTION
## Summary

- Enable NNAPI on real devices (was hardcoded to `false`)
- Skip NNAPI on emulator (no hardware accelerator)
- Existing fallback handles Tensor chips gracefully

## Context

NNAPI auto-delegates to the best available accelerator:
- Qualcomm → Hexagon DSP
- Samsung → Exynos NPU  
- Google Tensor → TPU (or CPU fallback via our existing code)

Full LiteRT integration for Tensor-specific optimization tracked separately in #2.

## Test plan

- [x] Build passes
- [x] 15/15 unit tests pass
- [ ] Test on Snapdragon device with NNAPI
- [ ] Test on Pixel with Tensor fallback