### PR TITLE
Add Android RecognitionService for system-wide voice input

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,75 @@ The [`app/`](app/) module is a minimal voice assistant demo with:
 
 - Real-time VAD waveform visualization
 - Echo mode: transcribes speech and synthesizes it back (no LLM)
+- Dictation mode: streaming partial results
+- `SpeechRecognizer` test screen — exercises the system-wide voice input path
 - Chat bubble UI with STT/TTS latency display
 
 ```bash
 ./gradlew :app:installDebug
 ```
+
+### System voice input (`RecognitionService`)
+
+The SDK ships a ready-made `audio.soniqo.speech.service.SpeechRecognitionService`
+that plugs into Android's framework `SpeechRecognizer` API — no code to write.
+Once your app is selected as the default voice recognizer, any third-party app
+calling `SpeechRecognizer.createSpeechRecognizer(context)` (with no
+`ComponentName`) gets fully on-device STT through your pipeline.
+
+**1. Declare `RECORD_AUDIO` and the service in `AndroidManifest.xml`:**
+
+```xml
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+<application>
+    <service
+        android:name="audio.soniqo.speech.service.SpeechRecognitionService"
+        android:exported="true"
+        android:permission="android.permission.RECORD_AUDIO">
+        <intent-filter>
+            <action android:name="android.speech.RecognitionService" />
+        </intent-filter>
+        <meta-data
+            android:name="android.speech"
+            android:resource="@xml/recognition_service" />
+    </service>
+</application>
+```
+
+**2. Add `app/src/main/res/xml/recognition_service.xml`:**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<recognition-service xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
+(Optionally add `android:settingsActivity="..."` to expose a gear icon in the
+system Voice-input picker.)
+
+**3. Set the service as the system default** (Settings → System → Languages
+& input → Voice input picker on stock Android, or via adb):
+
+```bash
+adb shell settings put secure voice_recognition_service \
+  your.package/audio.soniqo.speech.service.SpeechRecognitionService
+```
+
+**4. Verify** by running the demo app's *Recognizer test* screen, which calls
+`SpeechRecognizer.createSpeechRecognizer(ctx)` (no component) and logs every
+framework callback — useful for confirming the binder round-trip without
+needing logcat.
+
+The service implements `onCheckRecognitionSupport` (API 33+) returning the
+27 BCP-47 languages Parakeet TDT v3 covers, marked
+`installedOnDeviceLanguage` once models are present (or
+`pendingOnDeviceLanguage` while they're downloading). Audio focus is
+acquired with `AUDIOFOCUS_GAIN_TRANSIENT` for the duration of a session.
+
+**Caveat:** Gboard, Samsung Keyboard, and Google Assistant bundle their own
+recognizers and skip the system default. Apps that explicitly call the
+framework `SpeechRecognizer` API (or build their own UI on top of it) are
+the ones that flow through your service.
 
 ## Performance
 

--- a/README_de.md
+++ b/README_de.md
@@ -79,11 +79,59 @@ Das Modul [`app/`](app/) ist eine minimale Sprachassistenten-Demo mit:
 
 - Echtzeit-VAD-Wellenformvisualisierung
 - Echo-Modus: transkribiert Sprache und synthetisiert sie zurück (kein LLM)
+- Diktiermodus: Streaming-Teilergebnisse
+- `SpeechRecognizer`-Testbildschirm — übt den systemweiten Spracheingabepfad aus
 - Chat-Bubble-UI mit STT/TTS-Latenzanzeige
 
 ```bash
 ./gradlew :app:installDebug
 ```
+
+### Systemweite Spracheingabe (`RecognitionService`)
+
+Das SDK enthält einen einsatzbereiten `audio.soniqo.speech.service.SpeechRecognitionService`, der sich in die `SpeechRecognizer`-API des Android-Frameworks einklinkt — kein Code zu schreiben. Sobald deine App als Standard-Spracherkennung ausgewählt ist, erhält jede Drittanbieter-App, die `SpeechRecognizer.createSpeechRecognizer(context)` (ohne `ComponentName`) aufruft, vollständiges On-Device-STT über deine Pipeline.
+
+**1. Deklariere `RECORD_AUDIO` und den Dienst in `AndroidManifest.xml`:**
+
+```xml
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+<application>
+    <service
+        android:name="audio.soniqo.speech.service.SpeechRecognitionService"
+        android:exported="true"
+        android:permission="android.permission.RECORD_AUDIO">
+        <intent-filter>
+            <action android:name="android.speech.RecognitionService" />
+        </intent-filter>
+        <meta-data
+            android:name="android.speech"
+            android:resource="@xml/recognition_service" />
+    </service>
+</application>
+```
+
+**2. Füge `app/src/main/res/xml/recognition_service.xml` hinzu:**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<recognition-service xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
+(Optional kannst du `android:settingsActivity="..."` hinzufügen, um ein Zahnrad-Icon im systemweiten Spracheingabe-Picker anzuzeigen.)
+
+**3. Setze den Dienst als System-Standard** (Einstellungen → System → Sprachen & Eingabe → Spracheingabe-Auswahl auf Stock-Android, oder über adb):
+
+```bash
+adb shell settings put secure voice_recognition_service \
+  your.package/audio.soniqo.speech.service.SpeechRecognitionService
+```
+
+**4. Verifiziere**, indem du den *Recognizer test*-Bildschirm der Demo-App ausführst, der `SpeechRecognizer.createSpeechRecognizer(ctx)` (ohne Komponente) aufruft und jeden Framework-Callback protokolliert — nützlich, um den Binder-Roundtrip ohne logcat zu bestätigen.
+
+Der Dienst implementiert `onCheckRecognitionSupport` (API 33+) und gibt die 27 BCP-47-Sprachen zurück, die Parakeet TDT v3 abdeckt, markiert als `installedOnDeviceLanguage`, sobald Modelle vorhanden sind (oder `pendingOnDeviceLanguage`, während sie heruntergeladen werden). Während einer Sitzung wird Audiofokus mit `AUDIOFOCUS_GAIN_TRANSIENT` angefordert.
+
+**Einschränkung:** Gboard, Samsung Keyboard und Google Assistant bringen eigene Erkenner mit und überspringen den System-Standard. Apps, die die Framework-`SpeechRecognizer`-API explizit aufrufen (oder eine eigene UI darauf aufbauen), gehen über deinen Dienst.
 
 ## Leistung
 

--- a/README_es.md
+++ b/README_es.md
@@ -79,11 +79,59 @@ El módulo [`app/`](app/) es una demo mínima de asistente de voz con:
 
 - Visualización de forma de onda VAD en tiempo real
 - Modo eco: transcribe la voz y la sintetiza de vuelta (sin LLM)
+- Modo dictado: resultados parciales en streaming
+- Pantalla de prueba `SpeechRecognizer` — ejercita la ruta de entrada de voz a nivel de sistema
 - UI de burbujas de chat con visualización de latencia STT/TTS
 
 ```bash
 ./gradlew :app:installDebug
 ```
+
+### Entrada de voz del sistema (`RecognitionService`)
+
+El SDK incluye un `audio.soniqo.speech.service.SpeechRecognitionService` listo para usar que se conecta a la API `SpeechRecognizer` del framework de Android — sin código que escribir. Una vez que tu app está seleccionada como reconocedor de voz predeterminado, cualquier app de terceros que llame a `SpeechRecognizer.createSpeechRecognizer(context)` (sin `ComponentName`) obtiene STT completamente en el dispositivo a través de tu pipeline.
+
+**1. Declara `RECORD_AUDIO` y el servicio en `AndroidManifest.xml`:**
+
+```xml
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+<application>
+    <service
+        android:name="audio.soniqo.speech.service.SpeechRecognitionService"
+        android:exported="true"
+        android:permission="android.permission.RECORD_AUDIO">
+        <intent-filter>
+            <action android:name="android.speech.RecognitionService" />
+        </intent-filter>
+        <meta-data
+            android:name="android.speech"
+            android:resource="@xml/recognition_service" />
+    </service>
+</application>
+```
+
+**2. Añade `app/src/main/res/xml/recognition_service.xml`:**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<recognition-service xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
+(Opcionalmente añade `android:settingsActivity="..."` para exponer un icono de engranaje en el selector de entrada de voz del sistema.)
+
+**3. Configura el servicio como predeterminado del sistema** (Ajustes → Sistema → Idiomas e introducción → Selector de entrada de voz en Android puro, o vía adb):
+
+```bash
+adb shell settings put secure voice_recognition_service \
+  your.package/audio.soniqo.speech.service.SpeechRecognitionService
+```
+
+**4. Verifica** ejecutando la pantalla *Recognizer test* de la app demo, que llama a `SpeechRecognizer.createSpeechRecognizer(ctx)` (sin componente) y registra cada callback del framework — útil para confirmar el round-trip del binder sin necesitar logcat.
+
+El servicio implementa `onCheckRecognitionSupport` (API 33+) devolviendo los 27 idiomas BCP-47 que cubre Parakeet TDT v3, marcados como `installedOnDeviceLanguage` cuando los modelos están presentes (o `pendingOnDeviceLanguage` mientras se descargan). Se adquiere foco de audio con `AUDIOFOCUS_GAIN_TRANSIENT` durante la sesión.
+
+**Limitación:** Gboard, Samsung Keyboard y Google Assistant incluyen sus propios reconocedores y se saltan el predeterminado del sistema. Las apps que llaman explícitamente a la API `SpeechRecognizer` del framework (o construyen su propia UI sobre ella) son las que pasan por tu servicio.
 
 ## Rendimiento
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -79,11 +79,59 @@ Le module [`app/`](app/) est une démo minimale d'assistant vocal avec :
 
 - Visualisation de la forme d'onde VAD en temps réel
 - Mode écho : transcrit la voix et la synthétise en retour (sans LLM)
+- Mode dictée : résultats partiels en streaming
+- Écran de test `SpeechRecognizer` — exerce le chemin d'entrée vocale à l'échelle du système
 - Interface de bulles de chat avec affichage de la latence STT/TTS
 
 ```bash
 ./gradlew :app:installDebug
 ```
+
+### Entrée vocale système (`RecognitionService`)
+
+Le SDK fournit un `audio.soniqo.speech.service.SpeechRecognitionService` prêt à l'emploi qui s'intègre à l'API `SpeechRecognizer` du framework Android — aucun code à écrire. Une fois votre app sélectionnée comme reconnaisseur vocal par défaut, toute application tierce appelant `SpeechRecognizer.createSpeechRecognizer(context)` (sans `ComponentName`) obtient un STT entièrement on-device via votre pipeline.
+
+**1. Déclarez `RECORD_AUDIO` et le service dans `AndroidManifest.xml` :**
+
+```xml
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+<application>
+    <service
+        android:name="audio.soniqo.speech.service.SpeechRecognitionService"
+        android:exported="true"
+        android:permission="android.permission.RECORD_AUDIO">
+        <intent-filter>
+            <action android:name="android.speech.RecognitionService" />
+        </intent-filter>
+        <meta-data
+            android:name="android.speech"
+            android:resource="@xml/recognition_service" />
+    </service>
+</application>
+```
+
+**2. Ajoutez `app/src/main/res/xml/recognition_service.xml` :**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<recognition-service xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
+(Ajoutez optionnellement `android:settingsActivity="..."` pour afficher une icône d'engrenage dans le sélecteur d'entrée vocale système.)
+
+**3. Définissez le service comme valeur par défaut système** (Paramètres → Système → Langues et saisie → Sélecteur d'entrée vocale sur Android pur, ou via adb) :
+
+```bash
+adb shell settings put secure voice_recognition_service \
+  your.package/audio.soniqo.speech.service.SpeechRecognitionService
+```
+
+**4. Vérifiez** en lançant l'écran *Recognizer test* de l'app de démo, qui appelle `SpeechRecognizer.createSpeechRecognizer(ctx)` (sans composant) et journalise chaque callback du framework — utile pour confirmer l'aller-retour binder sans avoir besoin de logcat.
+
+Le service implémente `onCheckRecognitionSupport` (API 33+) renvoyant les 27 langues BCP-47 couvertes par Parakeet TDT v3, marquées `installedOnDeviceLanguage` lorsque les modèles sont présents (ou `pendingOnDeviceLanguage` pendant leur téléchargement). Le focus audio est acquis avec `AUDIOFOCUS_GAIN_TRANSIENT` pendant la durée d'une session.
+
+**Limitation :** Gboard, Samsung Keyboard et Google Assistant intègrent leurs propres reconnaisseurs et contournent la valeur par défaut système. Les applications qui appellent explicitement l'API `SpeechRecognizer` du framework (ou construisent leur propre UI par-dessus) sont celles qui passent par votre service.
 
 ## Performance
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -79,11 +79,59 @@ cd speech-android
 
 - रीयल-टाइम VAD वेवफ़ॉर्म विज़ुअलाइज़ेशन
 - इको मोड: स्पीच को ट्रांसक्राइब करता है और इसे वापस सिंथेसाइज़ करता है (कोई LLM नहीं)
+- डिक्टेशन मोड: स्ट्रीमिंग आंशिक परिणाम
+- `SpeechRecognizer` टेस्ट स्क्रीन — सिस्टम-वाइड वॉयस इनपुट पथ का परीक्षण करता है
 - STT/TTS विलंबता प्रदर्शन के साथ चैट बबल UI
 
 ```bash
 ./gradlew :app:installDebug
 ```
+
+### सिस्टम वॉयस इनपुट (`RecognitionService`)
+
+SDK एक उपयोग के लिए तैयार `audio.soniqo.speech.service.SpeechRecognitionService` शामिल करता है जो Android फ्रेमवर्क के `SpeechRecognizer` API से जुड़ता है — कोई कोड लिखने की आवश्यकता नहीं। एक बार आपका ऐप डिफ़ॉल्ट वॉयस रिकग्नाइज़र के रूप में चुना जाता है, कोई भी थर्ड-पार्टी ऐप जो `SpeechRecognizer.createSpeechRecognizer(context)` (बिना `ComponentName` के) कॉल करता है, आपकी पाइपलाइन के माध्यम से पूरी तरह से ऑन-डिवाइस STT प्राप्त करता है।
+
+**1. `AndroidManifest.xml` में `RECORD_AUDIO` और सेवा घोषित करें:**
+
+```xml
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+<application>
+    <service
+        android:name="audio.soniqo.speech.service.SpeechRecognitionService"
+        android:exported="true"
+        android:permission="android.permission.RECORD_AUDIO">
+        <intent-filter>
+            <action android:name="android.speech.RecognitionService" />
+        </intent-filter>
+        <meta-data
+            android:name="android.speech"
+            android:resource="@xml/recognition_service" />
+    </service>
+</application>
+```
+
+**2. `app/src/main/res/xml/recognition_service.xml` जोड़ें:**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<recognition-service xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
+(वैकल्पिक रूप से `android:settingsActivity="..."` जोड़ें ताकि सिस्टम वॉयस-इनपुट पिकर में एक गियर आइकन दिखे।)
+
+**3. सेवा को सिस्टम डिफ़ॉल्ट के रूप में सेट करें** (स्टॉक Android पर सेटिंग्स → सिस्टम → भाषाएँ और इनपुट → वॉयस इनपुट पिकर, या adb के माध्यम से):
+
+```bash
+adb shell settings put secure voice_recognition_service \
+  your.package/audio.soniqo.speech.service.SpeechRecognitionService
+```
+
+**4. सत्यापित करें** डेमो ऐप का *Recognizer test* स्क्रीन चलाकर, जो `SpeechRecognizer.createSpeechRecognizer(ctx)` (बिना कंपोनेंट के) कॉल करता है और हर फ्रेमवर्क कॉलबैक को लॉग करता है — logcat के बिना binder राउंड-ट्रिप की पुष्टि के लिए उपयोगी।
+
+सेवा `onCheckRecognitionSupport` (API 33+) को लागू करती है जो Parakeet TDT v3 द्वारा कवर की गई 27 BCP-47 भाषाओं को लौटाती है, मॉडल मौजूद होने पर `installedOnDeviceLanguage` के रूप में चिह्नित (या डाउनलोड के दौरान `pendingOnDeviceLanguage`)। सत्र की अवधि के लिए `AUDIOFOCUS_GAIN_TRANSIENT` के साथ ऑडियो फोकस प्राप्त किया जाता है।
+
+**सीमा:** Gboard, Samsung Keyboard और Google Assistant अपने स्वयं के पहचानकर्ता बंडल करते हैं और सिस्टम डिफ़ॉल्ट को छोड़ देते हैं। फ्रेमवर्क `SpeechRecognizer` API को स्पष्ट रूप से कॉल करने वाले ऐप (या उसके ऊपर अपना UI बनाने वाले) ही आपकी सेवा से होकर गुजरते हैं।
 
 ## प्रदर्शन
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -79,11 +79,59 @@ cd speech-android
 
 - リアルタイム VAD 波形の可視化
 - エコーモード:音声を文字起こしして合成し直す(LLM なし)
+- ディクテーションモード:ストリーミング部分結果
+- `SpeechRecognizer` テスト画面 — システム全体の音声入力パスを実行
 - STT/TTS のレイテンシ表示付きチャットバブル UI
 
 ```bash
 ./gradlew :app:installDebug
 ```
+
+### システム音声入力(`RecognitionService`)
+
+SDK には、Android フレームワークの `SpeechRecognizer` API に組み込めるすぐに使える `audio.soniqo.speech.service.SpeechRecognitionService` が含まれています — コードを書く必要はありません。アプリがデフォルトの音声認識サービスに選択されると、`SpeechRecognizer.createSpeechRecognizer(context)`(`ComponentName` なし)を呼び出す任意のサードパーティアプリが、あなたのパイプラインを通じて完全なオンデバイス STT を利用できます。
+
+**1. `AndroidManifest.xml` で `RECORD_AUDIO` とサービスを宣言します:**
+
+```xml
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+<application>
+    <service
+        android:name="audio.soniqo.speech.service.SpeechRecognitionService"
+        android:exported="true"
+        android:permission="android.permission.RECORD_AUDIO">
+        <intent-filter>
+            <action android:name="android.speech.RecognitionService" />
+        </intent-filter>
+        <meta-data
+            android:name="android.speech"
+            android:resource="@xml/recognition_service" />
+    </service>
+</application>
+```
+
+**2. `app/src/main/res/xml/recognition_service.xml` を追加します:**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<recognition-service xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
+(オプションで `android:settingsActivity="..."` を追加すると、システム音声入力ピッカーに歯車アイコンが表示されます。)
+
+**3. サービスをシステムデフォルトに設定します**(標準 Android では 設定 → システム → 言語と入力 → 音声入力ピッカー、または adb 経由):
+
+```bash
+adb shell settings put secure voice_recognition_service \
+  your.package/audio.soniqo.speech.service.SpeechRecognitionService
+```
+
+**4. 確認**:デモアプリの *Recognizer test* 画面を実行します。これは `SpeechRecognizer.createSpeechRecognizer(ctx)`(コンポーネントなし)を呼び出し、すべてのフレームワークコールバックをログに記録します — logcat なしで binder のラウンドトリップを確認するのに便利です。
+
+サービスは `onCheckRecognitionSupport`(API 33+)を実装し、Parakeet TDT v3 がカバーする 27 の BCP-47 言語を返します。モデルが存在する場合は `installedOnDeviceLanguage`、ダウンロード中は `pendingOnDeviceLanguage` でマークされます。セッション中は `AUDIOFOCUS_GAIN_TRANSIENT` でオーディオフォーカスを取得します。
+
+**注意:** Gboard、Samsung Keyboard、Google Assistant は独自の認識エンジンを同梱しており、システムデフォルトをスキップします。あなたのサービスを通過するのは、フレームワーク `SpeechRecognizer` API を明示的に呼び出すアプリ(またはその上に独自 UI を構築するアプリ)です。
 
 ## パフォーマンス
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -79,11 +79,59 @@ cd speech-android
 
 - 실시간 VAD 파형 시각화
 - 에코 모드: 음성을 전사하고 다시 합성(LLM 없음)
+- 받아쓰기 모드: 스트리밍 부분 결과
+- `SpeechRecognizer` 테스트 화면 — 시스템 전체 음성 입력 경로 실행
 - STT/TTS 지연 시간 표시가 있는 채팅 버블 UI
 
 ```bash
 ./gradlew :app:installDebug
 ```
+
+### 시스템 음성 입력(`RecognitionService`)
+
+SDK는 Android 프레임워크 `SpeechRecognizer` API에 연결되는 바로 사용 가능한 `audio.soniqo.speech.service.SpeechRecognitionService`를 제공합니다 — 작성할 코드가 없습니다. 앱이 기본 음성 인식기로 선택되면, `SpeechRecognizer.createSpeechRecognizer(context)`(`ComponentName` 없이)를 호출하는 모든 타사 앱이 파이프라인을 통해 완전히 온디바이스 STT를 받을 수 있습니다.
+
+**1. `AndroidManifest.xml`에서 `RECORD_AUDIO`와 서비스를 선언합니다:**
+
+```xml
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+<application>
+    <service
+        android:name="audio.soniqo.speech.service.SpeechRecognitionService"
+        android:exported="true"
+        android:permission="android.permission.RECORD_AUDIO">
+        <intent-filter>
+            <action android:name="android.speech.RecognitionService" />
+        </intent-filter>
+        <meta-data
+            android:name="android.speech"
+            android:resource="@xml/recognition_service" />
+    </service>
+</application>
+```
+
+**2. `app/src/main/res/xml/recognition_service.xml`을 추가합니다:**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<recognition-service xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
+(선택적으로 `android:settingsActivity="..."`를 추가하면 시스템 음성 입력 선택기에 톱니바퀴 아이콘이 노출됩니다.)
+
+**3. 서비스를 시스템 기본값으로 설정합니다**(스톡 Android에서는 설정 → 시스템 → 언어 및 입력 → 음성 입력 선택기 또는 adb를 통해):
+
+```bash
+adb shell settings put secure voice_recognition_service \
+  your.package/audio.soniqo.speech.service.SpeechRecognitionService
+```
+
+**4. 검증**: 데모 앱의 *Recognizer test* 화면을 실행하면 `SpeechRecognizer.createSpeechRecognizer(ctx)`(컴포넌트 없이)를 호출하고 모든 프레임워크 콜백을 기록합니다 — logcat 없이 binder 왕복을 확인하는 데 유용합니다.
+
+서비스는 `onCheckRecognitionSupport`(API 33+)를 구현하여 Parakeet TDT v3가 지원하는 27개 BCP-47 언어를 반환합니다. 모델이 존재하면 `installedOnDeviceLanguage`, 다운로드 중이면 `pendingOnDeviceLanguage`로 표시됩니다. 세션 동안 `AUDIOFOCUS_GAIN_TRANSIENT`로 오디오 포커스를 획득합니다.
+
+**주의:** Gboard, 삼성 키보드, Google Assistant는 자체 인식 엔진을 번들로 제공하며 시스템 기본값을 건너뜁니다. 프레임워크 `SpeechRecognizer` API를 명시적으로 호출하거나 그 위에 자체 UI를 구축하는 앱만이 서비스를 통과합니다.
 
 ## 성능
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -79,11 +79,59 @@ O módulo [`app/`](app/) é uma demo mínima de assistente de voz com:
 
 - Visualização de forma de onda VAD em tempo real
 - Modo eco: transcreve a fala e a sintetiza de volta (sem LLM)
+- Modo ditado: resultados parciais em streaming
+- Tela de teste `SpeechRecognizer` — exercita o caminho de entrada de voz em todo o sistema
 - UI de bolhas de chat com exibição de latência STT/TTS
 
 ```bash
 ./gradlew :app:installDebug
 ```
+
+### Entrada de voz do sistema (`RecognitionService`)
+
+O SDK fornece um `audio.soniqo.speech.service.SpeechRecognitionService` pronto para uso que se conecta à API `SpeechRecognizer` do framework do Android — sem código a escrever. Uma vez que seu app é selecionado como o reconhecedor de voz padrão, qualquer app de terceiros chamando `SpeechRecognizer.createSpeechRecognizer(context)` (sem `ComponentName`) obtém STT totalmente no dispositivo através do seu pipeline.
+
+**1. Declare `RECORD_AUDIO` e o serviço em `AndroidManifest.xml`:**
+
+```xml
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+<application>
+    <service
+        android:name="audio.soniqo.speech.service.SpeechRecognitionService"
+        android:exported="true"
+        android:permission="android.permission.RECORD_AUDIO">
+        <intent-filter>
+            <action android:name="android.speech.RecognitionService" />
+        </intent-filter>
+        <meta-data
+            android:name="android.speech"
+            android:resource="@xml/recognition_service" />
+    </service>
+</application>
+```
+
+**2. Adicione `app/src/main/res/xml/recognition_service.xml`:**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<recognition-service xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
+(Opcionalmente adicione `android:settingsActivity="..."` para expor um ícone de engrenagem no seletor de entrada de voz do sistema.)
+
+**3. Defina o serviço como padrão do sistema** (Configurações → Sistema → Idiomas e entrada → Seletor de entrada de voz no Android puro, ou via adb):
+
+```bash
+adb shell settings put secure voice_recognition_service \
+  your.package/audio.soniqo.speech.service.SpeechRecognitionService
+```
+
+**4. Verifique** executando a tela *Recognizer test* do app demo, que chama `SpeechRecognizer.createSpeechRecognizer(ctx)` (sem componente) e registra cada callback do framework — útil para confirmar o round-trip do binder sem precisar do logcat.
+
+O serviço implementa `onCheckRecognitionSupport` (API 33+) retornando os 27 idiomas BCP-47 cobertos pelo Parakeet TDT v3, marcados como `installedOnDeviceLanguage` quando os modelos estão presentes (ou `pendingOnDeviceLanguage` enquanto eles são baixados). O foco de áudio é adquirido com `AUDIOFOCUS_GAIN_TRANSIENT` pela duração de uma sessão.
+
+**Limitação:** Gboard, Samsung Keyboard e Google Assistant agrupam seus próprios reconhecedores e ignoram o padrão do sistema. Apps que chamam explicitamente a API `SpeechRecognizer` do framework (ou constroem sua própria UI em cima dela) são os que passam pelo seu serviço.
 
 ## Desempenho
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -79,11 +79,59 @@ cd speech-android
 
 - Визуализацию формы волны VAD в реальном времени
 - Эхо-режим: транскрибирует речь и синтезирует её обратно (без LLM)
+- Режим диктовки: потоковые частичные результаты
+- Тестовый экран `SpeechRecognizer` — задействует системный путь голосового ввода
 - UI с пузырями чата и отображением задержки STT/TTS
 
 ```bash
 ./gradlew :app:installDebug
 ```
+
+### Системный голосовой ввод (`RecognitionService`)
+
+SDK включает готовый к использованию `audio.soniqo.speech.service.SpeechRecognitionService`, который подключается к API `SpeechRecognizer` фреймворка Android — никакого кода писать не нужно. Как только ваше приложение выбрано в качестве распознавателя голоса по умолчанию, любое стороннее приложение, вызывающее `SpeechRecognizer.createSpeechRecognizer(context)` (без `ComponentName`), получает полностью локальный STT через ваш конвейер.
+
+**1. Объявите `RECORD_AUDIO` и сервис в `AndroidManifest.xml`:**
+
+```xml
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+<application>
+    <service
+        android:name="audio.soniqo.speech.service.SpeechRecognitionService"
+        android:exported="true"
+        android:permission="android.permission.RECORD_AUDIO">
+        <intent-filter>
+            <action android:name="android.speech.RecognitionService" />
+        </intent-filter>
+        <meta-data
+            android:name="android.speech"
+            android:resource="@xml/recognition_service" />
+    </service>
+</application>
+```
+
+**2. Добавьте `app/src/main/res/xml/recognition_service.xml`:**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<recognition-service xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
+(Опционально добавьте `android:settingsActivity="..."`, чтобы отобразить иконку шестерёнки в системном выборе голосового ввода.)
+
+**3. Установите сервис по умолчанию в системе** (Настройки → Система → Языки и ввод → Выбор голосового ввода на стоковом Android, или через adb):
+
+```bash
+adb shell settings put secure voice_recognition_service \
+  your.package/audio.soniqo.speech.service.SpeechRecognitionService
+```
+
+**4. Проверьте**, запустив экран *Recognizer test* в демо-приложении, который вызывает `SpeechRecognizer.createSpeechRecognizer(ctx)` (без компонента) и логирует каждый callback фреймворка — удобно для подтверждения binder round-trip без необходимости в logcat.
+
+Сервис реализует `onCheckRecognitionSupport` (API 33+), возвращающий 27 BCP-47 языков, поддерживаемых Parakeet TDT v3, помеченных как `installedOnDeviceLanguage` при наличии моделей (или `pendingOnDeviceLanguage` во время загрузки). Аудиофокус удерживается с `AUDIOFOCUS_GAIN_TRANSIENT` на время сессии.
+
+**Оговорка:** Gboard, Samsung Keyboard и Google Assistant поставляются с собственными распознавателями и обходят системное значение по умолчанию. Через ваш сервис проходят только те приложения, которые явно вызывают API `SpeechRecognizer` фреймворка (или строят на нём собственный UI).
 
 ## Производительность
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -79,11 +79,59 @@ cd speech-android
 
 - 实时 VAD 波形可视化
 - 回声模式:转录语音并将其合成回放(无 LLM)
+- 听写模式:流式部分结果
+- `SpeechRecognizer` 测试界面 — 演练系统级语音输入路径
 - 带有 STT/TTS 延迟显示的聊天气泡 UI
 
 ```bash
 ./gradlew :app:installDebug
 ```
+
+### 系统语音输入(`RecognitionService`)
+
+SDK 自带可直接使用的 `audio.soniqo.speech.service.SpeechRecognitionService`,接入 Android 框架的 `SpeechRecognizer` API — 无需编写代码。一旦你的应用被设为默认语音识别器,任何调用 `SpeechRecognizer.createSpeechRecognizer(context)`(不指定 `ComponentName`)的第三方应用都能通过你的流水线获得完全本地的 STT。
+
+**1. 在 `AndroidManifest.xml` 中声明 `RECORD_AUDIO` 和服务:**
+
+```xml
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+<application>
+    <service
+        android:name="audio.soniqo.speech.service.SpeechRecognitionService"
+        android:exported="true"
+        android:permission="android.permission.RECORD_AUDIO">
+        <intent-filter>
+            <action android:name="android.speech.RecognitionService" />
+        </intent-filter>
+        <meta-data
+            android:name="android.speech"
+            android:resource="@xml/recognition_service" />
+    </service>
+</application>
+```
+
+**2. 添加 `app/src/main/res/xml/recognition_service.xml`:**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<recognition-service xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
+(可选添加 `android:settingsActivity="..."` 以在系统语音输入选择器中显示设置图标。)
+
+**3. 将服务设为系统默认**(原生 Android 上 设置 → 系统 → 语言和输入 → 语音输入选择器,或通过 adb):
+
+```bash
+adb shell settings put secure voice_recognition_service \
+  your.package/audio.soniqo.speech.service.SpeechRecognitionService
+```
+
+**4. 验证**:运行演示应用的*识别器测试*界面,它调用 `SpeechRecognizer.createSpeechRecognizer(ctx)`(不带组件)并记录每个框架回调 — 无需 logcat 即可确认 binder 往返。
+
+服务实现了 `onCheckRecognitionSupport`(API 33+),返回 Parakeet TDT v3 涵盖的 27 个 BCP-47 语言,在模型存在时标记为 `installedOnDeviceLanguage`(下载中时为 `pendingOnDeviceLanguage`)。会话期间使用 `AUDIOFOCUS_GAIN_TRANSIENT` 获取音频焦点。
+
+**注意:** Gboard、三星键盘和 Google Assistant 都自带识别器,会跳过系统默认。显式调用框架 `SpeechRecognizer` API(或在其上构建自己 UI)的应用才会经过你的服务。
 
 ## 性能
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,5 +20,17 @@
 
         <activity android:name=".MainActivity" android:exported="false" />
         <activity android:name=".DictationActivity" android:exported="false" />
+
+        <service
+            android:name="audio.soniqo.speech.service.SpeechRecognitionService"
+            android:exported="true"
+            android:permission="android.permission.RECORD_AUDIO">
+            <intent-filter>
+                <action android:name="android.speech.RecognitionService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.speech"
+                android:resource="@xml/recognition_service" />
+        </service>
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,17 @@
         <activity android:name=".MainActivity" android:exported="false" />
         <activity android:name=".DictationActivity" android:exported="false" />
 
+        <!-- Settings entry the system Voice-input picker opens via the gear -->
+        <activity
+            android:name=".SpeechRecognitionSettingsActivity"
+            android:exported="true"
+            android:label="Speech recognition settings">
+            <intent-filter>
+                <action android:name="android.speech.action.RECOGNIZER_INTENT" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name="audio.soniqo.speech.service.SpeechRecognitionService"
             android:exported="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
 
         <activity android:name=".MainActivity" android:exported="false" />
         <activity android:name=".DictationActivity" android:exported="false" />
+        <activity android:name=".SpeechRecognizerTestActivity" android:exported="false" />
 
         <!-- Settings entry the system Voice-input picker opens via the gear -->
         <activity

--- a/app/src/main/kotlin/com/soniqo/speech/demo/DictationActivity.kt
+++ b/app/src/main/kotlin/com/soniqo/speech/demo/DictationActivity.kt
@@ -20,6 +20,8 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.core.app.ActivityCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.lifecycleScope
 import audio.soniqo.speech.ModelManager
 import audio.soniqo.speech.ModelPrecision
@@ -66,6 +68,13 @@ class DictationActivity : ComponentActivity() {
         val root = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             setBackgroundColor(Color.parseColor("#0F0F0F"))
+        }
+
+        // Edge-to-edge insets — same as MainActivity.
+        ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
+            val sb = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(v.paddingLeft, sb.top, v.paddingRight, sb.bottom)
+            insets
         }
 
         // Status bar

--- a/app/src/main/kotlin/com/soniqo/speech/demo/LauncherActivity.kt
+++ b/app/src/main/kotlin/com/soniqo/speech/demo/LauncherActivity.kt
@@ -44,6 +44,11 @@ class LauncherActivity : ComponentActivity() {
             finish()
         })
 
+        root.addView(modeButton("Recognizer test", "Exercises android.speech.SpeechRecognizer") {
+            startActivity(Intent(this, SpeechRecognizerTestActivity::class.java))
+            finish()
+        })
+
         setContentView(root)
     }
 

--- a/app/src/main/kotlin/com/soniqo/speech/demo/MainActivity.kt
+++ b/app/src/main/kotlin/com/soniqo/speech/demo/MainActivity.kt
@@ -22,6 +22,8 @@ import android.widget.ScrollView
 import android.widget.TextView
 import androidx.activity.ComponentActivity
 import androidx.core.app.ActivityCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.lifecycleScope
 import audio.soniqo.speech.ModelManager
 import audio.soniqo.speech.ModelPrecision
@@ -72,6 +74,14 @@ class MainActivity : ComponentActivity() {
         val root = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             setBackgroundColor(Color.parseColor("#0F0F0F"))
+        }
+
+        // Android 15 / One UI 8 force edge-to-edge — without this, the mic
+        // button at the bottom slides under the gesture-nav bar.
+        ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
+            val sb = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(v.paddingLeft, sb.top, v.paddingRight, sb.bottom)
+            insets
         }
 
         // Status bar

--- a/app/src/main/kotlin/com/soniqo/speech/demo/SpeechRecognitionSettingsActivity.kt
+++ b/app/src/main/kotlin/com/soniqo/speech/demo/SpeechRecognitionSettingsActivity.kt
@@ -1,0 +1,97 @@
+package audio.soniqo.speech.demo
+
+import android.graphics.Color
+import android.graphics.Typeface
+import android.os.Bundle
+import android.view.Gravity
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import androidx.activity.ComponentActivity
+import audio.soniqo.speech.ModelManager
+import audio.soniqo.speech.ModelPrecision
+import audio.soniqo.speech.service.SpeechRecognitionService
+
+/**
+ * Settings entry that the system "Voice input" picker (Settings → System →
+ * Languages & input → Voice input) opens via the gear icon next to our
+ * recognizer. Currently informational — there's nothing user-tunable yet —
+ * but having this Activity registered prevents Android from greying out the
+ * gear, which signals to users that the recognizer is configurable / alive.
+ */
+class SpeechRecognitionSettingsActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val root = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(Color.parseColor("#0F0F0F"))
+            setPadding(64, 96, 64, 64)
+        }
+
+        root.addView(TextView(this).apply {
+            text = "Speech Recognition"
+            textSize = 22f
+            setTextColor(Color.WHITE)
+            typeface = Typeface.MONOSPACE
+            gravity = Gravity.CENTER
+            setPadding(0, 0, 0, 32)
+        })
+
+        val ready = ModelManager.areModelsReady(this, ModelPrecision.INT8)
+        root.addView(TextView(this).apply {
+            text = if (ready) "Models: ready (on-device)" else "Models: pending download"
+            textSize = 14f
+            setTextColor(if (ready) Color.parseColor("#4CAF50") else Color.parseColor("#FFB74D"))
+            setPadding(0, 0, 0, 16)
+        })
+
+        root.addView(TextView(this).apply {
+            text = "Recognition runs entirely on-device via Parakeet TDT v3 + Silero VAD. " +
+                "No audio leaves the device."
+            textSize = 13f
+            setTextColor(Color.parseColor("#AAAAAA"))
+            setPadding(0, 0, 0, 32)
+        })
+
+        root.addView(divider())
+
+        root.addView(TextView(this).apply {
+            text = "Supported languages"
+            textSize = 16f
+            setTextColor(Color.WHITE)
+            setPadding(0, 24, 0, 12)
+        })
+
+        val langScroll = ScrollView(this).apply {
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, 0, 1f,
+            )
+        }
+        val langList = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+        }
+        SpeechRecognitionService.SUPPORTED_LANGUAGES.forEach { tag ->
+            langList.addView(TextView(this).apply {
+                text = "  • $tag"
+                textSize = 14f
+                setTextColor(Color.parseColor("#CCCCCC"))
+                typeface = Typeface.MONOSPACE
+                setPadding(0, 6, 0, 6)
+            })
+        }
+        langScroll.addView(langList)
+        root.addView(langScroll)
+
+        setContentView(root)
+    }
+
+    private fun divider() = View(this).apply {
+        setBackgroundColor(Color.parseColor("#222222"))
+        layoutParams = LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT, 1,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/soniqo/speech/demo/SpeechRecognitionSettingsActivity.kt
+++ b/app/src/main/kotlin/com/soniqo/speech/demo/SpeechRecognitionSettingsActivity.kt
@@ -9,6 +9,8 @@ import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.activity.ComponentActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import audio.soniqo.speech.ModelManager
 import audio.soniqo.speech.ModelPrecision
 import audio.soniqo.speech.service.SpeechRecognitionService
@@ -29,6 +31,18 @@ class SpeechRecognitionSettingsActivity : ComponentActivity() {
             orientation = LinearLayout.VERTICAL
             setBackgroundColor(Color.parseColor("#0F0F0F"))
             setPadding(64, 96, 64, 64)
+        }
+
+        // Edge-to-edge insets — push content below status bar / above nav.
+        ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
+            val sb = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(
+                v.paddingLeft,
+                v.paddingTop + sb.top,
+                v.paddingRight,
+                v.paddingBottom + sb.bottom,
+            )
+            insets
         }
 
         root.addView(TextView(this).apply {

--- a/app/src/main/kotlin/com/soniqo/speech/demo/SpeechRecognizerTestActivity.kt
+++ b/app/src/main/kotlin/com/soniqo/speech/demo/SpeechRecognizerTestActivity.kt
@@ -1,0 +1,270 @@
+package audio.soniqo.speech.demo
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.graphics.Color
+import android.graphics.Typeface
+import android.os.Bundle
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
+import android.view.Gravity
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import androidx.activity.ComponentActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+/**
+ * Exercises the framework `SpeechRecognizer` API without going through a
+ * keyboard. Mirrors what Gboard / a third-party app would do, but uses
+ * `createSpeechRecognizer(ctx)` (no `ComponentName`) which routes the
+ * request to whatever is configured as the system default voice
+ * recognition service.
+ *
+ * If our `SpeechRecognitionService` is set as the default
+ * (`settings put secure voice_recognition_service
+ *  audio.soniqo.speech.demo/audio.soniqo.speech.service.SpeechRecognitionService`),
+ * tapping "start" here ends up in our `onStartListening` and audio
+ * flows through our pipeline. The log view shows every callback the
+ * framework delivers — useful for diagnosing the binder round-trip
+ * without needing logcat.
+ */
+class SpeechRecognizerTestActivity : ComponentActivity() {
+
+    private var recognizer: SpeechRecognizer? = null
+    private lateinit var statusView: TextView
+    private lateinit var logView: TextView
+    private lateinit var startBtn: TextView
+    private lateinit var stopBtn: TextView
+    private val log = StringBuilder()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        buildUI()
+
+        if (!SpeechRecognizer.isRecognitionAvailable(this)) {
+            statusView.text = "no recognition service available on this device"
+            return
+        }
+        statusView.text = "ready — tap start"
+        startBtn.isEnabled = true
+    }
+
+    private fun buildUI() {
+        val root = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(Color.parseColor("#0F0F0F"))
+            setPadding(48, 96, 48, 48)
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
+            val sb = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(
+                v.paddingLeft,
+                v.paddingTop + sb.top,
+                v.paddingRight,
+                v.paddingBottom + sb.bottom,
+            )
+            insets
+        }
+
+        root.addView(TextView(this).apply {
+            text = "SpeechRecognizer test"
+            textSize = 20f
+            setTextColor(Color.WHITE)
+            typeface = Typeface.MONOSPACE
+            gravity = Gravity.CENTER
+            setPadding(0, 0, 0, 16)
+        })
+        root.addView(TextView(this).apply {
+            text = "Calls SpeechRecognizer.createSpeechRecognizer(ctx) with " +
+                "no component, exercising the system default. " +
+                "Set our service as default first via " +
+                "Settings → Voice input, or:\n\n" +
+                "adb shell settings put secure voice_recognition_service " +
+                "audio.soniqo.speech.demo/audio.soniqo.speech.service.SpeechRecognitionService"
+            textSize = 12f
+            setTextColor(Color.parseColor("#888888"))
+            setPadding(0, 0, 0, 24)
+        })
+
+        statusView = TextView(this).apply {
+            text = "initialising..."
+            textSize = 14f
+            setTextColor(Color.parseColor("#4FC3F7"))
+            typeface = Typeface.MONOSPACE
+            setPadding(0, 0, 0, 16)
+        }
+        root.addView(statusView)
+
+        val buttons = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER
+            setPadding(0, 0, 0, 24)
+        }
+        startBtn = button("Start").apply {
+            isEnabled = false
+            setOnClickListener { handleStart() }
+        }
+        stopBtn = button("Stop").apply {
+            isEnabled = false
+            setOnClickListener { handleStop() }
+        }
+        buttons.addView(startBtn)
+        buttons.addView(stopBtn)
+        root.addView(buttons)
+
+        val scroll = ScrollView(this).apply {
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, 0, 1f,
+            )
+        }
+        logView = TextView(this).apply {
+            textSize = 12f
+            setTextColor(Color.parseColor("#CCCCCC"))
+            typeface = Typeface.MONOSPACE
+            setPadding(16, 16, 16, 16)
+            setBackgroundColor(Color.parseColor("#181818"))
+            setTextIsSelectable(true)
+        }
+        scroll.addView(logView)
+        root.addView(scroll)
+
+        setContentView(root)
+    }
+
+    private fun button(label: String) = TextView(this).apply {
+        text = label
+        textSize = 16f
+        setTextColor(Color.parseColor("#4FC3F7"))
+        setPadding(48, 16, 48, 16)
+        gravity = Gravity.CENTER
+    }
+
+    private fun handleStart() {
+        if (checkSelfPermission(Manifest.permission.RECORD_AUDIO)
+            != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(
+                this, arrayOf(Manifest.permission.RECORD_AUDIO), 1)
+            return
+        }
+        appendLog("→ createSpeechRecognizer(ctx)  // no component")
+        recognizer = SpeechRecognizer.createSpeechRecognizer(this).apply {
+            setRecognitionListener(listener)
+        }
+        val intent = android.content.Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+            putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
+            putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, true)
+        }
+        appendLog("→ startListening(...)")
+        statusView.text = "listening..."
+        recognizer?.startListening(intent)
+        startBtn.isEnabled = false
+        stopBtn.isEnabled = true
+    }
+
+    private fun handleStop() {
+        appendLog("→ stopListening()")
+        recognizer?.stopListening()
+        stopBtn.isEnabled = false
+    }
+
+    private val listener = object : RecognitionListener {
+        override fun onReadyForSpeech(params: Bundle?) =
+            runOnUiThread {
+                appendLog("← onReadyForSpeech")
+                statusView.text = "speak now"
+            }
+
+        override fun onBeginningOfSpeech() =
+            runOnUiThread {
+                appendLog("← onBeginningOfSpeech")
+                statusView.text = "hearing speech"
+            }
+
+        override fun onRmsChanged(rmsdB: Float) = Unit  // too chatty for the log
+
+        override fun onBufferReceived(buffer: ByteArray?) = Unit
+
+        override fun onEndOfSpeech() =
+            runOnUiThread {
+                appendLog("← onEndOfSpeech")
+                statusView.text = "transcribing..."
+            }
+
+        override fun onError(error: Int) =
+            runOnUiThread {
+                appendLog("← onError(${errorName(error)})")
+                statusView.text = "error: ${errorName(error)}"
+                resetButtons()
+            }
+
+        override fun onResults(results: Bundle?) =
+            runOnUiThread {
+                val texts = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+                appendLog("← onResults: ${texts?.firstOrNull() ?: "(empty)"}")
+                statusView.text = "done — ${texts?.firstOrNull() ?: ""}"
+                resetButtons()
+            }
+
+        override fun onPartialResults(partialResults: Bundle?) =
+            runOnUiThread {
+                val text = partialResults?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+                    ?.firstOrNull()
+                if (!text.isNullOrEmpty()) {
+                    appendLog("← onPartialResults: $text")
+                }
+            }
+
+        override fun onEvent(eventType: Int, params: Bundle?) =
+            runOnUiThread {
+                appendLog("← onEvent(type=$eventType)")
+            }
+    }
+
+    private fun resetButtons() {
+        startBtn.isEnabled = true
+        stopBtn.isEnabled = false
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int, permissions: Array<String>, grantResults: IntArray,
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == 1 && grantResults.firstOrNull() == PackageManager.PERMISSION_GRANTED) {
+            handleStart()
+        } else {
+            statusView.text = "RECORD_AUDIO denied"
+        }
+    }
+
+    override fun onDestroy() {
+        recognizer?.destroy()
+        recognizer = null
+        super.onDestroy()
+    }
+
+    private fun appendLog(line: String) {
+        log.appendLine(line)
+        logView.text = log.toString()
+    }
+
+    private fun errorName(code: Int): String = when (code) {
+        SpeechRecognizer.ERROR_NETWORK -> "ERROR_NETWORK"
+        SpeechRecognizer.ERROR_NETWORK_TIMEOUT -> "ERROR_NETWORK_TIMEOUT"
+        SpeechRecognizer.ERROR_AUDIO -> "ERROR_AUDIO"
+        SpeechRecognizer.ERROR_SERVER -> "ERROR_SERVER"
+        SpeechRecognizer.ERROR_CLIENT -> "ERROR_CLIENT"
+        SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "ERROR_SPEECH_TIMEOUT"
+        SpeechRecognizer.ERROR_NO_MATCH -> "ERROR_NO_MATCH"
+        SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "ERROR_RECOGNIZER_BUSY"
+        SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS -> "ERROR_INSUFFICIENT_PERMISSIONS"
+        SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> "ERROR_TOO_MANY_REQUESTS"
+        else -> "code=$code"
+    }
+}

--- a/app/src/main/res/xml/recognition_service.xml
+++ b/app/src/main/res/xml/recognition_service.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<recognition-service xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/app/src/main/res/xml/recognition_service.xml
+++ b/app/src/main/res/xml/recognition_service.xml
@@ -1,2 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<recognition-service xmlns:android="http://schemas.android.com/apk/res/android" />
+<recognition-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:settingsActivity="audio.soniqo.speech.demo.SpeechRecognitionSettingsActivity" />

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -104,6 +104,7 @@ publishing {
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("androidx.annotation:annotation:1.8.2")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -47,6 +47,10 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
 }
 
 mavenPublishing {
@@ -104,6 +108,10 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+    testImplementation("org.robolectric:robolectric:4.13")
+    testImplementation("androidx.test:core:1.6.1")
+    testImplementation("androidx.test.ext:junit:1.2.1")
+    testImplementation("io.mockk:mockk:1.13.13")
 
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test:runner:1.6.2")

--- a/sdk/src/main/kotlin/com/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/com/soniqo/speech/ModelManager.kt
@@ -70,6 +70,38 @@ object ModelManager {
         val completed: Int,
     )
 
+    /**
+     * True iff every required model file for [precision] is already on disk
+     * and passes [isValidModel] (right ONNX magic, above the per-file size
+     * floor) and the cached version matches [MODEL_VERSION].
+     *
+     * Cheap and side-effect free — does not start a download. Used by paths
+     * that must answer "are we ready?" without blocking, e.g.
+     * `SpeechRecognitionService.onCheckRecognitionSupport()`.
+     */
+    fun areModelsReady(
+        context: Context,
+        precision: ModelPrecision = ModelPrecision.INT8,
+    ): Boolean {
+        val dir = File(context.filesDir, "models")
+        if (!dir.exists()) return false
+
+        val versionFile = File(dir, "version.txt")
+        val cached = versionFile.takeIf { it.exists() }?.readText()?.trim()?.toIntOrNull() ?: 0
+        if (cached < MODEL_VERSION) return false
+
+        val fileList = models(precision)
+        val allFiles = if (precision == ModelPrecision.FP32) {
+            fileList + ModelFile("Parakeet-TDT-0.6B-ONNX", "parakeet-encoder.onnx.data")
+        } else {
+            fileList
+        }
+        return allFiles.all { model ->
+            val dest = File(dir, model.filename)
+            dest.exists() && isValidModel(dest, model.filename)
+        }
+    }
+
     /** Returns the model directory path, downloading models if needed. */
     suspend fun ensureModels(
         context: Context,

--- a/sdk/src/main/kotlin/com/soniqo/speech/SpeechPipeline.kt
+++ b/sdk/src/main/kotlin/com/soniqo/speech/SpeechPipeline.kt
@@ -11,6 +11,9 @@ import kotlinx.coroutines.flow.asSharedFlow
  * Wraps speech-core (C++) via JNI. All inference runs locally via ONNX Runtime
  * with NNAPI acceleration on Qualcomm Snapdragon / Samsung Exynos.
  *
+ * Construct via `SpeechPipeline(config)`. Tests can supply their own
+ * implementation of this interface to avoid loading the native library.
+ *
  * Usage:
  * ```
  * val pipeline = SpeechPipeline(config)
@@ -21,15 +24,41 @@ import kotlinx.coroutines.flow.asSharedFlow
  * pipeline.close()
  * ```
  */
-class SpeechPipeline(private val config: SpeechConfig) : AutoCloseable {
+interface SpeechPipeline : AutoCloseable {
+
+    /** Stream of pipeline events (speech start/end, transcriptions, audio). */
+    val events: SharedFlow<SpeechEvent>
+
+    val state: PipelineState
+
+    /**
+     * Non-null if NNAPI failed during model loading and the engine fell back to CPU.
+     * Contains the NNAPI error message. Useful for diagnostics — ask users to report this.
+     */
+    val nnapiFallbackReason: String?
+
+    fun start()
+    fun stop()
+
+    /** Feed PCM Float32 microphone samples at 16 kHz. */
+    fun pushAudio(samples: FloatArray)
+
+    /** Signal that response playback finished — resume listening. */
+    fun resumeListening()
+
+    companion object {
+        operator fun invoke(config: SpeechConfig): SpeechPipeline = SpeechPipelineImpl(config)
+    }
+}
+
+internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
 
     private val _events = MutableSharedFlow<SpeechEvent>(
         extraBufferCapacity = 64,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
 
-    /** Stream of pipeline events (speech start/end, transcriptions, audio). */
-    val events: SharedFlow<SpeechEvent> = _events.asSharedFlow()
+    override val events: SharedFlow<SpeechEvent> = _events.asSharedFlow()
 
     private val nativeCallback = object : NativeBridge.EventCallback {
         override fun onEvent(
@@ -68,31 +97,25 @@ class SpeechPipeline(private val config: SpeechConfig) : AutoCloseable {
         )
     }
 
-    val state: PipelineState
+    override val state: PipelineState
         get() = PipelineState.from(NativeBridge.nativeGetState(handle))
 
-    /**
-     * Non-null if NNAPI failed during model loading and the engine fell back to CPU.
-     * Contains the NNAPI error message. Useful for diagnostics — ask users to report this.
-     */
-    val nnapiFallbackReason: String?
+    override val nnapiFallbackReason: String?
         get() = NativeBridge.nativeNnapiFallbackReason()
 
-    fun start() {
+    override fun start() {
         NativeBridge.nativeStart(handle)
     }
 
-    fun stop() {
+    override fun stop() {
         NativeBridge.nativeStop(handle)
     }
 
-    /** Feed PCM Float32 microphone samples at 16 kHz. */
-    fun pushAudio(samples: FloatArray) {
+    override fun pushAudio(samples: FloatArray) {
         NativeBridge.nativePushAudio(handle, samples, samples.size)
     }
 
-    /** Signal that response playback finished — resume listening. */
-    fun resumeListening() {
+    override fun resumeListening() {
         NativeBridge.nativeResumeListen(handle)
     }
 

--- a/sdk/src/main/kotlin/com/soniqo/speech/service/SpeechRecognitionService.kt
+++ b/sdk/src/main/kotlin/com/soniqo/speech/service/SpeechRecognitionService.kt
@@ -1,0 +1,229 @@
+package audio.soniqo.speech.service
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaRecorder
+import android.os.Bundle
+import android.speech.RecognitionService
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
+import android.util.Log
+import audio.soniqo.speech.ModelManager
+import audio.soniqo.speech.ModelPrecision
+import audio.soniqo.speech.SpeechConfig
+import audio.soniqo.speech.SpeechEvent
+import audio.soniqo.speech.SpeechPipeline
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Exposes [SpeechPipeline] via Android's [RecognitionService] API so any app
+ * using [SpeechRecognizer] (Gboard, Duolingo, the system voice input picker)
+ * can invoke fully on-device STT.
+ *
+ * Register in your app's manifest with intent filter
+ * `android.speech.RecognitionService` and a `@xml/recognition_service`
+ * meta-data resource. The user can then select this app under
+ * Settings → System → Languages & input → Voice input.
+ *
+ * The service reads the microphone itself via [AudioRecord] — callers do not
+ * push audio. `EXTRA_LANGUAGE` is currently logged but not enforced; Parakeet
+ * v3 auto-detects across 114 languages.
+ */
+class SpeechRecognitionService : RecognitionService() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    @Volatile
+    private var session: Session? = null
+
+    private class Session(
+        val pipeline: SpeechPipeline,
+        val audioRecord: AudioRecord,
+        val micJob: Job,
+        val eventJob: Job,
+    )
+
+    override fun onStartListening(recognizerIntent: Intent?, listener: Callback) {
+        if (session != null) {
+            listener.error(SpeechRecognizer.ERROR_RECOGNIZER_BUSY)
+            return
+        }
+        if (checkSelfPermission(Manifest.permission.RECORD_AUDIO)
+            != PackageManager.PERMISSION_GRANTED) {
+            listener.error(SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS)
+            return
+        }
+
+        val wantPartial = recognizerIntent
+            ?.getBooleanExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, false) ?: false
+        val requestedLang = recognizerIntent?.getStringExtra(RecognizerIntent.EXTRA_LANGUAGE)
+        if (requestedLang != null) {
+            Log.i(TAG, "EXTRA_LANGUAGE=$requestedLang (auto-detected by STT, hint not enforced)")
+        }
+
+        scope.launch { startSession(listener, wantPartial) }
+    }
+
+    private suspend fun startSession(listener: Callback, wantPartial: Boolean) {
+        val pipeline: SpeechPipeline
+        val record: AudioRecord
+        try {
+            val modelDir = ModelManager.ensureModels(this, ModelPrecision.INT8)
+            pipeline = SpeechPipeline(
+                SpeechConfig(
+                    modelDir = modelDir,
+                    emitPartialTranscriptions = wantPartial,
+                )
+            )
+
+            val sampleRate = 16_000
+            val minBuf = AudioRecord.getMinBufferSize(
+                sampleRate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_FLOAT
+            )
+            if (minBuf <= 0) {
+                listener.error(SpeechRecognizer.ERROR_AUDIO)
+                pipeline.close()
+                return
+            }
+            record = AudioRecord(
+                MediaRecorder.AudioSource.VOICE_RECOGNITION,
+                sampleRate,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_FLOAT,
+                minBuf * 4,
+            )
+            if (record.state != AudioRecord.STATE_INITIALIZED) {
+                listener.error(SpeechRecognizer.ERROR_AUDIO)
+                record.release()
+                pipeline.close()
+                return
+            }
+        } catch (t: Throwable) {
+            Log.e(TAG, "failed to initialize pipeline", t)
+            listener.error(mapInitError(t))
+            return
+        }
+
+        pipeline.start()
+        record.startRecording()
+        listener.readyForSpeech(Bundle.EMPTY)
+
+        val eventJob = scope.launch {
+            pipeline.events.collect { ev -> handleEvent(ev, listener) }
+        }
+
+        val micJob = scope.launch(Dispatchers.IO) {
+            val buf = FloatArray(512)
+            while (isActive) {
+                val n = record.read(buf, 0, buf.size, AudioRecord.READ_BLOCKING)
+                if (n > 0) {
+                    val samples = if (n == buf.size) buf else buf.copyOf(n)
+                    pipeline.pushAudio(samples)
+                } else if (n < 0) {
+                    Log.w(TAG, "AudioRecord.read returned $n")
+                    break
+                }
+            }
+        }
+
+        session = Session(pipeline, record, micJob, eventJob)
+    }
+
+    private fun handleEvent(event: SpeechEvent, listener: Callback) {
+        when (event) {
+            is SpeechEvent.SpeechStarted -> safeCallback { listener.beginningOfSpeech() }
+
+            is SpeechEvent.SpeechEnded -> safeCallback { listener.endOfSpeech() }
+
+            is SpeechEvent.PartialTranscription -> {
+                if (event.text.isEmpty()) return
+                val bundle = Bundle().apply {
+                    putStringArrayList(
+                        SpeechRecognizer.RESULTS_RECOGNITION,
+                        arrayListOf(event.text),
+                    )
+                }
+                safeCallback { listener.partialResults(bundle) }
+            }
+
+            is SpeechEvent.TranscriptionCompleted -> {
+                val bundle = Bundle().apply {
+                    putStringArrayList(
+                        SpeechRecognizer.RESULTS_RECOGNITION,
+                        arrayListOf(event.text),
+                    )
+                    putFloatArray(
+                        SpeechRecognizer.CONFIDENCE_SCORES,
+                        floatArrayOf(event.confidence),
+                    )
+                }
+                safeCallback { listener.results(bundle) }
+                tearDownSession()
+            }
+
+            is SpeechEvent.Error -> {
+                Log.e(TAG, "pipeline error: ${event.message}")
+                safeCallback { listener.error(SpeechRecognizer.ERROR_SERVER) }
+                tearDownSession()
+            }
+
+            else -> Unit
+        }
+    }
+
+    override fun onStopListening(listener: Callback) {
+        // Stop reading the mic but let the pipeline flush so VAD detects
+        // end-of-utterance and emits the final TranscriptionCompleted event.
+        val s = session ?: return
+        s.micJob.cancel()
+        runCatching { s.audioRecord.stop() }
+    }
+
+    override fun onCancel(listener: Callback) {
+        tearDownSession()
+    }
+
+    private fun tearDownSession() {
+        val s = session ?: return
+        session = null
+        runCatching { s.eventJob.cancel() }
+        runCatching { s.micJob.cancel() }
+        runCatching { s.audioRecord.stop() }
+        runCatching { s.audioRecord.release() }
+        runCatching { s.pipeline.stop() }
+        runCatching { s.pipeline.close() }
+    }
+
+    override fun onDestroy() {
+        tearDownSession()
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    private inline fun safeCallback(block: () -> Unit) {
+        try {
+            block()
+        } catch (e: Exception) {
+            Log.w(TAG, "callback delivery failed: ${e.message}")
+        }
+    }
+
+    private fun mapInitError(t: Throwable): Int = when (t) {
+        is java.io.IOException -> SpeechRecognizer.ERROR_NETWORK
+        is SecurityException -> SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS
+        else -> SpeechRecognizer.ERROR_SERVER
+    }
+
+    companion object {
+        private const val TAG = "SoniqoRecognition"
+    }
+}

--- a/sdk/src/main/kotlin/com/soniqo/speech/service/SpeechRecognitionService.kt
+++ b/sdk/src/main/kotlin/com/soniqo/speech/service/SpeechRecognitionService.kt
@@ -3,14 +3,20 @@ package audio.soniqo.speech.service
 import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
 import android.media.AudioFormat
+import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.MediaRecorder
+import android.os.Build
 import android.os.Bundle
 import android.speech.RecognitionService
+import android.speech.RecognitionSupport
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
 import android.util.Log
+import androidx.annotation.RequiresApi
 import audio.soniqo.speech.ModelManager
 import audio.soniqo.speech.ModelPrecision
 import audio.soniqo.speech.SpeechConfig
@@ -56,6 +62,9 @@ open class SpeechRecognitionService : RecognitionService() {
     // begins, so a second start request rejects with BUSY instead of racing to
     // create a parallel session that leaks AudioRecord and the pipeline.
     private val starting = AtomicBoolean(false)
+
+    @Volatile
+    private var audioFocusRequest: AudioFocusRequest? = null
 
     private class Session(
         val pipeline: SpeechPipeline,
@@ -124,6 +133,7 @@ open class SpeechRecognitionService : RecognitionService() {
 
         pipeline.start()
         record.startRecording()
+        requestAudioFocus()
         listener.readyForSpeech(Bundle.EMPTY)
 
         val eventJob = scope.launch {
@@ -219,6 +229,7 @@ open class SpeechRecognitionService : RecognitionService() {
         runCatching { s.audioRecord.release() }
         runCatching { s.pipeline.stop() }
         runCatching { s.pipeline.close() }
+        abandonAudioFocus()
     }
 
     override fun onDestroy() {
@@ -269,7 +280,88 @@ open class SpeechRecognitionService : RecognitionService() {
         )
     }
 
+    // -- audio focus ---------------------------------------------------------
+
+    /**
+     * Acquire transient audio focus while we're listening so music ducks /
+     * pauses, and we get notified when something more important needs the
+     * mic (incoming call, navigation prompt). Best-effort; logs and proceeds
+     * if the system denies the request.
+     */
+    private fun requestAudioFocus() {
+        val am = getSystemService(AudioManager::class.java) ?: return
+        val attrs = AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+            .build()
+        val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+            .setAudioAttributes(attrs)
+            .setOnAudioFocusChangeListener { change ->
+                when (change) {
+                    AudioManager.AUDIOFOCUS_LOSS,
+                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT,
+                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
+                        Log.i(TAG, "audio focus lost ($change), tearing down session")
+                        tearDownSession()
+                    }
+                    else -> Unit
+                }
+            }
+            .build()
+        audioFocusRequest = request
+        val result = am.requestAudioFocus(request)
+        if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+            Log.w(TAG, "audio focus request denied (result=$result) — proceeding anyway")
+        }
+    }
+
+    private fun abandonAudioFocus() {
+        val am = getSystemService(AudioManager::class.java) ?: return
+        val req = audioFocusRequest ?: return
+        audioFocusRequest = null
+        runCatching { am.abandonAudioFocusRequest(req) }
+    }
+
+    // -- onCheckRecognitionSupport (API 33+) --------------------------------
+
+    /**
+     * Tell the framework which BCP-47 languages we can recognize on-device.
+     * If the models are already present we report them as installed; if
+     * they're still pending download we mark them pending so the caller can
+     * surface a "downloading" UX instead of falling back to an online
+     * recognizer.
+     *
+     * The list is a representative subset of Parakeet TDT v3's claimed
+     * 114-language support — extend [SUPPORTED_LANGUAGES] to advertise more.
+     */
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    override fun onCheckRecognitionSupport(
+        recognizerIntent: Intent,
+        listener: SupportCallback,
+    ) {
+        val builder = RecognitionSupport.Builder()
+        val ready = ModelManager.areModelsReady(this, ModelPrecision.INT8)
+        SUPPORTED_LANGUAGES.forEach { tag ->
+            if (ready) builder.addInstalledOnDeviceLanguage(tag)
+            else builder.addPendingOnDeviceLanguage(tag)
+        }
+        listener.onSupportResult(builder.build())
+    }
+
     companion object {
         private const val TAG = "SoniqoRecognition"
+
+        /**
+         * BCP-47 tags advertised via [onCheckRecognitionSupport]. Parakeet
+         * TDT v3 is multilingual; this is a curated subset of the most-
+         * requested languages — extend as needed.
+         */
+        @JvmField
+        val SUPPORTED_LANGUAGES: List<String> = listOf(
+            "ar", "cs", "da", "de", "el", "en", "es", "fi",
+            "fr", "he", "hi", "hu", "id", "it", "ja", "ko",
+            "nb", "nl", "pl", "pt", "ru", "sv", "th", "tr",
+            "uk", "vi", "zh",
+        )
     }
 }

--- a/sdk/src/main/kotlin/com/soniqo/speech/service/SpeechRecognitionService.kt
+++ b/sdk/src/main/kotlin/com/soniqo/speech/service/SpeechRecognitionService.kt
@@ -21,8 +21,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Exposes [SpeechPipeline] via Android's [RecognitionService] API so any app
@@ -45,6 +48,11 @@ class SpeechRecognitionService : RecognitionService() {
     @Volatile
     private var session: Session? = null
 
+    // Synchronously claimed in onStartListening before the suspending setup
+    // begins, so a second start request rejects with BUSY instead of racing to
+    // create a parallel session that leaks AudioRecord and the pipeline.
+    private val starting = AtomicBoolean(false)
+
     private class Session(
         val pipeline: SpeechPipeline,
         val audioRecord: AudioRecord,
@@ -53,13 +61,13 @@ class SpeechRecognitionService : RecognitionService() {
     )
 
     override fun onStartListening(recognizerIntent: Intent?, listener: Callback) {
-        if (session != null) {
-            listener.error(SpeechRecognizer.ERROR_RECOGNIZER_BUSY)
-            return
-        }
         if (checkSelfPermission(Manifest.permission.RECORD_AUDIO)
             != PackageManager.PERMISSION_GRANTED) {
             listener.error(SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS)
+            return
+        }
+        if (session != null || !starting.compareAndSet(false, true)) {
+            listener.error(SpeechRecognizer.ERROR_RECOGNIZER_BUSY)
             return
         }
 
@@ -70,7 +78,13 @@ class SpeechRecognitionService : RecognitionService() {
             Log.i(TAG, "EXTRA_LANGUAGE=$requestedLang (auto-detected by STT, hint not enforced)")
         }
 
-        scope.launch { startSession(listener, wantPartial) }
+        scope.launch {
+            try {
+                startSession(listener, wantPartial)
+            } finally {
+                starting.set(false)
+            }
+        }
     }
 
     private suspend fun startSession(listener: Callback, wantPartial: Boolean) {
@@ -181,11 +195,20 @@ class SpeechRecognitionService : RecognitionService() {
     }
 
     override fun onStopListening(listener: Callback) {
-        // Stop reading the mic but let the pipeline flush so VAD detects
-        // end-of-utterance and emits the final TranscriptionCompleted event.
+        // nativeStop does not flush — VAD only detects end-of-utterance from
+        // silence in the audio stream. After cutting the mic, push ~1 s of
+        // zeros so the pipeline emits its final TranscriptionCompleted event.
         val s = session ?: return
-        s.micJob.cancel()
         runCatching { s.audioRecord.stop() }
+        scope.launch {
+            s.micJob.cancelAndJoin()
+            val silence = FloatArray(512)
+            repeat(32) { // 32 × 32 ms ≈ 1 s @ 16 kHz
+                if (session !== s) return@launch
+                runCatching { s.pipeline.pushAudio(silence) }
+                delay(32)
+            }
+        }
     }
 
     override fun onCancel(listener: Callback) {

--- a/sdk/src/main/kotlin/com/soniqo/speech/service/SpeechRecognitionService.kt
+++ b/sdk/src/main/kotlin/com/soniqo/speech/service/SpeechRecognitionService.kt
@@ -40,8 +40,12 @@ import java.util.concurrent.atomic.AtomicBoolean
  * The service reads the microphone itself via [AudioRecord] — callers do not
  * push audio. `EXTRA_LANGUAGE` is currently logged but not enforced; Parakeet
  * v3 auto-detects across 114 languages.
+ *
+ * Open for test subclassing: [createPipeline], [resolveModelDir], and
+ * [newAudioRecord] are protected seams so JVM unit tests can run without
+ * loading the native library or opening a real microphone.
  */
-class SpeechRecognitionService : RecognitionService() {
+open class SpeechRecognitionService : RecognitionService() {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
@@ -91,30 +95,21 @@ class SpeechRecognitionService : RecognitionService() {
         val pipeline: SpeechPipeline
         val record: AudioRecord
         try {
-            val modelDir = ModelManager.ensureModels(this, ModelPrecision.INT8)
-            pipeline = SpeechPipeline(
+            val modelDir = resolveModelDir()
+            pipeline = createPipeline(
                 SpeechConfig(
                     modelDir = modelDir,
                     emitPartialTranscriptions = wantPartial,
                 )
             )
 
-            val sampleRate = 16_000
-            val minBuf = AudioRecord.getMinBufferSize(
-                sampleRate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_FLOAT
-            )
-            if (minBuf <= 0) {
+            val newRecord = newAudioRecord()
+            if (newRecord == null) {
                 listener.error(SpeechRecognizer.ERROR_AUDIO)
                 pipeline.close()
                 return
             }
-            record = AudioRecord(
-                MediaRecorder.AudioSource.VOICE_RECOGNITION,
-                sampleRate,
-                AudioFormat.CHANNEL_IN_MONO,
-                AudioFormat.ENCODING_PCM_FLOAT,
-                minBuf * 4,
-            )
+            record = newRecord
             if (record.state != AudioRecord.STATE_INITIALIZED) {
                 listener.error(SpeechRecognizer.ERROR_AUDIO)
                 record.release()
@@ -244,6 +239,34 @@ class SpeechRecognitionService : RecognitionService() {
         is java.io.IOException -> SpeechRecognizer.ERROR_NETWORK
         is SecurityException -> SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS
         else -> SpeechRecognizer.ERROR_SERVER
+    }
+
+    /** Build the pipeline. Overridden in tests to inject a fake. */
+    protected open fun createPipeline(config: SpeechConfig): SpeechPipeline =
+        SpeechPipeline(config)
+
+    /** Resolve the model directory. Overridden in tests to skip the download. */
+    protected open suspend fun resolveModelDir(): String =
+        ModelManager.ensureModels(this, ModelPrecision.INT8)
+
+    /**
+     * Open the microphone. Returns null when the format is unsupported on this
+     * device (negative [AudioRecord.getMinBufferSize]). Overridden in tests so
+     * Robolectric doesn't have to stand up a real recorder.
+     */
+    protected open fun newAudioRecord(): AudioRecord? {
+        val sampleRate = 16_000
+        val minBuf = AudioRecord.getMinBufferSize(
+            sampleRate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_FLOAT
+        )
+        if (minBuf <= 0) return null
+        return AudioRecord(
+            MediaRecorder.AudioSource.VOICE_RECOGNITION,
+            sampleRate,
+            AudioFormat.CHANNEL_IN_MONO,
+            AudioFormat.ENCODING_PCM_FLOAT,
+            minBuf * 4,
+        )
     }
 
     companion object {

--- a/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechRecognitionServiceTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechRecognitionServiceTest.kt
@@ -1,0 +1,184 @@
+package audio.soniqo.speech.service
+
+import android.Manifest
+import android.app.Application
+import android.content.Intent
+import android.media.AudioRecord
+import android.speech.RecognitionService
+import android.speech.SpeechRecognizer
+import androidx.test.core.app.ApplicationProvider
+import audio.soniqo.speech.PipelineState
+import audio.soniqo.speech.SpeechConfig
+import audio.soniqo.speech.SpeechEvent
+import audio.soniqo.speech.SpeechPipeline
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ServiceController
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric tests for [SpeechRecognitionService].
+ *
+ * Uses the protected seams [SpeechRecognitionService.createPipeline],
+ * [SpeechRecognitionService.resolveModelDir], and
+ * [SpeechRecognitionService.newAudioRecord] to inject a fake pipeline and a
+ * mocked AudioRecord — no native library load, no real microphone, no model
+ * download. Each test runs in well under a second.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class SpeechRecognitionServiceTest {
+
+    private lateinit var fakePipeline: FakeSpeechPipeline
+    private lateinit var fakeRecord: AudioRecord
+    private lateinit var controller: ServiceController<TestableService>
+    private lateinit var service: TestableService
+    private lateinit var listener: RecognitionService.Callback
+
+    @Before
+    fun setUp() {
+        val app = ApplicationProvider.getApplicationContext<Application>()
+        shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+
+        fakePipeline = FakeSpeechPipeline()
+        fakeRecord = mockk(relaxed = true) {
+            every { state } returns AudioRecord.STATE_INITIALIZED
+            // Returning -1 makes the mic loop exit immediately so it doesn't
+            // hot-spin during the test. We're not exercising the mic path here.
+            every { read(any<FloatArray>(), any(), any(), any()) } returns -1
+        }
+
+        controller = Robolectric.buildService(TestableService::class.java)
+        service = controller.create().get()
+        service.install(fakePipeline, fakeRecord)
+        listener = mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        controller.destroy()
+        unmockkAll()
+    }
+
+    @Test
+    fun startListening_setsUpPipelineAndSignalsReady() {
+        service.onStartListening(Intent(), listener)
+
+        verify(timeout = 1500) { listener.readyForSpeech(any()) }
+    }
+
+    @Test
+    fun startListening_concurrentCallReturnsBusy() {
+        // Regression test for the race fix: the first call must claim the
+        // `starting` flag synchronously so a second call hits the busy branch
+        // before the suspending setup of the first one completes.
+        service.onStartListening(Intent(), listener)
+
+        val second = mockk<RecognitionService.Callback>(relaxed = true)
+        service.onStartListening(Intent(), second)
+
+        verify { second.error(SpeechRecognizer.ERROR_RECOGNIZER_BUSY) }
+    }
+
+    @Test
+    fun stopListening_flushesPipelineWithSilence() {
+        // Regression test for the stop-hang fix: VAD detects end-of-utterance
+        // from silence in the audio stream, and nativeStop does not flush. We
+        // expect ~32 chunks × 32 ms ≈ 1 s of zero frames pushed after the mic
+        // is cut so the pipeline emits its final TranscriptionCompleted.
+        service.onStartListening(Intent(), listener)
+        verify(timeout = 1500) { listener.readyForSpeech(any()) }
+
+        service.onStopListening(listener)
+
+        waitFor(2_000) { fakePipeline.silencePushCount >= 30 }
+    }
+
+    @Test
+    fun startListening_withoutPermission_reportsInsufficient() {
+        val app = ApplicationProvider.getApplicationContext<Application>()
+        shadowOf(app).denyPermissions(Manifest.permission.RECORD_AUDIO)
+
+        service.onStartListening(Intent(), listener)
+
+        verify { listener.error(SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS) }
+    }
+
+    @Test
+    fun transcriptionCompleted_emitsResultsAndTearsDownSession() {
+        service.onStartListening(Intent(), listener)
+        verify(timeout = 1500) { listener.readyForSpeech(any()) }
+
+        kotlinx.coroutines.runBlocking {
+            fakePipeline.emit(SpeechEvent.TranscriptionCompleted("hello world", 0.9f, 12.5f))
+        }
+
+        verify(timeout = 1500) { listener.results(any()) }
+        // Pipeline closed → a fresh start is allowed again.
+        waitFor(1_000) { fakePipeline.closeCalls > 0 }
+    }
+
+    private fun waitFor(timeoutMs: Long, predicate: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate()) return
+            Thread.sleep(20)
+        }
+        assertTrue("predicate did not become true within ${timeoutMs}ms", predicate())
+    }
+
+    /** Subclass that exposes the protected seams. */
+    class TestableService : SpeechRecognitionService() {
+        private lateinit var pipelineToInject: SpeechPipeline
+        private lateinit var recordToInject: AudioRecord
+
+        fun install(pipeline: SpeechPipeline, record: AudioRecord) {
+            pipelineToInject = pipeline
+            recordToInject = record
+        }
+
+        override fun createPipeline(config: SpeechConfig): SpeechPipeline = pipelineToInject
+
+        override suspend fun resolveModelDir(): String = "/fake/models"
+
+        override fun newAudioRecord(): AudioRecord = recordToInject
+    }
+
+    /** Minimal SpeechPipeline that records calls and lets the test push events. */
+    class FakeSpeechPipeline : SpeechPipeline {
+        private val _events = MutableSharedFlow<SpeechEvent>(extraBufferCapacity = 64)
+        override val events: SharedFlow<SpeechEvent> = _events.asSharedFlow()
+        override val state: PipelineState = PipelineState.Idle
+        override val nnapiFallbackReason: String? = null
+
+        @Volatile var silencePushCount = 0
+        @Volatile var totalPushCount = 0
+        @Volatile var startCalls = 0
+        @Volatile var stopCalls = 0
+        @Volatile var closeCalls = 0
+
+        override fun start() { startCalls++ }
+        override fun stop() { stopCalls++ }
+        override fun pushAudio(samples: FloatArray) {
+            totalPushCount++
+            if (samples.size == 512 && samples.all { it == 0f }) silencePushCount++
+        }
+        override fun resumeListening() {}
+        override fun close() { closeCalls++ }
+
+        suspend fun emit(event: SpeechEvent) = _events.emit(event)
+    }
+}

--- a/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechRecognitionServiceTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechRecognitionServiceTest.kt
@@ -3,8 +3,11 @@ package audio.soniqo.speech.service
 import android.Manifest
 import android.app.Application
 import android.content.Intent
+import android.media.AudioFocusRequest
+import android.media.AudioManager
 import android.media.AudioRecord
 import android.speech.RecognitionService
+import android.speech.RecognitionSupport
 import android.speech.SpeechRecognizer
 import androidx.test.core.app.ApplicationProvider
 import audio.soniqo.speech.PipelineState
@@ -13,6 +16,7 @@ import audio.soniqo.speech.SpeechEvent
 import audio.soniqo.speech.SpeechPipeline
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -131,6 +135,61 @@ class SpeechRecognitionServiceTest {
         waitFor(1_000) { fakePipeline.closeCalls > 0 }
     }
 
+    @Test
+    fun startListening_requestsAudioFocus() {
+        service.startListening(Intent(), listener)
+        verify(timeout = 1500) { listener.readyForSpeech(any()) }
+
+        val app = ApplicationProvider.getApplicationContext<Application>()
+        val am = app.getSystemService(AudioManager::class.java)
+        val granted = shadowOf(am).lastAudioFocusRequest
+        assertTrue(
+            "expected an AudioFocusRequest after startListening, got $granted",
+            granted != null,
+        )
+    }
+
+    @Test
+    fun audioFocusLoss_tearsDownSession() {
+        service.startListening(Intent(), listener)
+        verify(timeout = 1500) { listener.readyForSpeech(any()) }
+
+        // Simulate the system handing audio focus to a phone call: invoke
+        // the listener that was registered at startListening time.
+        val app = ApplicationProvider.getApplicationContext<Application>()
+        val am = app.getSystemService(AudioManager::class.java)
+        val recordedReq = shadowOf(am).lastAudioFocusRequest!!
+        recordedReq.listener.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS)
+
+        // tearDownSession() runs synchronously on the main thread; the
+        // pipeline's close() is part of it, so we can assert on closeCalls
+        // without polling for long.
+        waitFor(1_000) { fakePipeline.closeCalls > 0 }
+    }
+
+    @Test
+    fun onCheckRecognitionSupport_modelsNotReady_marksLanguagesPending() {
+        val callback = mockk<RecognitionService.SupportCallback>(relaxed = true)
+        service.checkRecognitionSupport(Intent(), callback)
+
+        val supportSlot = slot<RecognitionSupport>()
+        verify(timeout = 1500) { callback.onSupportResult(capture(supportSlot)) }
+        val support = supportSlot.captured
+
+        // Models aren't on disk in the test, so all advertised languages
+        // should be pending — never installed.
+        assertTrue("installed should be empty", support.installedOnDeviceLanguages.isEmpty())
+        assertTrue(
+            "pending should include 'en'",
+            support.pendingOnDeviceLanguages.contains("en"),
+        )
+        assertTrue(
+            "pending should match SUPPORTED_LANGUAGES",
+            support.pendingOnDeviceLanguages
+                .containsAll(SpeechRecognitionService.SUPPORTED_LANGUAGES),
+        )
+    }
+
     private fun waitFor(timeoutMs: Long, predicate: () -> Boolean) {
         val deadline = System.currentTimeMillis() + timeoutMs
         while (System.currentTimeMillis() < deadline) {
@@ -158,6 +217,9 @@ class SpeechRecognitionServiceTest {
             onStartListening(intent, listener)
 
         fun stopListening(listener: Callback) = onStopListening(listener)
+
+        fun checkRecognitionSupport(intent: Intent, callback: SupportCallback) =
+            onCheckRecognitionSupport(intent, callback)
 
         override fun createPipeline(config: SpeechConfig): SpeechPipeline = pipelineToInject
 

--- a/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechRecognitionServiceTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechRecognitionServiceTest.kt
@@ -75,7 +75,7 @@ class SpeechRecognitionServiceTest {
 
     @Test
     fun startListening_setsUpPipelineAndSignalsReady() {
-        service.onStartListening(Intent(), listener)
+        service.startListening(Intent(), listener)
 
         verify(timeout = 1500) { listener.readyForSpeech(any()) }
     }
@@ -85,10 +85,10 @@ class SpeechRecognitionServiceTest {
         // Regression test for the race fix: the first call must claim the
         // `starting` flag synchronously so a second call hits the busy branch
         // before the suspending setup of the first one completes.
-        service.onStartListening(Intent(), listener)
+        service.startListening(Intent(), listener)
 
         val second = mockk<RecognitionService.Callback>(relaxed = true)
-        service.onStartListening(Intent(), second)
+        service.startListening(Intent(), second)
 
         verify { second.error(SpeechRecognizer.ERROR_RECOGNIZER_BUSY) }
     }
@@ -99,10 +99,10 @@ class SpeechRecognitionServiceTest {
         // from silence in the audio stream, and nativeStop does not flush. We
         // expect ~32 chunks × 32 ms ≈ 1 s of zero frames pushed after the mic
         // is cut so the pipeline emits its final TranscriptionCompleted.
-        service.onStartListening(Intent(), listener)
+        service.startListening(Intent(), listener)
         verify(timeout = 1500) { listener.readyForSpeech(any()) }
 
-        service.onStopListening(listener)
+        service.stopListening(listener)
 
         waitFor(2_000) { fakePipeline.silencePushCount >= 30 }
     }
@@ -112,14 +112,14 @@ class SpeechRecognitionServiceTest {
         val app = ApplicationProvider.getApplicationContext<Application>()
         shadowOf(app).denyPermissions(Manifest.permission.RECORD_AUDIO)
 
-        service.onStartListening(Intent(), listener)
+        service.startListening(Intent(), listener)
 
         verify { listener.error(SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS) }
     }
 
     @Test
     fun transcriptionCompleted_emitsResultsAndTearsDownSession() {
-        service.onStartListening(Intent(), listener)
+        service.startListening(Intent(), listener)
         verify(timeout = 1500) { listener.readyForSpeech(any()) }
 
         kotlinx.coroutines.runBlocking {
@@ -140,7 +140,11 @@ class SpeechRecognitionServiceTest {
         assertTrue("predicate did not become true within ${timeoutMs}ms", predicate())
     }
 
-    /** Subclass that exposes the protected seams. */
+    /**
+     * Subclass that exposes the protected seams plus public helpers for the
+     * protected RecognitionService callbacks (onStartListening / onStopListening
+     * are protected on the SDK class, so tests can't call them directly).
+     */
     class TestableService : SpeechRecognitionService() {
         private lateinit var pipelineToInject: SpeechPipeline
         private lateinit var recordToInject: AudioRecord
@@ -149,6 +153,11 @@ class SpeechRecognitionServiceTest {
             pipelineToInject = pipeline
             recordToInject = record
         }
+
+        fun startListening(intent: Intent, listener: Callback) =
+            onStartListening(intent, listener)
+
+        fun stopListening(listener: Callback) = onStopListening(listener)
 
         override fun createPipeline(config: SpeechConfig): SpeechPipeline = pipelineToInject
 


### PR DESCRIPTION
## Summary

A new `SpeechRecognitionService` (in `audio.soniqo.speech.service`) wrapping `SpeechPipeline` so any app using the `SpeechRecognizer` API (Gboard, Duolingo, the system voice-input picker) can invoke fully on-device STT.

This PR also absorbs what was originally split into PR #21 (interface refactor + Robolectric tests). Replacement for #21 — close it once this lands.

### Service contract

- Owns its own `AudioRecord` (`VOICE_RECOGNITION`, 16 kHz, PCM_FLOAT) — callers do not push audio.
- **Event mapping:** `SpeechStarted → beginningOfSpeech`, `PartialTranscription → partialResults`, `TranscriptionCompleted → results` (session ends), `SpeechEnded → endOfSpeech`, `Error → error(ERROR_SERVER)`.
- Honors `EXTRA_PARTIAL_RESULTS` by wiring `emitPartialTranscriptions` on the pipeline.
- `EXTRA_LANGUAGE` is logged but not enforced — Parakeet TDT v3 auto-detects.

### Service polish (added during review)

- **`onCheckRecognitionSupport` (API 33+).** Returns a `RecognitionSupport` with our `SUPPORTED_LANGUAGES` (27 BCP-47 tags from Parakeet TDT v3) marked installed-on-device when `ModelManager.areModelsReady()` is true, pending otherwise. Lets callers surface a "downloading models" UX instead of silently falling back to an online recognizer.
- **Audio focus management.** Acquires `AUDIOFOCUS_GAIN_TRANSIENT` with `USAGE_VOICE_COMMUNICATION` when a session starts, abandons on tear down. On `AUDIOFOCUS_LOSS` / `LOSS_TRANSIENT` the listener tears down the session — yields the mic to incoming calls and nav prompts. Best-effort: a denied focus request logs and proceeds.
- **Settings activity** (in the demo app). Without it, the gear icon next to the recognizer in the system Voice-input picker is greyed out. Currently informational — shows model-readiness state and the supported-language list. Wired via `android:settingsActivity` in `recognition_service.xml` and a `RECOGNIZER_INTENT` filter in the demo manifest.
- **`ModelManager.areModelsReady()` public API.** Synchronous, side-effect-free check used by `onCheckRecognitionSupport` and the settings activity.

### Bug fixes pinned by tests

- **Stop-hang.** `onStopListening` cut the mic without flushing → VAD never saw silence → `TranscriptionCompleted` never fired. Now pushes ~1 s of zero frames after cancelling the mic job.
- **Start-race.** The busy check happened before launching the suspending setup, so two concurrent starts both passed the gate. Now claims an `AtomicBoolean` synchronously.

### Refactor + Robolectric coverage

- `SpeechPipeline` becomes an **interface** with `SpeechPipelineImpl`; companion `invoke` keeps `SpeechPipeline(config)` working at every existing call site (demo + `androidTest`).
- Service opened for subclassing with three protected seams: `createPipeline`, `resolveModelDir`, `newAudioRecord`.
- 8 Robolectric tests exercising the contract end-to-end on the JVM in <1 s each:

| Test | What it pins |
|---|---|
| `startListening_setsUpPipelineAndSignalsReady` | Happy path — `readyForSpeech` fires after pipeline init |
| `startListening_concurrentCallReturnsBusy` | **Regression — start-race fix** |
| `stopListening_flushesPipelineWithSilence` | **Regression — stop-hang fix** (~30 zero-frame chunks) |
| `startListening_withoutPermission_reportsInsufficient` | Permission-denied path |
| `transcriptionCompleted_emitsResultsAndTearsDownSession` | Final event delivers `results(...)` and closes the pipeline |
| `startListening_requestsAudioFocus` | Audio-focus request goes out at session start |
| `audioFocusLoss_tearsDownSession` | `AUDIOFOCUS_LOSS` callback closes the pipeline |
| `onCheckRecognitionSupport_modelsNotReady_marksLanguagesPending` | API 33+ language-support path returns the right shape |

Tests use a `TestableService` subclass that overrides the seams, a `FakeSpeechPipeline` implementing the new interface, and a MockK-mocked `AudioRecord`.

## Scope

**Out of scope (deferred):**

- A true language hint to STT — would need an API change in `SpeechConfig` / `parakeet_stt.cpp`. Tracked separately.
- The legacy `BroadcastReceiver` for `RecognizerIntent.ACTION_GET_LANGUAGE_DETAILS` (pre-API-33 language discovery). minSdk is 26 but the modern `onCheckRecognitionSupport` path covers the dominant case; can add the receiver later if real-world demand surfaces.

Closes #4.

## Test plan

- [x] `./gradlew :sdk:assembleDebug :app:assembleDebug` — green
- [x] `./gradlew :sdk:testDebugUnitTest` — **23/23 pass** (8 service + 15 ModelManager)
- [x] `./gradlew :sdk:connectedDebugAndroidTest` — 34/34 pass on arm64 emulator (verifies the `SpeechPipeline` interface refactor doesn't break the existing pipeline tests)
- [x] Installed demo on arm64 emulator; service registered (`dumpsys package audio.soniqo.speech.demo`):
  - `android.speech.RecognitionService` filter on `SpeechRecognitionService` with `RECORD_AUDIO` permission
  - `android.speech.action.RECOGNIZER_INTENT` filter on `SpeechRecognitionSettingsActivity`
- [x] Set as system default: `settings put secure voice_recognition_service audio.soniqo.speech.demo/audio.soniqo.speech.service.SpeechRecognitionService` — readback confirmed
- [x] Settings activity launches via `am start -a android.speech.action.RECOGNIZER_INTENT` — renders title, model-readiness state, and the 27-language list (screenshot in PR thread)
- [ ] **Manual:** open Gboard in any text field, tap mic, speak — verify transcription comes back from our service
- [ ] **Manual:** Settings → System → Languages & input → Voice input picker — confirm our service appears with the gear icon enabled

## Notes

- This PR replaces #21 (cherry-picked its commits). #21 should be closed when this lands.
- Stacked PRs #22 and #23 will rebase onto this once it merges.
