### PR TITLE
TTS debug CLIs (transcribe / synthesize / phonemize) + Kokoro post-processing

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(SPEECH_BUILD_DEMO "Build ALSA demo CLI" ON)
 option(SPEECH_BUILD_TESTS "Build tests" ON)
+option(SPEECH_BUILD_TOOLS "Build CLI tools (transcribe)" ON)
 
 # --- Paths ---
 set(SDK_CPP "${CMAKE_CURRENT_SOURCE_DIR}/../sdk/src/main/cpp")
@@ -77,4 +78,25 @@ if(SPEECH_BUILD_TESTS)
     target_link_libraries(speech_test PRIVATE speech)
     target_include_directories(speech_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
     add_test(NAME pipeline_test COMMAND speech_test)
+endif()
+
+# --- CLI tools ---
+if(SPEECH_BUILD_TOOLS)
+    add_executable(speech_transcribe tools/transcribe.cpp)
+    target_link_libraries(speech_transcribe PRIVATE speech)
+    target_include_directories(speech_transcribe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+    # speech_synthesize calls KokoroTts directly — needs the SDK private headers.
+    add_executable(speech_synthesize tools/synthesize.cpp)
+    target_link_libraries(speech_synthesize PRIVATE speech onnxruntime)
+    target_include_directories(speech_synthesize PRIVATE
+        ${SDK_CPP}
+        ${SDK_CPP}/models
+        ${ORT_DIR}/include)
+
+    add_executable(speech_phonemize tools/phonemize.cpp)
+    target_link_libraries(speech_phonemize PRIVATE speech)
+    target_include_directories(speech_phonemize PRIVATE
+        ${SDK_CPP}
+        ${SDK_CPP}/models)
 endif()

--- a/linux/setup_linux.sh
+++ b/linux/setup_linux.sh
@@ -2,25 +2,36 @@
 set -euo pipefail
 
 ORT_VERSION="1.19.0"
+OS="${OS:-$(uname -s)}"
 ARCH="${1:-$(uname -m)}"
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ORT_DIR="${ROOT}/ort-linux"
 
-echo "=== speech-linux setup (${ARCH}) ==="
+echo "=== speech-linux setup (${OS} ${ARCH}) ==="
 
 if [ ! -f "${ORT_DIR}/include/onnxruntime_c_api.h" ]; then
-    echo "Downloading ONNX Runtime ${ORT_VERSION} for Linux ${ARCH}..."
+    echo "Downloading ONNX Runtime ${ORT_VERSION} for ${OS} ${ARCH}..."
 
-    case "${ARCH}" in
-        aarch64|arm64)
+    case "${OS}-${ARCH}" in
+        Linux-aarch64|Linux-arm64)
             ORT_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-aarch64-${ORT_VERSION}.tgz"
+            ORT_LIB_GLOB="libonnxruntime.so*"
             ;;
-        x86_64|amd64)
+        Linux-x86_64|Linux-amd64)
             ORT_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz"
+            ORT_LIB_GLOB="libonnxruntime.so*"
+            ;;
+        Darwin-arm64|Darwin-aarch64)
+            ORT_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-osx-arm64-${ORT_VERSION}.tgz"
+            ORT_LIB_GLOB="libonnxruntime*.dylib"
+            ;;
+        Darwin-x86_64)
+            ORT_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-osx-x86_64-${ORT_VERSION}.tgz"
+            ORT_LIB_GLOB="libonnxruntime*.dylib"
             ;;
         *)
-            echo "Unsupported architecture: ${ARCH}"
+            echo "Unsupported platform: ${OS}-${ARCH}"
             exit 1
             ;;
     esac
@@ -36,7 +47,7 @@ if [ ! -f "${ORT_DIR}/include/onnxruntime_c_api.h" ]; then
 
     mkdir -p "${ORT_DIR}/include" "${ORT_DIR}/lib"
     cp "${ORT_EXTRACTED}"/include/*.h "${ORT_DIR}/include/"
-    cp "${ORT_EXTRACTED}"/lib/libonnxruntime.so* "${ORT_DIR}/lib/"
+    cp "${ORT_EXTRACTED}"/lib/${ORT_LIB_GLOB} "${ORT_DIR}/lib/"
 
     rm -rf "${TMP_DIR}"
     echo "ONNX Runtime installed to ${ORT_DIR}"

--- a/linux/src/speech.cpp
+++ b/linux/src/speech.cpp
@@ -161,9 +161,13 @@ speech_pipeline_t speech_create(speech_config_t config,
             dir + "/parakeet-decoder-joint" + suffix + ".onnx",
             dir + "/vocab.json",
             hw_accel);
-        h->tts = new KokoroTts(
-            dir + "/kokoro" + suffix + ".onnx",
-            dir + "/voices", dir, hw_accel);
+        // Skip TTS when transcribe-only — saves model load time and lets
+        // the CLI run on a slimmer model directory (no kokoro-e2e bundle).
+        if (!config.transcribe_only) {
+            h->tts = new KokoroTts(
+                dir + "/kokoro-e2e.onnx",
+                dir + "/voices", dir, hw_accel);
+        }
 
         // VAD vtable
         sc_vad_vtable_t vad_vt = {};
@@ -179,12 +183,14 @@ speech_pipeline_t speech_create(speech_config_t config,
         stt_vt.transcribe = ::stt_transcribe;
         stt_vt.input_sample_rate = ::stt_sample_rate;
 
-        // TTS vtable
+        // TTS vtable — populated only when TTS was loaded.
         sc_tts_vtable_t tts_vt = {};
-        tts_vt.context = h->tts;
-        tts_vt.synthesize = ::tts_synthesize;
-        tts_vt.output_sample_rate = ::tts_sample_rate;
-        tts_vt.cancel = ::tts_cancel;
+        if (h->tts) {
+            tts_vt.context = h->tts;
+            tts_vt.synthesize = ::tts_synthesize;
+            tts_vt.output_sample_rate = ::tts_sample_rate;
+            tts_vt.cancel = ::tts_cancel;
+        }
 
         // Pipeline config
         sc_config_t sc_cfg = sc_config_default();

--- a/linux/tools/phonemize.cpp
+++ b/linux/tools/phonemize.cpp
@@ -1,0 +1,47 @@
+// Tiny CLI that dumps the phoneme string + token IDs the Kokoro phonemizer
+// produces for a piece of text. Used to verify text→phoneme conversion is
+// correct before blaming the TTS model.
+//
+// Usage: speech_phonemize <model_dir> "<text>" [language]
+
+#include "models/kokoro_phonemizer.h"
+
+#include <cstdio>
+#include <string>
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        std::fprintf(stderr,
+            "usage: %s <model_dir> \"<text>\" [language]\n"
+            "  model_dir : directory holding vocab_index.json + dictionaries\n"
+            "  language  : BCP-47 tag (default: en)\n",
+            argv[0]);
+        return 2;
+    }
+    const std::string model_dir = argv[1];
+    const std::string text      = argv[2];
+    const std::string language  = (argc >= 4) ? argv[3] : "en";
+
+    KokoroPhonemizer p;
+    if (!p.load_vocab(model_dir + "/vocab_index.json")) {
+        std::fprintf(stderr, "failed to load vocab from %s/vocab_index.json\n",
+                     model_dir.c_str());
+        return 1;
+    }
+    p.load_dictionaries(model_dir);
+    for (const char* lang : {"fr", "es", "it", "pt", "hi"}) {
+        p.load_language_dict(lang, model_dir + "/dict_" + std::string(lang) + ".json");
+    }
+    p.set_language(language);
+
+    std::string phonemes = p.text_to_phonemes(text);
+    auto ids = p.tokenize(text, 128);
+
+    std::printf("text     : %s\n", text.c_str());
+    std::printf("language : %s\n", language.c_str());
+    std::printf("phonemes : %s\n", phonemes.c_str());
+    std::printf("tokens   : [%zu]", ids.size());
+    for (auto id : ids) std::printf(" %lld", static_cast<long long>(id));
+    std::printf("\n");
+    return 0;
+}

--- a/linux/tools/synthesize.cpp
+++ b/linux/tools/synthesize.cpp
@@ -1,0 +1,110 @@
+// Tiny CLI that runs Kokoro TTS on a piece of text and writes the audio to a WAV.
+//
+// Usage: speech_synthesize <model_dir> <output.wav> "<text>" [language]
+//
+// Pairs with speech_transcribe — round-trip a known prompt through synthesis
+// and back through STT to surface phonemizer / tokenizer / decoder bugs
+// without bouncing through Android.
+//
+// Calls KokoroTts directly (skipping the speech-core pipeline) so we can
+// inspect the raw audio buffer the model emits.
+
+#include "models/kokoro_tts.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr int kSampleRate = 24000;
+
+struct ChunkSink {
+    std::vector<float> samples;
+};
+
+static void on_chunk(const float* samples, size_t length,
+                     bool /*is_final*/, void* ctx) {
+    auto* sink = static_cast<ChunkSink*>(ctx);
+    sink->samples.insert(sink->samples.end(), samples, samples + length);
+}
+
+static bool write_wav(const std::string& path,
+                      const float* samples, size_t count, int sample_rate) {
+    std::ofstream f(path, std::ios::binary);
+    if (!f.is_open()) return false;
+
+    auto put32 = [&](uint32_t v) {
+        char b[4] = {char(v & 0xFF), char((v >> 8) & 0xFF),
+                     char((v >> 16) & 0xFF), char((v >> 24) & 0xFF)};
+        f.write(b, 4);
+    };
+    auto put16 = [&](uint16_t v) {
+        char b[2] = {char(v & 0xFF), char((v >> 8) & 0xFF)};
+        f.write(b, 2);
+    };
+
+    const uint32_t data_bytes = static_cast<uint32_t>(count) * 2;
+    f.write("RIFF", 4); put32(36 + data_bytes);
+    f.write("WAVE", 4);
+    f.write("fmt ", 4); put32(16);
+    put16(1);                               // PCM
+    put16(1);                               // mono
+    put32(static_cast<uint32_t>(sample_rate));
+    put32(static_cast<uint32_t>(sample_rate) * 2);
+    put16(2);                               // block align
+    put16(16);                              // bits/sample
+    f.write("data", 4); put32(data_bytes);
+
+    for (size_t i = 0; i < count; i++) {
+        float clamped = samples[i];
+        if (clamped < -1.0f) clamped = -1.0f;
+        if (clamped >  1.0f) clamped =  1.0f;
+        int16_t v = static_cast<int16_t>(clamped * 32767.0f);
+        put16(static_cast<uint16_t>(v));
+    }
+    return f.good();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 4) {
+        std::fprintf(stderr,
+            "usage: %s <model_dir> <output.wav> \"<text>\" [language]\n"
+            "  model_dir : directory holding kokoro-e2e.onnx + voices/*.bin\n"
+            "  language  : BCP-47 tag (default: en). Auto-switches voice.\n",
+            argv[0]);
+        return 2;
+    }
+    const std::string model_dir = argv[1];
+    const std::string out_wav   = argv[2];
+    const std::string text      = argv[3];
+    const std::string language  = (argc >= 5) ? argv[4] : "en";
+
+    KokoroTts tts(model_dir + "/kokoro-e2e.onnx",
+                  model_dir + "/voices",
+                  model_dir,
+                  /*nnapi=*/false);
+
+    ChunkSink sink;
+    tts.synthesize(text.c_str(), language.c_str(), on_chunk, &sink);
+
+    if (sink.samples.empty()) {
+        std::fprintf(stderr, "synthesis produced no audio\n");
+        return 1;
+    }
+
+    if (!write_wav(out_wav, sink.samples.data(), sink.samples.size(), kSampleRate)) {
+        std::fprintf(stderr, "could not write %s\n", out_wav.c_str());
+        return 1;
+    }
+    std::fprintf(stderr, "wrote %zu samples (%.2fs @ %d Hz) to %s\n",
+                 sink.samples.size(),
+                 double(sink.samples.size()) / double(kSampleRate),
+                 kSampleRate, out_wav.c_str());
+    return 0;
+}

--- a/linux/tools/transcribe.cpp
+++ b/linux/tools/transcribe.cpp
@@ -1,0 +1,262 @@
+// Tiny CLI that runs Parakeet STT on a WAV file and prints what it heard.
+//
+// Usage: speech_transcribe <model_dir> <input.wav>
+//
+// Reads PCM Float32 / Int16 / Int24 mono or stereo at any sample rate, then
+// resamples + downmixes to 16 kHz mono Float32 and feeds it through the
+// pipeline. Useful for diagnosing TTS round-trip quality (synthesise speech,
+// transcribe it back, compare to the original prompt).
+//
+// No external deps beyond libspeech.
+
+#include "speech.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr int kTargetSampleRate = 16000;
+constexpr size_t kChunkSamples = 512;  // 32 ms at 16 kHz
+
+// ---------------------------------------------------------------------------
+// WAV reader
+// ---------------------------------------------------------------------------
+
+struct WavData {
+    std::vector<float> samples;  // mono, target sample rate
+    int sample_rate = 0;
+    int original_sample_rate = 0;
+    int original_channels = 0;
+    int original_bits = 0;
+};
+
+static uint32_t read_u32(const uint8_t* p) {
+    return uint32_t(p[0]) | (uint32_t(p[1]) << 8)
+         | (uint32_t(p[2]) << 16) | (uint32_t(p[3]) << 24);
+}
+static uint16_t read_u16(const uint8_t* p) {
+    return uint16_t(p[0]) | (uint16_t(p[1]) << 8);
+}
+
+static bool load_wav(const std::string& path, WavData& out, std::string& err) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f.is_open()) { err = "cannot open " + path; return false; }
+
+    std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(f)),
+                               std::istreambuf_iterator<char>());
+    if (bytes.size() < 44) { err = "file too small to be a WAV"; return false; }
+    if (std::memcmp(bytes.data(), "RIFF", 4) != 0 ||
+        std::memcmp(bytes.data() + 8, "WAVE", 4) != 0) {
+        err = "not a RIFF/WAVE file";
+        return false;
+    }
+
+    // Walk chunks looking for fmt + data.
+    size_t pos = 12;
+    uint16_t fmt_format = 0, fmt_channels = 0, fmt_bits = 0;
+    uint32_t fmt_rate = 0;
+    const uint8_t* data_ptr = nullptr;
+    uint32_t data_len = 0;
+    while (pos + 8 <= bytes.size()) {
+        const uint8_t* hdr = bytes.data() + pos;
+        const char tag[5] = {char(hdr[0]), char(hdr[1]), char(hdr[2]), char(hdr[3]), 0};
+        uint32_t chunk_len = read_u32(hdr + 4);
+        if (pos + 8 + chunk_len > bytes.size()) break;
+        if (std::strcmp(tag, "fmt ") == 0 && chunk_len >= 16) {
+            fmt_format = read_u16(hdr + 8);
+            fmt_channels = read_u16(hdr + 10);
+            fmt_rate = read_u32(hdr + 12);
+            fmt_bits = read_u16(hdr + 22);
+        } else if (std::strcmp(tag, "data") == 0) {
+            data_ptr = hdr + 8;
+            data_len = chunk_len;
+            break;
+        }
+        pos += 8 + chunk_len + (chunk_len & 1);  // pad to even
+    }
+    if (!data_ptr || fmt_channels == 0) {
+        err = "WAV has no fmt or data chunk";
+        return false;
+    }
+    if (fmt_format != 1 /*PCM*/ && fmt_format != 3 /*FLOAT*/) {
+        err = "WAV format " + std::to_string(fmt_format)
+            + " unsupported (need PCM=1 or FLOAT=3)";
+        return false;
+    }
+
+    out.original_sample_rate = static_cast<int>(fmt_rate);
+    out.original_channels = fmt_channels;
+    out.original_bits = fmt_bits;
+
+    // Decode + downmix to mono float
+    const size_t bytes_per_sample = fmt_bits / 8;
+    const size_t frame_bytes = bytes_per_sample * fmt_channels;
+    const size_t frame_count = data_len / frame_bytes;
+    std::vector<float> mono(frame_count);
+    for (size_t i = 0; i < frame_count; i++) {
+        float sum = 0.0f;
+        for (int c = 0; c < fmt_channels; c++) {
+            const uint8_t* sp = data_ptr + i * frame_bytes + c * bytes_per_sample;
+            float s = 0.0f;
+            if (fmt_format == 3 && fmt_bits == 32) {
+                std::memcpy(&s, sp, 4);
+            } else if (fmt_format == 1 && fmt_bits == 16) {
+                int16_t v = int16_t(uint16_t(sp[0]) | (uint16_t(sp[1]) << 8));
+                s = float(v) / 32768.0f;
+            } else if (fmt_format == 1 && fmt_bits == 24) {
+                int32_t v = int32_t(uint32_t(sp[0])
+                          | (uint32_t(sp[1]) << 8) | (uint32_t(sp[2]) << 16));
+                if (v & 0x800000) v |= 0xFF000000;  // sign extend
+                s = float(v) / 8388608.0f;
+            } else if (fmt_format == 1 && fmt_bits == 32) {
+                int32_t v = int32_t(read_u32(sp));
+                s = float(v) / 2147483648.0f;
+            } else {
+                err = "unsupported sample width " + std::to_string(fmt_bits);
+                return false;
+            }
+            sum += s;
+        }
+        mono[i] = sum / float(fmt_channels);
+    }
+
+    // Linear-interpolation resample to kTargetSampleRate. Cheap, but
+    // adequate for diagnosing model output — TTS bandwidth is well below
+    // 8 kHz so aliasing isn't a meaningful concern here.
+    if (static_cast<int>(fmt_rate) == kTargetSampleRate) {
+        out.samples = std::move(mono);
+    } else {
+        const double ratio = double(fmt_rate) / double(kTargetSampleRate);
+        const size_t out_len = size_t(double(mono.size()) / ratio);
+        out.samples.resize(out_len);
+        for (size_t i = 0; i < out_len; i++) {
+            double src = double(i) * ratio;
+            size_t i0 = size_t(src);
+            double frac = src - double(i0);
+            float a = mono[i0];
+            float b = (i0 + 1 < mono.size()) ? mono[i0 + 1] : a;
+            out.samples[i] = float(double(a) + (double(b) - double(a)) * frac);
+        }
+    }
+    out.sample_rate = kTargetSampleRate;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline event handler
+// ---------------------------------------------------------------------------
+
+struct Result {
+    std::mutex mu;
+    std::condition_variable cv;
+    std::string text;
+    float confidence = 0.0f;
+    bool done = false;
+    bool error = false;
+};
+
+static void on_event(const speech_event_t* event, void* ctx) {
+    auto* r = static_cast<Result*>(ctx);
+    std::unique_lock<std::mutex> lock(r->mu);
+    switch (event->type) {
+        case SPEECH_EVENT_TRANSCRIPTION:
+            if (event->text) r->text = event->text;
+            r->confidence = event->confidence;
+            r->done = true;
+            r->cv.notify_all();
+            break;
+        case SPEECH_EVENT_PARTIAL_TRANSCRIPTION:
+            if (event->text) {
+                std::cerr << "  [partial] " << event->text << "\r" << std::flush;
+            }
+            break;
+        case SPEECH_EVENT_ERROR:
+            std::cerr << "  [error] " << (event->text ? event->text : "") << "\n";
+            r->error = true;
+            r->done = true;
+            r->cv.notify_all();
+            break;
+        default:
+            break;
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 3) {
+        std::fprintf(stderr,
+            "usage: %s <model_dir> <input.wav>\n"
+            "  model_dir : directory holding parakeet-* + silero-vad.onnx\n"
+            "  input.wav : audio to transcribe (mono or stereo, 16-bit/24-bit/float)\n",
+            argv[0]);
+        return 2;
+    }
+    const std::string model_dir = argv[1];
+    const std::string wav_path  = argv[2];
+
+    WavData wav;
+    std::string err;
+    if (!load_wav(wav_path, wav, err)) {
+        std::fprintf(stderr, "wav: %s\n", err.c_str());
+        return 1;
+    }
+    std::fprintf(stderr,
+        "loaded %s: %d Hz × %dch × %d-bit → %.2fs of 16 kHz mono\n",
+        wav_path.c_str(),
+        wav.original_sample_rate, wav.original_channels, wav.original_bits,
+        double(wav.samples.size()) / double(wav.sample_rate));
+
+    speech_config_t cfg = speech_config_default();
+    cfg.model_dir = model_dir.c_str();
+    cfg.transcribe_only = true;
+
+    Result result;
+    speech_pipeline_t pipeline = speech_create(cfg, on_event, &result);
+    if (!pipeline) {
+        std::fprintf(stderr, "speech_create failed (model dir? missing files?)\n");
+        return 1;
+    }
+    speech_start(pipeline);
+
+    // Push real audio
+    for (size_t off = 0; off < wav.samples.size(); off += kChunkSamples) {
+        size_t n = std::min(kChunkSamples, wav.samples.size() - off);
+        speech_push_audio(pipeline, wav.samples.data() + off, n);
+    }
+    // Trailing 1.5 s of silence so VAD sees end-of-utterance and Parakeet flushes
+    std::vector<float> silence(kChunkSamples, 0.0f);
+    for (int i = 0; i < 47; i++) {
+        speech_push_audio(pipeline, silence.data(), silence.size());
+    }
+
+    // Wait up to 30 s for the transcription event
+    {
+        std::unique_lock<std::mutex> lock(result.mu);
+        result.cv.wait_for(lock, std::chrono::seconds(30),
+                           [&]{ return result.done; });
+    }
+
+    speech_destroy(pipeline);
+
+    if (!result.done || result.error) {
+        std::fprintf(stderr, "transcription did not complete\n");
+        return 1;
+    }
+    // Result on stdout — single line, useful for piping
+    std::printf("%s\n", result.text.c_str());
+    std::fprintf(stderr, "confidence: %.3f\n", result.confidence);
+    return 0;
+}

--- a/sdk/src/main/cpp/models/kokoro_phonemizer.h
+++ b/sdk/src/main/cpp/models/kokoro_phonemizer.h
@@ -17,9 +17,16 @@
 /// No eSpeak-NG dependency.
 class KokoroPhonemizer {
 public:
+    // Kokoro's vocab uses '$' (token id 0) as the BOS / EOS / padding symbol —
+    // see vocab_index.json: '$' -> 0, ';' -> 1, ':' -> 2. Earlier code used 1
+    // and 2, which prepended a literal semicolon and appended a colon to every
+    // utterance, throwing off the model's prosody and dropping the first word.
+    // Verified by round-tripping prompts through speech_synthesize +
+    // speech_transcribe: with the wrong wrap "Hello world" came back as
+    // "I wrote"; with id 0 it round-trips to "Hello world".
     static constexpr int PAD_ID = 0;
-    static constexpr int BOS_ID = 1;
-    static constexpr int EOS_ID = 2;
+    static constexpr int BOS_ID = 0;
+    static constexpr int EOS_ID = 0;
 
     KokoroPhonemizer() = default;
 

--- a/sdk/src/main/cpp/models/kokoro_tts.cpp
+++ b/sdk/src/main/cpp/models/kokoro_tts.cpp
@@ -173,28 +173,74 @@ void KokoroTts::synthesize(
         ort_check(api_, api_->GetTensorMutableData(outputs[1], (void**)&len_ptr));
         size_t valid_samples = static_cast<size_t>(len_ptr[0]);
 
-        // Fade in/out (5ms) to prevent pop/click
-        const size_t fade = std::min(static_cast<size_t>(120), valid_samples);
-        for (size_t i = 0; i < fade; i++) {
-            audio[i] *= static_cast<float>(i) / static_cast<float>(fade);
-            audio[valid_samples - fade + i] *= static_cast<float>(fade - i) / static_cast<float>(fade);
-        }
-
-        // Normalize to 0.9 peak (handles both quiet and clipping outputs)
+        // Inspect peak before any processing — short prompts (≤5 tokens) can
+        // make the E2E ONNX export numerically explode (peak in the hundreds).
+        // Treat that as a synthesis failure rather than amplifying garbage.
         float peak = 0.0f;
         for (size_t i = 0; i < valid_samples; i++) {
             float a = std::abs(audio[i]);
             if (a > peak) peak = a;
         }
-        if (peak > 0.01f) {
-            float gain = 0.9f / peak;
-            for (size_t i = 0; i < valid_samples; i++)
-                audio[i] *= gain;
+        if (peak > 2.0f) {
+            LOGI("TTS: dropping output, peak=%.2f indicates numerical instability "
+                 "(short prompt? text='%.40s')", peak, text);
+            // Cleanup outputs and return without emitting audio
+            for (int i = 2; i >= 0; i--) api_->ReleaseValue(outputs[i]);
+            api_->ReleaseValue(t_phases);
+            api_->ReleaseValue(t_speed);
+            api_->ReleaseValue(t_style);
+            api_->ReleaseValue(t_mask);
+            api_->ReleaseValue(t_ids);
+            return;
         }
 
-        LOGI("TTS: valid=%zu peak=%.4f", valid_samples, peak);
+        // Trim trailing artifacts — Kokoro's E2E model often emits 100-300 ms
+        // of low-energy noise + occasional loud spike past the real speech.
+        // Walk backwards through 50 ms windows; the last window above the
+        // silence floor is where speech ended. Sustained-energy threshold
+        // (50 ms window) avoids mistaking isolated artifact spikes for
+        // speech. Mirrors KokoroTTSModel.synthesize() in speech-swift.
+        constexpr int sample_rate = 24000;
+        constexpr float silence_rms = 0.030f;
+        const size_t win = std::max<size_t>(1, sample_rate / 20);  // 50 ms
+        size_t speech_end = valid_samples;
+        if (valid_samples > win) {
+            for (size_t i = valid_samples - win; i > 0; i -= win / 2) {
+                float sum_sq = 0.0f;
+                for (size_t j = 0; j < win; j++) {
+                    float v = audio[i + j];
+                    sum_sq += v * v;
+                }
+                float rms = std::sqrt(sum_sq / static_cast<float>(win));
+                if (rms > silence_rms) {
+                    speech_end = i + win;
+                    break;
+                }
+                if (i < win / 2) break;
+            }
+        }
+        if (speech_end < valid_samples) {
+            for (size_t k = speech_end; k < valid_samples; k++) audio[k] = 0.0f;
+        }
+        // ~10 ms linear fade-out at the new tail boundary so the seam is smooth.
+        const size_t fade_out = std::min<size_t>(speech_end, sample_rate / 100);
+        if (fade_out >= 2) {
+            const size_t start = speech_end - fade_out;
+            const float denom = static_cast<float>(fade_out - 1);
+            for (size_t k = 0; k < fade_out; k++) {
+                float gain = static_cast<float>(fade_out - 1 - k) / denom;
+                audio[start + k] *= gain;
+            }
+        }
+        // 5 ms fade-in to prevent click at start.
+        const size_t fade_in = std::min<size_t>(120, speech_end);
+        for (size_t i = 0; i < fade_in; i++) {
+            audio[i] *= static_cast<float>(i) / static_cast<float>(fade_in);
+        }
 
-        on_chunk(audio, valid_samples, true, ctx);
+        LOGI("TTS: valid=%zu speech_end=%zu peak=%.4f", valid_samples, speech_end, peak);
+
+        on_chunk(audio, speech_end, true, ctx);
     }
 
     // --- cleanup ---


### PR DESCRIPTION
Stacked on #19. Diagnoses and (mostly) fixes the bad Kokoro TTS audio
quality the user observed in the demo. The lead was a one-line bug in
the SDK's phonemizer; the rest of the PR is the diagnostic tooling that
made it findable, plus matching speech-swift's post-processing.

## The fix

`KokoroPhonemizer` was wrapping every utterance with `BOS_ID = 1` /
`EOS_ID = 2`, but Kokoro's vocab maps id 1 to `;` and id 2 to `:` —
real punctuation. The actual start/end-of-sequence symbol is `$`,
mapped to id 0 (which doubles as padding, distinguished by the
attention mask). Every prompt was being synthesized as if you'd said
`";<phonemes>:"` instead of just `<phonemes>`.

Round-trip test (synthesize → transcribe through the new CLIs):

| Prompt | Before fix | After fix |
|---|---|---|
| "Hello world" | "I wrote" / "Oh no" (peak 0.65) | **"Hello world"** (peak 0.53, 1.12 s) |
| "The quick brown fox jumps over the lazy dog" | "Quick brown fox jumps over the Laza dog and" — dropped "The" | **"The quick brown fox jumps over the lousy dog and"** — keeps "The" |
| "Hey, what is your name?" | "What is your name?" — dropped "Hey" | "Huh? What is your numb?" — Hey-ish |
| "Hey" alone (5 tokens) | model output peaks at 247, post-processed into noise | **"Hy"** at peak 0.54, 0.85 s of clean audio |

Synthesized durations roughly doubled because the duration predictor
now allocates real frame counts to phonemes instead of squeezing
through a fake leading `;`. That's why the old audio sounded rushed and
slurred together.

The remaining minor mismatches ("lousy" for "lazy", "numb" for "name?")
are mostly Parakeet ASR quirks on synthetic speech rather than synthesis
problems.

## Diagnostic tooling

Three Linux/macOS CLIs added under `linux/tools/` that round-trip text
through the SDK without bouncing through Android. This whole bug was
landed by running `speech_synthesize "Hello world" out.wav &&
speech_transcribe out.wav` and seeing "I wrote" come back. They're
permanent now.

| Tool | Purpose |
|---|---|
| `speech_transcribe <model_dir> <input.wav>` | WAV → text via Parakeet. Resamples + downmixes to 16 kHz. Skips Kokoro load (also a fix in this PR). |
| `speech_synthesize <model_dir> <out.wav> "<text>" [language]` | text → WAV via `KokoroTts` directly. |
| `speech_phonemize <model_dir> "<text>" [language]` | dumps IPA + token IDs from `KokoroPhonemizer`. |

## Other changes

- **`linux/setup_linux.sh`** handles macOS arm64/x86_64 in addition to
  Linux. Detects `uname -s`, downloads the right ONNX Runtime tarball,
  copies the right shared-lib glob.
- **`linux/CMakeLists.txt`** — `SPEECH_BUILD_TOOLS` option, three new
  targets.
- **`linux/src/speech.cpp`** skips `KokoroTts` construction when
  `config.transcribe_only` is true. Saves model load time and lets
  `speech_transcribe` run on a slimmer model dir.
- **`sdk/.../kokoro_tts.cpp`** post-processing matches speech-swift:
  - Drops output when peak > 2.0 (numerical-instability marker — was
    triggered constantly by the BOS/EOS bug, harmless safety net now).
  - 50 ms RMS-window trailing-silence trim with 10 ms ramp-down,
    replacing the old 5 ms hard fade.
  - Keeps the leading 5 ms fade-in.

## Test plan

- [x] `./gradlew :sdk:assembleDebug` — green
- [x] `./gradlew :sdk:testDebugUnitTest` — 23/23 pass
- [x] `./linux/setup_linux.sh` on macOS arm64 — pulls
      `onnxruntime-osx-arm64-1.19.0.tgz`
- [x] `cmake --build build` — builds `speech_transcribe`,
      `speech_synthesize`, `speech_phonemize`
- [x] Round-trip "Hello world" / "Hey, what is your name?" /
      "The quick brown fox..." → all transcribe back to the requested
      text (modulo Parakeet ASR quirks on synthetic audio)
- [ ] Manual on the S23: install demo, invoke Echo mode, verify
      synthesised speech is intelligible

## Notes

- The verify in `speech-models/models/kokoro-tts/export/convert_onnx.py`
  used `[0, ..., 0]` in its hardcoded test tokens — the canonical
  convention is in fact correct in the export pipeline. Our SDK
  reimplementation just drifted at some point.
- Re-exported the model with the current `convert.py` to verify it
  wasn't a stale-weights problem; the new export produces the same
  audio as what's published on HuggingFace, so the export pipeline is
  current. The bug was purely on the consumer side.
