### PR TITLE
Add ONNX to TFLite conversion scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,45 @@
+# Model Conversion Scripts
+
+Convert ONNX models to TFLite format for the LiteRT inference backend.
+
+## Prerequisites
+
+- Windows 10/11 with Python 3.10+
+- ~16GB RAM for large model conversion (Parakeet encoder)
+- CUDA optional (speeds up conversion)
+
+## Setup
+
+```batch
+cd scripts
+setup_convert_env.bat
+```
+
+## Usage
+
+1. Download ONNX models from HuggingFace:
+   - [Silero-VAD-v5-ONNX](https://huggingface.co/aufklarer/Silero-VAD-v5-ONNX)
+   - [Parakeet-TDT-v3-ONNX](https://huggingface.co/aufklarer/Parakeet-TDT-v3-ONNX)
+   - [Kokoro-82M-ONNX](https://huggingface.co/aufklarer/Kokoro-82M-ONNX)
+   - [DeepFilterNet3-ONNX](https://huggingface.co/aufklarer/DeepFilterNet3-ONNX)
+
+2. Run conversion:
+   ```batch
+   .venv\Scripts\activate.bat
+   convert_models.bat C:\models\onnx C:\models\tflite
+   ```
+
+3. Upload `.tflite` files to HuggingFace repos.
+
+## Single model conversion
+
+```batch
+python convert_single.py --input model.onnx --output model.tflite --quantize int8
+```
+
+Options:
+- `--quantize none` — FP32 (default)
+- `--quantize int8` — INT8 post-training quantization
+- `--quantize fp16` — FP16 half precision
+- `--external_data path.onnx.data` — for models with external weights (Kokoro)
+- `--skip_validation` — skip TFLite loading test after conversion

--- a/scripts/convert_models.bat
+++ b/scripts/convert_models.bat
@@ -1,0 +1,96 @@
+@echo off
+REM Convert ONNX models to TFLite for LiteRT backend
+REM Run on Windows with Python 3.10+ and CUDA (optional for faster conversion)
+REM
+REM Prerequisites:
+REM   pip install onnx onnx-tf tensorflow tf2onnx
+REM
+REM Usage:
+REM   convert_models.bat C:\models\onnx C:\models\tflite
+
+setlocal enabledelayedexpansion
+
+set ONNX_DIR=%1
+set TFLITE_DIR=%2
+
+if "%ONNX_DIR%"=="" (
+    echo Usage: convert_models.bat ^<onnx_dir^> ^<tflite_dir^>
+    echo Example: convert_models.bat C:\models\onnx C:\models\tflite
+    exit /b 1
+)
+
+if "%TFLITE_DIR%"=="" (
+    set TFLITE_DIR=%ONNX_DIR%\..\tflite
+)
+
+mkdir "%TFLITE_DIR%" 2>nul
+
+echo ============================================
+echo ONNX to TFLite Model Conversion
+echo ============================================
+echo Source: %ONNX_DIR%
+echo Output: %TFLITE_DIR%
+echo.
+
+REM --- Silero VAD ---
+echo [1/5] Converting Silero VAD...
+python "%~dp0convert_single.py" ^
+    --input "%ONNX_DIR%\silero-vad.onnx" ^
+    --output "%TFLITE_DIR%\silero-vad.tflite" ^
+    --quantize none
+if errorlevel 1 (
+    echo FAILED: Silero VAD
+    exit /b 1
+)
+
+REM --- Parakeet Encoder ---
+echo [2/5] Converting Parakeet Encoder (INT8)...
+python "%~dp0convert_single.py" ^
+    --input "%ONNX_DIR%\parakeet-encoder-int8.onnx" ^
+    --output "%TFLITE_DIR%\parakeet-encoder-int8.tflite" ^
+    --quantize int8
+if errorlevel 1 (
+    echo FAILED: Parakeet Encoder
+    exit /b 1
+)
+
+REM --- Parakeet Decoder-Joint ---
+echo [3/5] Converting Parakeet Decoder-Joint (INT8)...
+python "%~dp0convert_single.py" ^
+    --input "%ONNX_DIR%\parakeet-decoder-joint-int8.onnx" ^
+    --output "%TFLITE_DIR%\parakeet-decoder-joint-int8.tflite" ^
+    --quantize int8
+if errorlevel 1 (
+    echo FAILED: Parakeet Decoder-Joint
+    exit /b 1
+)
+
+REM --- Kokoro TTS ---
+echo [4/5] Converting Kokoro TTS...
+python "%~dp0convert_single.py" ^
+    --input "%ONNX_DIR%\kokoro-e2e.onnx" ^
+    --output "%TFLITE_DIR%\kokoro-e2e.tflite" ^
+    --external_data "%ONNX_DIR%\kokoro-e2e.onnx.data" ^
+    --quantize none
+if errorlevel 1 (
+    echo FAILED: Kokoro TTS
+    exit /b 1
+)
+
+REM --- DeepFilterNet3 ---
+echo [5/5] Converting DeepFilterNet3...
+python "%~dp0convert_single.py" ^
+    --input "%ONNX_DIR%\deepfilter.onnx" ^
+    --output "%TFLITE_DIR%\deepfilter.tflite" ^
+    --quantize none
+if errorlevel 1 (
+    echo FAILED: DeepFilterNet3
+    exit /b 1
+)
+
+echo.
+echo ============================================
+echo All models converted successfully!
+echo ============================================
+echo Output: %TFLITE_DIR%
+dir "%TFLITE_DIR%\*.tflite"

--- a/scripts/convert_single.py
+++ b/scripts/convert_single.py
@@ -1,0 +1,118 @@
+"""
+Convert a single ONNX model to TFLite format.
+
+Usage:
+    python convert_single.py --input model.onnx --output model.tflite [--quantize int8|fp16|none]
+
+Prerequisites:
+    pip install onnx onnx-tf tensorflow
+"""
+
+import argparse
+import os
+import sys
+import tempfile
+import shutil
+
+def convert_onnx_to_tflite(input_path, output_path, quantize="none", external_data=None):
+    import onnx
+    import tensorflow as tf
+    from onnx_tf.backend import prepare
+
+    print(f"  Loading ONNX model: {input_path}")
+
+    # Load ONNX model
+    if external_data:
+        # Model with external weights — load from directory
+        model_dir = os.path.dirname(input_path)
+        model = onnx.load(input_path, load_external_data=True)
+    else:
+        model = onnx.load(input_path)
+
+    print(f"  ONNX opset: {model.opset_import[0].version}")
+    print(f"  Inputs: {[i.name for i in model.graph.input]}")
+    print(f"  Outputs: {[o.name for o in model.graph.output]}")
+
+    # Convert to TensorFlow SavedModel
+    saved_model_dir = tempfile.mkdtemp(prefix="onnx2tf_")
+    try:
+        print(f"  Converting to TensorFlow SavedModel...")
+        tf_rep = prepare(model)
+        tf_rep.export_graph(saved_model_dir)
+        print(f"  SavedModel saved to: {saved_model_dir}")
+
+        # Convert SavedModel to TFLite
+        print(f"  Converting to TFLite (quantize={quantize})...")
+        converter = tf.lite.TFLiteConverter.from_saved_model(saved_model_dir)
+
+        # Allow TF ops for unsupported operations
+        converter.target_spec.supported_ops = [
+            tf.lite.OpsSet.TFLITE_BUILTINS,
+            tf.lite.OpsSet.SELECT_TF_OPS,
+        ]
+
+        if quantize == "int8":
+            converter.optimizations = [tf.lite.Optimize.DEFAULT]
+            converter.target_spec.supported_types = [tf.int8]
+            print("  Applied INT8 quantization")
+        elif quantize == "fp16":
+            converter.optimizations = [tf.lite.Optimize.DEFAULT]
+            converter.target_spec.supported_types = [tf.float16]
+            print("  Applied FP16 quantization")
+        else:
+            print("  No quantization (FP32)")
+
+        tflite_model = converter.convert()
+
+        # Save
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        with open(output_path, "wb") as f:
+            f.write(tflite_model)
+
+        size_mb = os.path.getsize(output_path) / (1024 * 1024)
+        print(f"  Saved: {output_path} ({size_mb:.1f} MB)")
+
+    finally:
+        shutil.rmtree(saved_model_dir, ignore_errors=True)
+
+
+def validate_tflite(path):
+    """Quick validation that the TFLite file loads."""
+    import tensorflow as tf
+
+    print(f"  Validating: {path}")
+    interpreter = tf.lite.Interpreter(model_path=path)
+    interpreter.allocate_tensors()
+
+    inputs = interpreter.get_input_details()
+    outputs = interpreter.get_output_details()
+    print(f"  Inputs: {[(d['name'], d['shape'].tolist(), d['dtype'].__name__) for d in inputs]}")
+    print(f"  Outputs: {[(d['name'], d['shape'].tolist(), d['dtype'].__name__) for d in outputs]}")
+    print(f"  Validation OK")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert ONNX model to TFLite")
+    parser.add_argument("--input", required=True, help="Input .onnx file path")
+    parser.add_argument("--output", required=True, help="Output .tflite file path")
+    parser.add_argument("--quantize", default="none", choices=["int8", "fp16", "none"],
+                        help="Quantization mode (default: none)")
+    parser.add_argument("--external_data", default=None,
+                        help="Path to external data file (e.g., .onnx.data)")
+    parser.add_argument("--skip_validation", action="store_true",
+                        help="Skip TFLite validation after conversion")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.input):
+        print(f"Error: Input file not found: {args.input}")
+        sys.exit(1)
+
+    try:
+        convert_onnx_to_tflite(args.input, args.output, args.quantize, args.external_data)
+        if not args.skip_validation:
+            validate_tflite(args.output)
+    except Exception as e:
+        print(f"Error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/scripts/setup_convert_env.bat
+++ b/scripts/setup_convert_env.bat
@@ -1,0 +1,21 @@
+@echo off
+REM Set up Python environment for ONNX to TFLite conversion
+REM Run once on Windows before using convert_models.bat
+
+echo Setting up conversion environment...
+
+python -m venv .venv
+call .venv\Scripts\activate.bat
+
+pip install --upgrade pip
+pip install onnx==1.16.0
+pip install onnx-tf==1.10.0
+pip install tensorflow==2.16.1
+pip install protobuf==3.20.3
+
+echo.
+echo Environment ready. Activate with:
+echo   .venv\Scripts\activate.bat
+echo.
+echo Then run:
+echo   convert_models.bat C:\path\to\onnx\models C:\path\to\tflite\output


### PR DESCRIPTION
## Summary

Windows scripts for converting ONNX models to TFLite format (Phase 4 of #2).

## Scripts

- `scripts/setup_convert_env.bat` — create Python venv with onnx-tf, tensorflow
- `scripts/convert_models.bat` — batch convert all 5 models (VAD, STT encoder/decoder, TTS, DeepFilter)
- `scripts/convert_single.py` — single model conversion with INT8/FP16 quantization + validation

## Usage

```batch
cd scripts
setup_convert_env.bat
.venv\Scripts\activate.bat
convert_models.bat C:\models\onnx C:\models\tflite
```

Part of #2