### PR TITLE
fix: issue #30 UX (download progress, back nav, icon) + Parakeet INT8 transcription crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
 
     <application
         android:allowBackup="false"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.Speech">

--- a/app/src/main/kotlin/audio/soniqo/speech/demo/DictationActivity.kt
+++ b/app/src/main/kotlin/audio/soniqo/speech/demo/DictationActivity.kt
@@ -44,6 +44,8 @@ class DictationActivity : ComponentActivity() {
     private var pipeline: SpeechPipeline? = null
     private var audioRecord: AudioRecord? = null
     private var recording = false
+    private var pipelineStarted = false
+    private var observingDownload = false
 
     private lateinit var statusView: TextView
     private lateinit var micButton: TextView
@@ -179,12 +181,17 @@ class DictationActivity : ComponentActivity() {
         statusView.text = "initializing..."
 
         // Models download in a foreground worker so the transfer survives
-        // backgrounding the app. Activity just observes progress.
-        val workId = ModelDownloadWorker.enqueue(applicationContext, ModelPrecision.INT8)
+        // backgrounding the app. Enqueue (KEEP reuses any in-flight download)
+        // and observe by the UNIQUE name, not a fresh request id — the latter
+        // stays null forever when an existing run is reused (issue #30).
+        ModelDownloadWorker.enqueue(applicationContext, ModelPrecision.INT8)
+        if (observingDownload) return
+        observingDownload = true
         WorkManager.getInstance(applicationContext)
-            .getWorkInfoByIdLiveData(workId)
-            .observe(this) { info ->
-                if (info == null) return@observe
+            .getWorkInfosForUniqueWorkLiveData(ModelDownloadWorker.UNIQUE_NAME)
+            .observe(this) { infos ->
+                val info = infos.firstOrNull { !it.state.isFinished }
+                    ?: infos.lastOrNull() ?: return@observe
                 when (info.state) {
                     WorkInfo.State.ENQUEUED,
                     WorkInfo.State.BLOCKED,
@@ -193,7 +200,12 @@ class DictationActivity : ComponentActivity() {
                         if (total > 0) {
                             val file = info.progress.getString(ModelDownloadWorker.KEY_FILE) ?: ""
                             val done = info.progress.getInt(ModelDownloadWorker.KEY_COMPLETED, 0)
-                            statusView.text = "$file $done/$total"
+                            val bytes = info.progress.getLong(ModelDownloadWorker.KEY_BYTES_DOWNLOADED, 0L)
+                            val fileTotal = info.progress.getLong(ModelDownloadWorker.KEY_FILE_TOTAL_BYTES, 0L)
+                            val mb = if (fileTotal > 0)
+                                "${bytes / 1_000_000}/${fileTotal / 1_000_000} MB"
+                            else "${bytes / 1_000_000} MB"
+                            statusView.text = "$file  $mb  ·  $done/$total"
                         }
                     }
                     WorkInfo.State.SUCCEEDED -> {
@@ -202,7 +214,10 @@ class DictationActivity : ComponentActivity() {
                             statusView.text = "worker succeeded but no model dir"
                             return@observe
                         }
-                        initPipeline(modelDir)
+                        if (!pipelineStarted) {
+                            pipelineStarted = true
+                            initPipeline(modelDir)
+                        }
                     }
                     WorkInfo.State.FAILED -> {
                         val err = info.outputData.getString(ModelDownloadWorker.KEY_ERROR)

--- a/app/src/main/kotlin/audio/soniqo/speech/demo/LauncherActivity.kt
+++ b/app/src/main/kotlin/audio/soniqo/speech/demo/LauncherActivity.kt
@@ -34,19 +34,19 @@ class LauncherActivity : ComponentActivity() {
         }
         root.addView(title)
 
+        // Note: do NOT finish() the picker here \u2014 keeping it on the back stack
+        // means Back from a mode screen returns to this menu instead of exiting
+        // the app (issue #30).
         root.addView(modeButton("Echo", "STT \u2192 TTS echo pipeline") {
             startActivity(Intent(this, MainActivity::class.java))
-            finish()
         })
 
         root.addView(modeButton("Dictation", "Real-time speech-to-text") {
             startActivity(Intent(this, DictationActivity::class.java))
-            finish()
         })
 
         root.addView(modeButton("Recognizer test", "Exercises android.speech.SpeechRecognizer") {
             startActivity(Intent(this, SpeechRecognizerTestActivity::class.java))
-            finish()
         })
 
         setContentView(root)

--- a/app/src/main/kotlin/audio/soniqo/speech/demo/MainActivity.kt
+++ b/app/src/main/kotlin/audio/soniqo/speech/demo/MainActivity.kt
@@ -46,6 +46,8 @@ class MainActivity : ComponentActivity() {
     private val ttsBuffer = mutableListOf<ByteArray>()
     private var lastTtsMs = 0f
     private var speechStartTime = 0L
+    private var pipelineStarted = false
+    private var observingDownload = false
 
     private lateinit var statusView: TextView
     private lateinit var micButton: TextView
@@ -219,25 +221,31 @@ class MainActivity : ComponentActivity() {
 
     private fun loadPipeline() {
         setStatus("initializing...")
+        downloadProgress.visibility = View.VISIBLE
+        downloadProgress.progress = 0
 
         // Models download in a foreground worker so the transfer survives
-        // backgrounding the app. Activity just observes progress.
-        val workId = ModelDownloadWorker.enqueue(applicationContext, ModelPrecision.INT8)
+        // backgrounding the app. Enqueue (KEEP reuses any in-flight download)
+        // and observe by the UNIQUE name — observing by a fresh request id
+        // would stay null forever whenever an existing run is reused (e.g. on
+        // rotation / re-entry), which looked like a hang. See issue #30.
+        ModelDownloadWorker.enqueue(applicationContext, ModelPrecision.INT8)
+        if (observingDownload) return
+        observingDownload = true
         WorkManager.getInstance(applicationContext)
-            .getWorkInfoByIdLiveData(workId)
-            .observe(this) { info ->
-                if (info == null) return@observe
+            .getWorkInfosForUniqueWorkLiveData(ModelDownloadWorker.UNIQUE_NAME)
+            .observe(this) { infos ->
+                val info = infos.firstOrNull { !it.state.isFinished }
+                    ?: infos.lastOrNull() ?: return@observe
                 when (info.state) {
                     WorkInfo.State.ENQUEUED,
                     WorkInfo.State.BLOCKED,
                     WorkInfo.State.RUNNING -> {
                         val total = info.progress.getInt(ModelDownloadWorker.KEY_TOTAL, 0)
                         if (total > 0) {
-                            val file = info.progress.getString(ModelDownloadWorker.KEY_FILE) ?: ""
-                            val done = info.progress.getInt(ModelDownloadWorker.KEY_COMPLETED, 0)
-                            val pct = info.progress.getInt(ModelDownloadWorker.KEY_PERCENT, 0)
-                            setStatus("$file $done/$total")
-                            downloadProgress.progress = pct
+                            setStatus(downloadStatus(info))
+                            downloadProgress.progress =
+                                info.progress.getInt(ModelDownloadWorker.KEY_PERCENT, 0)
                         }
                     }
                     WorkInfo.State.SUCCEEDED -> {
@@ -249,7 +257,10 @@ class MainActivity : ComponentActivity() {
                         }
                         downloadProgress.progress = 100
                         downloadProgress.visibility = View.GONE
-                        initPipeline(modelDir)
+                        if (!pipelineStarted) {
+                            pipelineStarted = true
+                            initPipeline(modelDir)
+                        }
                     }
                     WorkInfo.State.FAILED -> {
                         val err = info.outputData.getString(ModelDownloadWorker.KEY_ERROR)
@@ -261,6 +272,20 @@ class MainActivity : ComponentActivity() {
                     WorkInfo.State.CANCELLED -> setStatus("cancelled")
                 }
             }
+    }
+
+    /** "<file>  <done>/<total> MB  ·  <n>/<files>" from a worker progress payload. */
+    private fun downloadStatus(info: WorkInfo): String {
+        val file = info.progress.getString(ModelDownloadWorker.KEY_FILE) ?: ""
+        val done = info.progress.getInt(ModelDownloadWorker.KEY_COMPLETED, 0)
+        val total = info.progress.getInt(ModelDownloadWorker.KEY_TOTAL, 0)
+        val bytes = info.progress.getLong(ModelDownloadWorker.KEY_BYTES_DOWNLOADED, 0L)
+        val fileTotal = info.progress.getLong(ModelDownloadWorker.KEY_FILE_TOTAL_BYTES, 0L)
+        val mb = if (fileTotal > 0)
+            "${bytes / 1_000_000}/${fileTotal / 1_000_000} MB"
+        else
+            "${bytes / 1_000_000} MB"
+        return "$file  $mb  ·  $done/$total"
     }
 
     private fun initPipeline(modelDir: String) {
@@ -405,6 +430,7 @@ class MainActivity : ComponentActivity() {
     private fun retryInit() {
         statusView.setOnClickListener(null)
         statusView.setOnLongClickListener(null)
+        pipelineStarted = false
         loadPipeline()
     }
 

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,21 @@
+<!--
+    Launcher-icon foreground: a 5-bar audio waveform, echoing the in-app VAD
+    graph. Drawn as round-capped vertical strokes, centered within the
+    adaptive-icon safe zone (108x108 viewport, content kept inside ~[21,87]).
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path android:strokeColor="#43A047" android:strokeWidth="8.5"
+        android:strokeLineCap="round" android:pathData="M34,46 L34,62" />
+    <path android:strokeColor="#66BB6A" android:strokeWidth="8.5"
+        android:strokeLineCap="round" android:pathData="M44,38 L44,70" />
+    <path android:strokeColor="#FFFFFF" android:strokeWidth="8.5"
+        android:strokeLineCap="round" android:pathData="M54,28 L54,80" />
+    <path android:strokeColor="#66BB6A" android:strokeWidth="8.5"
+        android:strokeLineCap="round" android:pathData="M64,38 L64,70" />
+    <path android:strokeColor="#43A047" android:strokeWidth="8.5"
+        android:strokeLineCap="round" android:pathData="M74,46 L74,62" />
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/values/ic_launcher_background.xml
+++ b/app/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,3 @@
+<resources>
+    <color name="ic_launcher_background">#13151A</color>
+</resources>

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
@@ -61,26 +61,36 @@ class ModelDownloadWorker(
             ?.let { runCatching { ModelPrecision.valueOf(it) }.getOrNull() }
             ?: ModelPrecision.INT8
 
-        runCatching { setForeground(buildForegroundInfo(0, 0, "Preparing speech models…")) }
+        runCatching { setForeground(buildForegroundInfo(0, "Preparing speech models…")) }
+
+        // Only rebuild the foreground notification when the integer percent or
+        // the file changes — the underlying progress callback is already
+        // throttled to ~1 MB, but re-posting a Notification on every tick still
+        // janks the main thread, so we coalesce to visible changes only.
+        var lastNotifiedPct = -1
+        var lastNotifiedFile = ""
 
         return try {
             val modelDir = ModelManager.ensureModels(applicationContext, precision) { p ->
-                val pct = if (p.totalFiles > 0) {
-                    (p.completed * 100 / p.totalFiles).coerceIn(0, 100)
-                } else 0
+                val pct = progressPercent(p.completed, p.totalFiles, p.bytesDownloaded, p.fileTotalBytes)
                 setProgressAsync(workDataOf(
                     KEY_FILE to p.file,
                     KEY_COMPLETED to p.completed,
                     KEY_TOTAL to p.totalFiles,
                     KEY_BYTES_DOWNLOADED to p.bytesDownloaded,
+                    KEY_FILE_TOTAL_BYTES to p.fileTotalBytes,
                     KEY_PERCENT to pct,
                 ))
-                runCatching {
-                    setForegroundAsync(buildForegroundInfo(
-                        completed = p.completed,
-                        total = p.totalFiles,
-                        text = "${p.file}  ${p.completed}/${p.totalFiles}",
-                    ))
+                if (pct != lastNotifiedPct || p.file != lastNotifiedFile) {
+                    lastNotifiedPct = pct
+                    lastNotifiedFile = p.file
+                    runCatching {
+                        setForegroundAsync(buildForegroundInfo(
+                            percent = pct,
+                            text = "${p.file}  ${formatMb(p.bytesDownloaded)}/${formatMb(p.fileTotalBytes)}" +
+                                "  ·  ${p.completed}/${p.totalFiles}",
+                        ))
+                    }
                 }
             }
             Result.success(workDataOf(KEY_MODEL_DIR to modelDir))
@@ -92,14 +102,14 @@ class ModelDownloadWorker(
         }
     }
 
-    private fun buildForegroundInfo(completed: Int, total: Int, text: String): ForegroundInfo {
+    private fun buildForegroundInfo(percent: Int, text: String): ForegroundInfo {
         ensureChannel()
-        val indeterminate = total <= 0
+        val indeterminate = percent <= 0
         val notif = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
             .setContentTitle("Speech models")
             .setContentText(text)
             .setSmallIcon(android.R.drawable.stat_sys_download)
-            .setProgress(if (indeterminate) 100 else total, completed, indeterminate)
+            .setProgress(100, percent.coerceIn(0, 100), indeterminate)
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setPriority(NotificationCompat.PRIORITY_LOW)
@@ -122,9 +132,38 @@ class ModelDownloadWorker(
         ).apply { description = "Progress for downloading on-device speech models" })
     }
 
+    private fun formatMb(bytes: Long): String =
+        if (bytes <= 0) "…" else "%.0f MB".format(bytes / 1_000_000.0)
+
     companion object {
         /** Pass to [WorkManager.enqueueUniqueWork] to dedupe concurrent downloads. */
         const val UNIQUE_NAME = "audio.soniqo.speech.modelDownload"
+
+        /**
+         * Download completion percent (0-100) that advances *continuously* as
+         * the current file streams, instead of only when a whole file lands.
+         * It is the count of fully-finished files plus the fraction of the
+         * file in flight, scaled over the total file count:
+         *
+         *     pct = ((completed + bytesDownloaded / fileTotalBytes) / totalFiles) * 100
+         *
+         * This keeps the progress bar moving through the dominant ~840 MB
+         * encoder (issue #30: "stuck at 0/16, 0%"). When [fileTotalBytes] is
+         * unknown (0) it degrades to the previous whole-file behaviour for
+         * that file only. Pure + side-effect free so it is unit-testable.
+         */
+        fun progressPercent(
+            completed: Int,
+            totalFiles: Int,
+            bytesDownloaded: Long,
+            fileTotalBytes: Long,
+        ): Int {
+            if (totalFiles <= 0) return 0
+            val fraction = if (fileTotalBytes > 0) {
+                (bytesDownloaded.toDouble() / fileTotalBytes).coerceIn(0.0, 1.0)
+            } else 0.0
+            return (((completed + fraction) / totalFiles) * 100.0).toInt().coerceIn(0, 100)
+        }
 
         // Input keys
         const val KEY_PRECISION = "precision"
@@ -138,6 +177,7 @@ class ModelDownloadWorker(
         const val KEY_COMPLETED = "completed"
         const val KEY_TOTAL = "totalFiles"
         const val KEY_BYTES_DOWNLOADED = "bytesDownloaded"
+        const val KEY_FILE_TOTAL_BYTES = "fileTotalBytes"
         const val KEY_PERCENT = "percent"
 
         private const val CHANNEL_ID = "audio.soniqo.speech.models"

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -103,9 +103,16 @@ object ModelManager {
     data class Progress(
         val file: String,
         val bytesDownloaded: Long,
+        /** Total size of the file currently downloading, or 0 if unknown. */
+        val fileTotalBytes: Long,
         val totalFiles: Int,
         val completed: Int,
     )
+
+    // Report intra-file byte progress at most this often. Without throttling,
+    // downloadFile's 64 KB read loop fires the callback ~13k times for the
+    // ~840 MB encoder, flooding WorkManager's setProgress/setForeground.
+    private const val PROGRESS_REPORT_INTERVAL_BYTES = 1_000_000L
 
     /**
      * True iff every required model file for [precision] is already on disk
@@ -194,8 +201,8 @@ object ModelManager {
             dest.parentFile?.mkdirs()
 
             val url = "$BASE_URL/${model.repo}/resolve/main/${model.filename}"
-            downloadFile(url, dest) { bytes ->
-                onProgress?.invoke(Progress(model.filename, bytes, allFiles.size, completed))
+            downloadFile(url, dest) { bytes, fileTotal ->
+                onProgress?.invoke(Progress(model.filename, bytes, fileTotal, allFiles.size, completed))
             }
             completed++
         }
@@ -207,7 +214,7 @@ object ModelManager {
         dir.absolutePath
     }
 
-    private fun downloadFile(url: String, dest: File, onBytes: (Long) -> Unit) {
+    private fun downloadFile(url: String, dest: File, onBytes: (downloaded: Long, fileTotal: Long) -> Unit) {
         val tmp = File(dest.parentFile, "${dest.name}.tmp")
 
         var lastException: IOException? = null
@@ -241,17 +248,34 @@ object ModelManager {
                 val contentLength = body.contentLength()
                 val isResume = response.code == 206
 
+                // Full file size: on a 206 resume, contentLength is only the
+                // remaining range, so add what's already on disk. 0 means the
+                // server didn't advertise a length (progress stays file-count
+                // based for this file).
+                val fileTotal = when {
+                    contentLength <= 0 -> 0L
+                    isResume -> existingBytes + contentLength
+                    else -> contentLength
+                }
+
                 FileOutputStream(tmp, isResume).use { output ->
                     body.byteStream().use { input ->
                         val buf = ByteArray(65536)
                         var total = if (isResume) existingBytes else 0L
+                        var lastReported = -1L
+                        onBytes(total, fileTotal)
                         while (true) {
                             val n = input.read(buf)
                             if (n == -1) break
                             output.write(buf, 0, n)
                             total += n
-                            onBytes(total)
+                            // Throttle: only surface progress every ~1 MB.
+                            if (lastReported < 0 || total - lastReported >= PROGRESS_REPORT_INTERVAL_BYTES) {
+                                onBytes(total, fileTotal)
+                                lastReported = total
+                            }
                         }
+                        onBytes(total, fileTotal)
                     }
                 }
 

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -22,7 +22,10 @@ object ModelManager {
     private const val BASE_URL = "https://huggingface.co/soniqo"
 
     // Bump when models on HuggingFace are updated to trigger cache invalidation.
-    private const val MODEL_VERSION = 3
+    // v4: Parakeet INT8 moved from Parakeet-TDT-v3-ONNX (INT64 decoder-joint) to
+    // Parakeet-TDT-0.6B-ONNX (INT32) to match speech-core; the filenames are
+    // unchanged, so this bump is required to evict the stale, incompatible files.
+    private const val MODEL_VERSION = 4
 
     private const val MAX_RETRIES = 5
     private const val RETRY_DELAY_MS = 2000L
@@ -47,10 +50,17 @@ object ModelManager {
 
         // STT — Parakeet (auto-detect) or Nemotron-3.5 multilingual.
         when (sttModel) {
+            // Parakeet-TDT-0.6B-ONNX (not the older Parakeet-TDT-v3-ONNX): its
+            // decoder-joint takes INT32 `targets`/`target_length`, matching what
+            // speech-core's ParakeetStt::tdt_decode now sends. The v3 export used
+            // INT64, so pairing it with the current engine aborts at runtime with
+            // "ORT: Unexpected input data type. Actual: (tensor(int32)),
+            // expected: (tensor(int64))". This also matches the repo already used
+            // for the FP32 external-data file below.
             SttModel.PARAKEET -> files += listOf(
-                ModelFile("Parakeet-TDT-v3-ONNX", "parakeet-encoder${suffix}.onnx"),
-                ModelFile("Parakeet-TDT-v3-ONNX", "parakeet-decoder-joint${suffix}.onnx"),
-                ModelFile("Parakeet-TDT-v3-ONNX", "vocab.json"),
+                ModelFile("Parakeet-TDT-0.6B-ONNX", "parakeet-encoder${suffix}.onnx"),
+                ModelFile("Parakeet-TDT-0.6B-ONNX", "parakeet-decoder-joint${suffix}.onnx"),
+                ModelFile("Parakeet-TDT-0.6B-ONNX", "vocab.json"),
             )
             SttModel.NEMOTRON_MULTILINGUAL -> {
                 val base = "Nemotron-3.5-ASR-Streaming-Multilingual-0.6B"

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -22,10 +22,11 @@ object ModelManager {
     private const val BASE_URL = "https://huggingface.co/soniqo"
 
     // Bump when models on HuggingFace are updated to trigger cache invalidation.
-    // v4: Parakeet INT8 moved from Parakeet-TDT-v3-ONNX (INT64 decoder-joint) to
-    // Parakeet-TDT-0.6B-ONNX (INT32) to match speech-core; the filenames are
-    // unchanged, so this bump is required to evict the stale, incompatible files.
-    private const val MODEL_VERSION = 4
+    // v5: Parakeet-TDT-v3-ONNX decoder-joint re-exported to INT32 inputs named
+    // `targets`/`target_length` (was INT64 `prednet_lengths_orig`) to match
+    // speech-core. Filenames are unchanged, so this bump evicts both the old
+    // INT64 v3 decoder and the interim English-only 0.6B set.
+    private const val MODEL_VERSION = 5
 
     private const val MAX_RETRIES = 5
     private const val RETRY_DELAY_MS = 2000L
@@ -50,17 +51,18 @@ object ModelManager {
 
         // STT — Parakeet (auto-detect) or Nemotron-3.5 multilingual.
         when (sttModel) {
-            // Parakeet-TDT-0.6B-ONNX (not the older Parakeet-TDT-v3-ONNX): its
-            // decoder-joint takes INT32 `targets`/`target_length`, matching what
-            // speech-core's ParakeetStt::tdt_decode now sends. The v3 export used
-            // INT64, so pairing it with the current engine aborts at runtime with
-            // "ORT: Unexpected input data type. Actual: (tensor(int32)),
-            // expected: (tensor(int64))". This also matches the repo already used
-            // for the FP32 external-data file below.
+            // Parakeet-TDT-v3-ONNX is the multilingual export (8192-token vocab
+            // with Cyrillic/Greek/accented Latin) — required for non-English STT.
+            // Its INT8 decoder-joint was re-exported so `targets`/`target_length`
+            // are INT32 (was INT64) and the length input is named `target_length`
+            // (was `prednet_lengths_orig`), matching speech-core's
+            // ParakeetStt::tdt_decode. (The Parakeet-TDT-0.6B-ONNX export is
+            // English-only — speaking e.g. Russian transliterates to Latin — so
+            // it must not be used for the default STT.)
             SttModel.PARAKEET -> files += listOf(
-                ModelFile("Parakeet-TDT-0.6B-ONNX", "parakeet-encoder${suffix}.onnx"),
-                ModelFile("Parakeet-TDT-0.6B-ONNX", "parakeet-decoder-joint${suffix}.onnx"),
-                ModelFile("Parakeet-TDT-0.6B-ONNX", "vocab.json"),
+                ModelFile("Parakeet-TDT-v3-ONNX", "parakeet-encoder${suffix}.onnx"),
+                ModelFile("Parakeet-TDT-v3-ONNX", "parakeet-decoder-joint${suffix}.onnx"),
+                ModelFile("Parakeet-TDT-v3-ONNX", "vocab.json"),
             )
             SttModel.NEMOTRON_MULTILINGUAL -> {
                 val base = "Nemotron-3.5-ASR-Streaming-Multilingual-0.6B"

--- a/sdk/src/test/kotlin/audio/soniqo/speech/DownloadProgressTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/DownloadProgressTest.kt
@@ -1,0 +1,150 @@
+package audio.soniqo.speech
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression test for issue #30 — "download bar appears frozen / hung".
+ *
+ * Pure-JVM (no Robolectric / device / network): it drives the REAL production
+ * percent function [ModelDownloadWorker.progressPercent] over the actual 16-file
+ * INT8 size distribution, replaying the byte-stream contract of
+ * [ModelManager.ensureModels] (per-file `bytesDownloaded`, `completed`
+ * increments only AFTER each file lands).
+ *
+ * The old behaviour computed `pct = completed * 100 / totalFiles`, which pinned
+ * the bar to a single value for the entire ~840 MB `parakeet-encoder-int8.onnx`
+ * download (file #2) — indistinguishable from a hang. The fix makes the percent
+ * byte-aware, so it advances continuously through the dominant file. These
+ * assertions lock that in: the bar must MOVE during the encoder and never go
+ * backwards.
+ *
+ * Run: `./gradlew :sdk:test --tests '*DownloadProgressTest*'`
+ */
+class DownloadProgressTest {
+
+    private data class Sized(val name: String, val bytes: Long)
+
+    private val MB = 1_000_000L
+    private val totalFiles = 16
+
+    /** Real INT8 manifest order/sizes; file #2 dwarfs the rest (~85% of bytes). */
+    private val manifest = listOf(
+        Sized("silero-vad.onnx", 2 * MB),                   // #1
+        Sized("parakeet-encoder-int8.onnx", 840 * MB),      // #2  <-- the giant
+        Sized("parakeet-decoder-joint-int8.onnx", 51 * MB), // #3
+        Sized("vocab.json", 1 * MB),                        // #4
+        Sized("kokoro-e2e.onnx", 1 * MB),                   // #5
+        Sized("kokoro-e2e.onnx.data", 89 * MB),             // #6
+        Sized("vocab_index.json", 1 * MB),                  // #7
+        Sized("us_gold.json", 2 * MB),                      // #8
+        Sized("us_silver.json", 2 * MB),                    // #9
+        Sized("dict_fr.json", 1 * MB),                      // #10
+        Sized("dict_es.json", 1 * MB),                      // #11
+        Sized("dict_it.json", 1 * MB),                      // #12
+        Sized("dict_pt.json", 1 * MB),                      // #13
+        Sized("dict_hi.json", 1 * MB),                      // #14
+        Sized("voices/af_heart.bin", 1 * MB),               // #15
+        Sized("deepfilter-auxiliary.bin", 2 * MB),          // #16
+    )
+
+    private val CHUNK = 65536L
+
+    private data class Sample(
+        val file: String,
+        val completed: Int,
+        val fileBytes: Long,
+        val fileTotal: Long,
+        val percent: Int,
+    )
+
+    /** Replays ensureModels: `completed` lags until a file fully lands; each */
+    /** tick's percent comes from the production [ModelDownloadWorker.progressPercent]. */
+    private fun simulate(): List<Sample> {
+        val samples = ArrayList<Sample>()
+        var completed = 0
+        for (m in manifest) {
+            var fileBytes = 0L
+            while (fileBytes < m.bytes) {
+                fileBytes = minOf(m.bytes, fileBytes + CHUNK)
+                samples += Sample(
+                    file = m.name,
+                    completed = completed,
+                    fileBytes = fileBytes,
+                    fileTotal = m.bytes,
+                    percent = ModelDownloadWorker.progressPercent(
+                        completed, totalFiles, fileBytes, m.bytes,
+                    ),
+                )
+            }
+            completed++
+        }
+        return samples
+    }
+
+    @Test
+    fun progressPercent_isByteAware_unitValues() {
+        // Whole files done plus the fraction of the file in flight.
+        assertEquals(6, ModelDownloadWorker.progressPercent(1, 16, 0, 840 * MB))        // start of encoder
+        assertEquals(9, ModelDownloadWorker.progressPercent(1, 16, 420 * MB, 840 * MB)) // half the encoder
+        assertEquals(12, ModelDownloadWorker.progressPercent(2, 16, 0, 89 * MB))        // after encoder lands
+        assertEquals(100, ModelDownloadWorker.progressPercent(16, 16, 0, 0))            // all files done
+    }
+
+    @Test
+    fun progressPercent_unknownFileSize_fallsBackToFileCount() {
+        // When the server doesn't advertise a length, the in-flight file adds
+        // no fraction — degrades to the old whole-file value for that file only.
+        assertEquals(6, ModelDownloadWorker.progressPercent(1, 16, 12345, 0))
+    }
+
+    @Test
+    fun progressPercent_guardsZeroTotal() {
+        assertEquals(0, ModelDownloadWorker.progressPercent(3, 0, 1, 2))
+    }
+
+    @Test
+    fun fixed_barMovesContinuouslyThroughTheEncoder() {
+        val encoder = simulate().filter { it.file == "parakeet-encoder-int8.onnx" }
+
+        // The whole point of the fix: the bar is NO LONGER frozen on the
+        // dominant file — it advances through several distinct values.
+        val distinct = encoder.map { it.percent }.toSet()
+        assertTrue(
+            "encoder percent should advance through several values, got $distinct",
+            distinct.size >= 6,
+        )
+        // It spans roughly 6% -> 12% (one file's worth of the 16-file bar).
+        assertEquals("encoder starts at ~6%", 6, encoder.first().percent)
+        assertEquals("encoder ends at ~12%", 12, encoder.last().percent)
+        // ...and is monotonic non-decreasing within the file.
+        assertTrue(
+            "encoder percent must never go backwards",
+            encoder.zipWithNext().all { (a, b) -> b.percent >= a.percent },
+        )
+    }
+
+    @Test
+    fun fixed_byHalfTheEncoderBarHasMovedPastTheOldFrozenCeiling() {
+        // Before the fix the bar was pinned at 6 for the entire encoder. Now,
+        // halfway through the encoder bytes it has already climbed past 6.
+        val encoder = simulate().filter { it.file == "parakeet-encoder-int8.onnx" }
+        val midpoint = encoder.first { it.fileBytes >= it.fileTotal / 2 }
+        assertTrue(
+            "halfway through the encoder the bar should read >= 9 (was frozen at 6), " +
+                "was ${midpoint.percent}",
+            midpoint.percent >= 9,
+        )
+    }
+
+    @Test
+    fun fixed_wholeRunPercentIsMonotonic() {
+        val samples = simulate()
+        assertTrue(
+            "reported percent must never decrease across the whole download",
+            samples.zipWithNext().all { (a, b) -> b.percent >= a.percent },
+        )
+        assertEquals("download ends at 100%", 100, samples.last().percent)
+    }
+}

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelDownloadWorkerTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelDownloadWorkerTest.kt
@@ -49,7 +49,7 @@ class ModelDownloadWorkerTest {
     @Test
     fun doWork_success_returnsModelDirInOutputData() = runBlocking {
         coEvery {
-            ModelManager.ensureModels(any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any())
         } returns "/fake/model/dir"
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context)
@@ -68,7 +68,7 @@ class ModelDownloadWorkerTest {
         // The worker should bubble transient network/disk failures up to
         // WorkManager so it reschedules with exponential backoff.
         coEvery {
-            ModelManager.ensureModels(any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any())
         } throws IOException("network down")
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context).build()
@@ -83,7 +83,7 @@ class ModelDownloadWorkerTest {
         // — emit Failure with the message in outputData so the host activity
         // can surface a useful error.
         coEvery {
-            ModelManager.ensureModels(any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any())
         } throws IllegalStateException("models corrupt")
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context).build()
@@ -97,7 +97,7 @@ class ModelDownloadWorkerTest {
     @Test
     fun doWork_invalidPrecisionInput_defaultsToInt8() = runBlocking {
         coEvery {
-            ModelManager.ensureModels(any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any())
         } returns "/fake"
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context)
@@ -107,21 +107,21 @@ class ModelDownloadWorkerTest {
         worker.doWork()
 
         coVerify(exactly = 1) {
-            ModelManager.ensureModels(any(), ModelPrecision.INT8, any())
+            ModelManager.ensureModels(any(), ModelPrecision.INT8, any(), any(), any())
         }
     }
 
     @Test
     fun doWork_missingPrecisionInput_defaultsToInt8() = runBlocking {
         coEvery {
-            ModelManager.ensureModels(any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any())
         } returns "/fake"
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context).build()
         worker.doWork()
 
         coVerify(exactly = 1) {
-            ModelManager.ensureModels(any(), ModelPrecision.INT8, any())
+            ModelManager.ensureModels(any(), ModelPrecision.INT8, any(), any(), any())
         }
     }
 


### PR DESCRIPTION
## Repos touched
- **Code** — `soniqo/speech-android` (this PR, branch `fix/issue-30-buggy-app`)
- **Model** — `soniqo/Parakeet-TDT-v3-ONNX` on HuggingFace (https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX): re-exported INT8 `parakeet-decoder-joint-int8.onnx` (old INT64 revision retained in git history). **This PR depends on that upload.**

---

Fixes the four problems in #31's parent issue #30 (Pixel 9 Pro, Android 15/16, `targetSdk 35`), plus a native transcription crash found while verifying on an emulator. All verified on an arm64 emulator (android-35-ext14).

## #30 — Problems & fixes
1. **Download "stuck at 0/16, 0%"** — (a) byte-aware, continuous progress percent (`ModelDownloadWorker.progressPercent`, pure + unit-tested) instead of whole-file quantization; (b) observe `getWorkInfosForUniqueWorkLiveData(UNIQUE_NAME)` instead of the discarded request id (which stayed `null` on rotation/re-entry); (c) throttle the per-64 KB `setProgress`/`setForeground` flood to ~1 MB / percent-change. Status now shows live MB.
2. **Back gesture closed the app** — removed the `finish()` calls in `LauncherActivity`; the picker stays on the back stack.
3. **No launcher icon** — adaptive waveform icon (`mipmap-anydpi-v26`, `<monochrome>`) wired via `android:icon`/`roundIcon`.
4. **"Menus feel slow"** — perceptual; addressed by the notification-flood throttling above.

## Native transcription crash (found during testing)
With models present the app aborted (`SIGABRT`) on first transcription:
`ORT: Unexpected input data type. Actual: (tensor(int32)), expected: (tensor(int64))` in `ParakeetStt::tdt_decode`. The published `Parakeet-TDT-v3-ONNX` INT8 decoder-joint had INT64 inputs named `prednet_lengths_orig`, but speech-core sends INT32 named `target_length`.

**Fix (keeps multilingual):** re-exported the v3 INT8 decoder-joint on HuggingFace (`soniqo/Parakeet-TDT-v3-ONNX`, graph surgery — `Cast` nodes, no retraining) so inputs are INT32 and named `targets`/`target_length`. ModelManager stays on the multilingual `Parakeet-TDT-v3-ONNX` (8192-token vocab, Cyrillic-capable) and bumps `MODEL_VERSION` 3→5 to evict stale caches.
> An interim commit switched to `Parakeet-TDT-0.6B-ONNX` to dodge the crash, but that export is English-only (Russian transliterated to Latin), so it was superseded by the re-export.

## Test plan
- `./gradlew :sdk:test` → **BUILD SUCCESSFUL** (all green; new `DownloadProgressTest`; 5 pre-existing `ModelDownloadWorkerTest` failures also repaired).
- `./gradlew :app:assembleDebug` → builds; icon merges into the manifest.
- **On-device (arm64 emulator):**
  - Switcher: Echo → "ready", Dictation → "tap to dictate", Recognizer → "ready — tap start"; **Back returns to the picker** from each (no app exit).
  - Download progress shows live MB and the bar advances (no longer frozen).
  - Pipeline init reaches "tap to talk" (`Pipeline created, NNAPI=0`) — **no SIGABRT**.
  - **Russian STT → `Привет, как дела?`** (Cyrillic), not transliterated Latin.
  - Adaptive icon packaged; no `FATAL EXCEPTION` / tombstone in the session.

Closes #30