### PR TITLE
Release prep: bump to 0.0.9, fix demo TTS click/cut + mel.cpp constexpr

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Download the [signed APK](https://github.com/soniqo/speech-android/releases/late
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.8")
+    implementation("audio.soniqo:speech:0.0.9")
 }
 ```
 

--- a/README_de.md
+++ b/README_de.md
@@ -36,7 +36,7 @@ Lade das [signierte APK](https://github.com/soniqo/speech-android/releases/lates
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.8")
+    implementation("audio.soniqo:speech:0.0.9")
 }
 ```
 

--- a/README_es.md
+++ b/README_es.md
@@ -36,7 +36,7 @@ Descarga el [APK firmado](https://github.com/soniqo/speech-android/releases/late
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.8")
+    implementation("audio.soniqo:speech:0.0.9")
 }
 ```
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -36,7 +36,7 @@ Téléchargez l'[APK signé](https://github.com/soniqo/speech-android/releases/l
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.8")
+    implementation("audio.soniqo:speech:0.0.9")
 }
 ```
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -36,7 +36,7 @@ Android और एम्बेडेड Linux के लिए ऑन-डिव�
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.8")
+    implementation("audio.soniqo:speech:0.0.9")
 }
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -36,7 +36,7 @@
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.8")
+    implementation("audio.soniqo:speech:0.0.9")
 }
 ```
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -36,7 +36,7 @@
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.8")
+    implementation("audio.soniqo:speech:0.0.9")
 }
 ```
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -36,7 +36,7 @@ Baixe o [APK assinado](https://github.com/soniqo/speech-android/releases/latest/
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.8")
+    implementation("audio.soniqo:speech:0.0.9")
 }
 ```
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -36,7 +36,7 @@
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.8")
+    implementation("audio.soniqo:speech:0.0.9")
 }
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -36,7 +36,7 @@
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.8")
+    implementation("audio.soniqo:speech:0.0.9")
 }
 ```
 

--- a/app/src/main/kotlin/com/soniqo/speech/demo/MainActivity.kt
+++ b/app/src/main/kotlin/com/soniqo/speech/demo/MainActivity.kt
@@ -542,16 +542,24 @@ class MainActivity : ComponentActivity() {
         android.util.Log.i("Speech", "playTtsAudio: ${ttsBuffer.size} chunks")
         if (ttsBuffer.isEmpty()) return
 
-        // Merge all chunks into one buffer
-        val totalSize = ttsBuffer.sumOf { it.size }
-        android.util.Log.i("Speech", "playTtsAudio: $totalSize bytes = ${totalSize/2/TTS_SAMPLE_RATE.toFloat()}s")
-        val merged = ByteArray(totalSize)
+        // Merge all chunks, then prepend silence + apply fade-in/out so the
+        // audio HAL has time to spin up before the first phoneme and the
+        // playback ends on a zero sample (no abrupt-cut click).
+        val rawSize = ttsBuffer.sumOf { it.size }
+        android.util.Log.i("Speech", "playTtsAudio: $rawSize bytes = ${rawSize/2/TTS_SAMPLE_RATE.toFloat()}s")
+        val raw = ByteArray(rawSize)
         var offset = 0
         for (chunk in ttsBuffer) {
-            chunk.copyInto(merged, offset)
+            chunk.copyInto(raw, offset)
             offset += chunk.size
         }
         ttsBuffer.clear()
+
+        val leadSilenceSamples = TTS_SAMPLE_RATE * 80 / 1000   // 80ms HAL warmup
+        val fadeInSamples      = TTS_SAMPLE_RATE * 5  / 1000   // 5ms fade-in
+        val fadeOutSamples     = TTS_SAMPLE_RATE * 10 / 1000   // 10ms fade-out
+        val processed = applyFades(raw, leadSilenceSamples, fadeInSamples, fadeOutSamples)
+        val totalSize = processed.size
 
         // Write WAV file and play via MediaPlayer (louder on emulator)
         val wavFile = java.io.File(filesDir, "tts_playback.wav")
@@ -574,7 +582,7 @@ class MainActivity : ComponentActivity() {
             header.put("data".toByteArray())
             header.putInt(dataSize)
             fos.write(header.array())
-            fos.write(merged)
+            fos.write(processed)
         }
 
         val mp = android.media.MediaPlayer()
@@ -603,6 +611,31 @@ class MainActivity : ComponentActivity() {
             try { mp.stop() } catch (_: Exception) {}
             mp.release()
         }
+    }
+
+    private fun applyFades(
+        raw: ByteArray,
+        leadSilenceSamples: Int,
+        fadeInSamples: Int,
+        fadeOutSamples: Int,
+    ): ByteArray {
+        val rawSamples = raw.size / 2
+        val outSamples = leadSilenceSamples + rawSamples
+        val out = ByteArray(outSamples * 2)
+        val bb = java.nio.ByteBuffer.wrap(out).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        bb.position(leadSilenceSamples * 2)
+        val src = java.nio.ByteBuffer.wrap(raw).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        val fadeOutStart = (rawSamples - fadeOutSamples).coerceAtLeast(0)
+        for (i in 0 until rawSamples) {
+            val sample = src.short.toInt()
+            val gain = when {
+                i < fadeInSamples -> i.toFloat() / fadeInSamples
+                i >= fadeOutStart -> (rawSamples - i).toFloat() / fadeOutSamples
+                else -> 1f
+            }
+            bb.putShort((sample * gain).toInt().toShort())
+        }
+        return out
     }
 
     // ---------------------------------------------------------------------------

--- a/sdk/src/main/cpp/audio/mel.cpp
+++ b/sdk/src/main/cpp/audio/mel.cpp
@@ -16,7 +16,7 @@ static float htk_mel_to_hz(float mel) {
 //   Log above 1000 Hz:     mel = 15 + 27 * log(f/1000) / log(6.4)
 static constexpr float kSlaneyBreakHz = 1000.0f;
 static constexpr float kSlaneyBreakMel = 15.0f;      // 3 * 1000 / 200
-static constexpr float kSlaneyLogStep = 27.0f / std::log(6.4f);  // ≈ 14.536
+static const float kSlaneyLogStep = 27.0f / std::log(6.4f);  // ≈ 14.536
 
 static float slaney_hz_to_mel(float hz) {
     if (hz < kSlaneyBreakHz)


### PR DESCRIPTION
Release prep for v0.0.9.

## Changes

### Version bump (READMEs ×10)
`audio.soniqo:speech:0.0.8` → `0.0.9` across English + 9 translations to match what the v0.0.9 tag will publish.

### Demo TTS playback smoothing
Two on-device artifacts identified during the previous round of demo testing:
- **First phoneme cut off** while the audio HAL was spinning up (perceptually "swallowing" the start of synthesis).
- **Click at end-of-stream** from MediaPlayer tearing down on a non-zero sample.

Fix in `MainActivity.playTtsAudio()`:
- Prepend 80 ms of silence to give the HAL time to come up before the actual content starts.
- 5 ms linear fade-in / 10 ms linear fade-out on the merged PCM buffer so playback ends on a zero sample.
- ~30 lines, isolated to demo app — no SDK behavior change.

### `mel.cpp` constexpr build fix
`std::log` is not constexpr in C++17. Recent NDK clang treats this as an error rather than a warning; switch `kSlaneyLogStep` from `constexpr` to `const float`. (This was the same fix applied earlier in the session that got dropped in the merge order.)

## Test plan

- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew :sdk:testDebugUnitTest` — 23/23 pass
- [x] `./gradlew :sdk:connectedAndroidTest` — 34/34 pass on `speech_test` arm64-v8a emulator (27m run, full model download + e2e)

After merge: tag `v0.0.9` from main → CI publishes to Maven Central + GitHub Packages, attaches signed APK to the GH Release.
