### PR TITLE
Improve retry for HuggingFace 503 errors

### DIFF
--- a/sdk/src/main/kotlin/com/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/com/soniqo/speech/ModelManager.kt
@@ -24,7 +24,7 @@ object ModelManager {
     // Bump when models on HuggingFace are updated to trigger cache invalidation.
     private const val MODEL_VERSION = 2
 
-    private const val MAX_RETRIES = 3
+    private const val MAX_RETRIES = 5
     private const val RETRY_DELAY_MS = 2000L
 
     private val client = OkHttpClient.Builder()
@@ -145,8 +145,14 @@ object ModelManager {
                 val response = client.newCall(requestBuilder.build()).execute()
 
                 if (!response.isSuccessful && response.code != 206) {
+                    val code = response.code
                     response.close()
-                    throw IOException("HTTP ${response.code} for $url")
+                    if (code in 500..599) {
+                        // Server error — longer backoff, likely temporary
+                        throw IOException("Server temporarily unavailable (HTTP $code). " +
+                            "HuggingFace may be busy — try again in a few minutes.")
+                    }
+                    throw IOException("HTTP $code for $url")
                 }
 
                 val body = response.body ?: throw IOException("Empty response for $url")
@@ -189,8 +195,10 @@ object ModelManager {
             } catch (e: IOException) {
                 lastException = e
                 if (attempt < MAX_RETRIES) {
-                    Thread.sleep(RETRY_DELAY_MS * attempt)
-                    // Keep tmp file for resume on next attempt
+                    // Longer backoff for server errors (503 etc.)
+                    val isServerError = e.message?.contains("temporarily unavailable") == true
+                    val delay = if (isServerError) RETRY_DELAY_MS * attempt * 3 else RETRY_DELAY_MS * attempt
+                    Thread.sleep(delay)
                 }
             }
         }


### PR DESCRIPTION
## Summary

HuggingFace CDN returns 503 during high traffic. Current 3 retries with 2-4s backoff isn't enough.

- Increase to 5 retries
- Server errors (5xx) get 3x longer backoff: 6s → 12s → 18s → 24s
- User-friendly message: "Server temporarily unavailable, try again in a few minutes"

Reported by: Pixel 10 Pro XL user (Tensor G5)

## Test plan

- [x] Build passes
- [x] 15/15 unit tests pass