### PR TITLE
Add Supertonic-3 TTS (LiteRT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,17 @@ This repo is the **Android packaging**: Kotlin SDK, JNI bridge, demo app. The C+
 | --- | --- | --- | --- |
 | [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Speech recognition | 891 MB | 114 |
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Text-to-speech | 330 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Text-to-speech (LiteRT, flow-matching, G2P-free, 44.1 kHz) | ~380 MB | 31 |
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Voice activity detection | 2 MB | Any |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Noise cancellation | ~8 MB | Any |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | On-device LLM — structured function / tool calls | 283 MB | EN-tuned |
 
 Models are downloaded automatically on first launch via `ModelManager.ensureModels()`.
+
+**Supertonic-3** is an opt-in higher-quality multilingual TTS — select it with
+`SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (requires the LiteRT backend). The host runs its four
+non-autoregressive flow-matching graphs on-device at 44.1 kHz; the front-end is G2P-free (NFKD +
+Unicode index — no phonemizer), so all 31 languages go through one path.
 
 **FunctionGemma 270M** is a Gemma 3 derivative trained for structured tool
 calls. The Kotlin wrapper (`audio.soniqo.speech.llm.FunctionGemma`) is a

--- a/README_de.md
+++ b/README_de.md
@@ -18,10 +18,13 @@ Dieses Repo ist das **Android-Packaging**: Kotlin-SDK, JNI-Bridge, Demo-App. Die
 | --- | --- | --- | --- |
 | [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Spracherkennung | 891 MB | 114 |
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Text-to-Speech | 330 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Text-to-Speech (LiteRT, Flow-Matching, G2P-frei, 44,1 kHz) | ~380 MB | 31 |
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Sprachaktivitätserkennung | 2 MB | Beliebig |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Rauschunterdrückung | ~8 MB | Beliebig |
 
 Modelle werden beim ersten Start automatisch über `ModelManager.ensureModels()` heruntergeladen.
+
+**Supertonic-3** ist ein optionales, höherwertiges mehrsprachiges TTS — wähle es mit `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` aus (erfordert das LiteRT-Backend). Der Host führt seine vier nicht-autoregressiven Flow-Matching-Graphen mit 44,1 kHz auf dem Gerät aus; das Front-End ist G2P-frei (NFKD + Unicode-Index — kein Phonemizer), sodass alle 31 Sprachen über einen einzigen Pfad laufen.
 
 ## Demo ausprobieren
 

--- a/README_es.md
+++ b/README_es.md
@@ -18,10 +18,13 @@ Este repositorio es el **empaquetado para Android**: SDK de Kotlin, puente JNI, 
 | --- | --- | --- | --- |
 | [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Reconocimiento de voz | 891 MB | 114 |
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Texto a voz | 330 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Texto a voz (LiteRT, flow-matching, G2P-free, 44.1 kHz) | ~380 MB | 31 |
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Detección de actividad de voz | 2 MB | Cualquiera |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Cancelación de ruido | ~8 MB | Cualquiera |
 
 Los modelos se descargan automáticamente al primer inicio vía `ModelManager.ensureModels()`.
+
+**Supertonic-3** es un TTS multilingüe opcional de mayor calidad — selecciónalo con `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (requiere el backend LiteRT). El host ejecuta sus cuatro grafos de flow-matching no autorregresivos en el dispositivo a 44.1 kHz; el front-end es G2P-free (NFKD + índice Unicode — sin fonemizador), por lo que los 31 idiomas pasan por una sola ruta.
 
 ## Prueba la demo
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -18,10 +18,13 @@ Ce dépôt fournit le **packaging Android** : SDK Kotlin, pont JNI, application 
 | --- | --- | --- | --- |
 | [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Reconnaissance vocale | 891 Mo | 114 |
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Synthèse vocale | 330 Mo | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Synthèse vocale (LiteRT, flow-matching, G2P-free, 44,1 kHz) | ~380 Mo | 31 |
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Détection d'activité vocale | 2 Mo | Toutes |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Suppression de bruit | ~8 Mo | Toutes |
 
 Les modèles sont téléchargés automatiquement au premier lancement via `ModelManager.ensureModels()`.
+
+**Supertonic-3** est une synthèse vocale multilingue de meilleure qualité, activable en option — sélectionnez-la avec `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (nécessite le backend LiteRT). L'hôte exécute ses quatre graphes de flow-matching non autorégressifs en local à 44,1 kHz ; le front-end est G2P-free (NFKD + index Unicode — aucun phonémiseur), de sorte que les 31 langues passent par un seul chemin.
 
 ## Essayer la démo
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -18,10 +18,13 @@ Android के लिए ऑन-डिवाइस स्पीच SDK, [ONNX Ru
 | --- | --- | --- | --- |
 | [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | स्पीच रिकग्निशन | 891 MB | 114 |
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | टेक्स्ट-टू-स्पीच | 330 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | टेक्स्ट-टू-स्पीच (LiteRT, फ़्लो-मैचिंग, G2P-free, 44.1 kHz) | ~380 MB | 31 |
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | वॉयस एक्टिविटी डिटेक्शन | 2 MB | कोई भी |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | शोर रद्दीकरण | ~8 MB | कोई भी |
 
 मॉडल पहले लॉन्च पर `ModelManager.ensureModels()` के माध्यम से स्वचालित रूप से डाउनलोड होते हैं।
+
+**Supertonic-3** एक ऑप्ट-इन उच्च-गुणवत्ता वाला बहुभाषी TTS है — इसे `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` के साथ चुनें (LiteRT बैकएंड आवश्यक)। होस्ट इसके चार नॉन-ऑटोरिग्रेसिव फ़्लो-मैचिंग ग्राफ़ ऑन-डिवाइस 44.1 kHz पर चलाता है; फ़्रंट-एंड G2P-free है (NFKD + Unicode इंडेक्स — कोई फ़ोनेमाइज़र नहीं), इसलिए सभी 31 भाषाएँ एक ही पथ से होकर गुजरती हैं।
 
 ## डेमो आज़माएँ
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -18,10 +18,13 @@
 | --- | --- | --- | --- |
 | [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | 音声認識 | 891 MB | 114 |
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | テキスト読み上げ | 330 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | テキスト読み上げ(LiteRT、flow-matching、G2P-free、44.1 kHz) | ~380 MB | 31 |
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | 音声活動検出 | 2 MB | 任意 |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | ノイズキャンセリング | ~8 MB | 任意 |
 
 モデルは初回起動時に `ModelManager.ensureModels()` 経由で自動ダウンロードされます。
+
+**Supertonic-3** はオプトインの高品質な多言語 TTS です — `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` で選択します(LiteRT バックエンドが必要)。ホストはその 4 つの非自己回帰 flow-matching グラフを 44.1 kHz でオンデバイス実行します。フロントエンドは G2P-free(NFKD + Unicode インデックス — phonemizer なし)なので、31 言語すべてが単一のパスを通ります。
 
 ## デモを試す
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -18,10 +18,13 @@
 | --- | --- | --- | --- |
 | [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | 음성 인식 | 891 MB | 114 |
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 텍스트 음성 변환 | 330 MB | 8(en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 텍스트 음성 변환(LiteRT, flow-matching, G2P-free, 44.1 kHz) | ~380 MB | 31 |
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | 음성 활동 감지 | 2 MB | 모든 언어 |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 노이즈 캔슬링 | ~8 MB | 모든 언어 |
 
 모델은 `ModelManager.ensureModels()`를 통해 첫 실행 시 자동으로 다운로드됩니다.
+
+**Supertonic-3**는 옵트인 방식의 더 높은 품질의 다국어 TTS입니다 — `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)`로 선택하세요(LiteRT 백엔드가 필요합니다). 호스트는 4개의 비자기회귀(non-autoregressive) flow-matching 그래프를 44.1 kHz로 온디바이스에서 실행합니다. 프런트엔드는 G2P-free(NFKD + 유니코드 인덱스 — 음소 변환기 없음)이므로 31개 언어 모두 하나의 경로를 통과합니다.
 
 ## 데모 사용해보기
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -18,10 +18,13 @@ Este repositório é o **empacotamento Android**: SDK Kotlin, ponte JNI, app de 
 | --- | --- | --- | --- |
 | [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Reconhecimento de fala | 891 MB | 114 |
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Texto para fala | 330 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Texto para fala (LiteRT, flow-matching, G2P-free, 44,1 kHz) | ~380 MB | 31 |
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Detecção de atividade vocal | 2 MB | Qualquer |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Cancelamento de ruído | ~8 MB | Qualquer |
 
 Os modelos são baixados automaticamente no primeiro lançamento via `ModelManager.ensureModels()`.
+
+O **Supertonic-3** é um TTS multilíngue opcional de maior qualidade — selecione-o com `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (requer o backend LiteRT). O host executa seus quatro grafos de flow-matching não autorregressivos no dispositivo a 44,1 kHz; o front-end é G2P-free (NFKD + índice Unicode — sem phonemizer), de modo que todos os 31 idiomas seguem um único caminho.
 
 ## Experimente a demo
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -18,10 +18,13 @@
 | --- | --- | --- | --- |
 | [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Распознавание речи | 891 МБ | 114 |
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Синтез речи | 330 МБ | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Синтез речи (LiteRT, flow-matching, G2P-free, 44,1 кГц) | ~380 МБ | 31 |
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Определение голосовой активности | 2 МБ | Любой |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Шумоподавление | ~8 МБ | Любой |
 
 Модели загружаются автоматически при первом запуске через `ModelManager.ensureModels()`.
+
+**Supertonic-3** — это опциональный многоязычный TTS повышенного качества: выберите его через `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (требуется бэкенд LiteRT). Хост выполняет его четыре неавторегрессионных flow-matching-графа на устройстве на частоте 44,1 кГц; фронтенд работает G2P-free (NFKD + индекс Unicode — без фонемизатора), поэтому все 31 язык проходят через один путь.
 
 ## Попробовать демо
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -18,10 +18,13 @@
 | --- | --- | --- | --- |
 | [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | 语音识别 | 891 MB | 114 |
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 文本转语音 | 330 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 文本转语音(LiteRT、流匹配、免 G2P、44.1 kHz) | ~380 MB | 31 |
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | 语音活动检测 | 2 MB | 任意 |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 噪声消除 | ~8 MB | 任意 |
 
 模型在首次启动时通过 `ModelManager.ensureModels()` 自动下载。
+
+**Supertonic-3** 是可选启用的更高质量多语言 TTS — 通过 `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` 选用(需要 LiteRT 后端)。宿主在设备端以 44.1 kHz 运行其四个非自回归流匹配图;前端免 G2P(NFKD + Unicode 索引 — 无音素转换器),因此全部 31 种语言走同一条路径。
 
 ## 试用演示
 

--- a/sdk/src/main/cpp/jni_bridge.cpp
+++ b/sdk/src/main/cpp/jni_bridge.cpp
@@ -9,6 +9,7 @@
 #include <speech_core/models/silero_vad.h>
 #ifdef SPEECH_ANDROID_WITH_LITERT
 #include <speech_core/models/litert_nemotron_multilingual_stt.h>
+#include <speech_core/models/litert_supertonic_tts.h>
 #endif
 #include <speech_core/interfaces.h>
 #include <speech_core/pipeline/agent_config.h>
@@ -35,7 +36,7 @@
 struct PipelineHandle {
     std::unique_ptr<speech_core::SileroVad> vad;
     std::unique_ptr<speech_core::STTInterface> stt;  // Parakeet or Nemotron (ONNX/LiteRT)
-    std::unique_ptr<speech_core::KokoroTts> tts;
+    std::unique_ptr<speech_core::TTSInterface> tts;  // Kokoro (ONNX) or Supertonic (LiteRT)
     std::unique_ptr<speech_core::DeepFilterEnhancer> enhancer;
     std::unique_ptr<speech_core::VoicePipeline> pipeline;
 
@@ -142,7 +143,7 @@ JNIEXPORT jlong JNICALL
 Java_audio_soniqo_speech_NativeBridge_nativeCreate(
     JNIEnv* env, jobject /*thiz*/,
     jstring modelDir, jboolean useNnapi, jboolean useInt8,
-    jint sttModel, jint sttBackend, jstring language,
+    jint sttModel, jint sttBackend, jint ttsModel, jstring language,
     jobject callback,
     jboolean emitPartialTranscriptions, jfloat partialTranscriptionInterval)
 {
@@ -195,11 +196,30 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
                 dir + "/vocab.json",
                 nnapi);
         }
-        h->tts = std::make_unique<speech_core::KokoroTts>(
-            dir + "/kokoro-e2e.onnx",
-            dir + "/voices",
-            dir,
-            nnapi);
+        // TTS — Kokoro (ONNX, 24 kHz) or Supertonic-3 (LiteRT flow-matching, 44.1 kHz, G2P-free).
+        enum { TTS_KOKORO = 0, TTS_SUPERTONIC = 1 };
+        if (ttsModel == TTS_SUPERTONIC) {
+#ifdef SPEECH_ANDROID_WITH_LITERT
+            // Assets from soniqo/Supertonic-3-LiteRT: the four graphs + the G2P-free tokenizer
+            // (unicode_indexer.json + tts.json in modelDir) + voice_styles/.
+            h->tts = std::make_unique<speech_core::LiteRTSupertonicTts>(
+                dir + "/duration_predictor.tflite",
+                dir + "/text_encoder.tflite",
+                dir + "/vector_estimator.tflite",
+                dir + "/vocoder.tflite",
+                dir,
+                dir + "/voice_styles",
+                nnapi);
+#else
+            throw std::runtime_error("Supertonic TTS requires the LiteRT backend (not built into this SDK)");
+#endif
+        } else {
+            h->tts = std::make_unique<speech_core::KokoroTts>(
+                dir + "/kokoro-e2e.onnx",
+                dir + "/voices",
+                dir,
+                nnapi);
+        }
 
         speech_core::AgentConfig cfg;
         cfg.vad.min_silence_duration = 0.5f;

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -42,6 +42,7 @@ object ModelManager {
         precision: ModelPrecision,
         sttModel: SttModel = SttModel.PARAKEET,
         sttBackend: SttBackend = SttBackend.ONNX,
+        ttsModel: TtsModel = TtsModel.KOKORO,
     ): List<ModelFile> {
         val suffix = if (precision == ModelPrecision.INT8) "-int8" else ""
         val files = mutableListOf(
@@ -90,22 +91,36 @@ object ModelManager {
             }
         }
 
-        files += listOf(
-            // TTS (E2E model — single file + external weights)
-            ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx"),
-            ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx.data"),
-            ModelFile("Kokoro-82M-ONNX", "vocab_index.json"),
-            ModelFile("Kokoro-82M-ONNX", "us_gold.json"),
-            ModelFile("Kokoro-82M-ONNX", "us_silver.json"),
-            ModelFile("Kokoro-82M-ONNX", "dict_fr.json"),
-            ModelFile("Kokoro-82M-ONNX", "dict_es.json"),
-            ModelFile("Kokoro-82M-ONNX", "dict_it.json"),
-            ModelFile("Kokoro-82M-ONNX", "dict_pt.json"),
-            ModelFile("Kokoro-82M-ONNX", "dict_hi.json"),
-            ModelFile("Kokoro-82M-ONNX", "voices/af_heart.bin"),
-            // Noise cancellation
-            ModelFile("DeepFilterNet3-ONNX", "deepfilter-auxiliary.bin"),
-        )
+        // TTS — Kokoro (ONNX E2E, 24 kHz) or Supertonic-3 (LiteRT flow-matching, 44.1 kHz, G2P-free).
+        when (ttsModel) {
+            TtsModel.KOKORO -> files += listOf(
+                // E2E model — single file + external weights
+                ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx"),
+                ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx.data"),
+                ModelFile("Kokoro-82M-ONNX", "vocab_index.json"),
+                ModelFile("Kokoro-82M-ONNX", "us_gold.json"),
+                ModelFile("Kokoro-82M-ONNX", "us_silver.json"),
+                ModelFile("Kokoro-82M-ONNX", "dict_fr.json"),
+                ModelFile("Kokoro-82M-ONNX", "dict_es.json"),
+                ModelFile("Kokoro-82M-ONNX", "dict_it.json"),
+                ModelFile("Kokoro-82M-ONNX", "dict_pt.json"),
+                ModelFile("Kokoro-82M-ONNX", "dict_hi.json"),
+                ModelFile("Kokoro-82M-ONNX", "voices/af_heart.bin"),
+            )
+            // Four LiteRT graphs + the G2P-free tokenizer assets + the 10-voice catalog.
+            TtsModel.SUPERTONIC -> files += listOf(
+                "duration_predictor.tflite", "text_encoder.tflite",
+                "vector_estimator.tflite", "vocoder.tflite",
+                "tts.json", "unicode_indexer.json",
+                "voice_styles/F1.json", "voice_styles/F2.json", "voice_styles/F3.json",
+                "voice_styles/F4.json", "voice_styles/F5.json",
+                "voice_styles/M1.json", "voice_styles/M2.json", "voice_styles/M3.json",
+                "voice_styles/M4.json", "voice_styles/M5.json",
+            ).map { ModelFile("Supertonic-3-LiteRT", it) }
+        }
+
+        // Noise cancellation
+        files += ModelFile("DeepFilterNet3-ONNX", "deepfilter-auxiliary.bin")
         return files
         // Note: FP32 Parakeet encoder also needs parakeet-encoder.onnx.data.
     }
@@ -141,6 +156,7 @@ object ModelManager {
         precision: ModelPrecision = ModelPrecision.INT8,
         sttModel: SttModel = SttModel.PARAKEET,
         sttBackend: SttBackend = SttBackend.ONNX,
+        ttsModel: TtsModel = TtsModel.KOKORO,
     ): Boolean {
         val dir = File(context.filesDir, "models")
         if (!dir.exists()) return false
@@ -149,7 +165,7 @@ object ModelManager {
         val cached = versionFile.takeIf { it.exists() }?.readText()?.trim()?.toIntOrNull() ?: 0
         if (cached < MODEL_VERSION) return false
 
-        val fileList = models(precision, sttModel, sttBackend)
+        val fileList = models(precision, sttModel, sttBackend, ttsModel)
         val allFiles = if (precision == ModelPrecision.FP32 && sttModel == SttModel.PARAKEET) {
             fileList + ModelFile("Parakeet-TDT-0.6B-ONNX", "parakeet-encoder.onnx.data")
         } else {
@@ -171,6 +187,7 @@ object ModelManager {
         precision: ModelPrecision = ModelPrecision.INT8,
         sttModel: SttModel = SttModel.PARAKEET,
         sttBackend: SttBackend = SttBackend.ONNX,
+        ttsModel: TtsModel = TtsModel.KOKORO,
         onProgress: ((Progress) -> Unit)? = null,
     ): String = withContext(Dispatchers.IO) {
         val dir = File(context.filesDir, "models")
@@ -190,7 +207,7 @@ object ModelManager {
         // bytes=N- on the next attempt. Stale .tmp from an old MODEL_VERSION
         // is already wiped above.
 
-        val fileList = models(precision, sttModel, sttBackend)
+        val fileList = models(precision, sttModel, sttBackend, ttsModel)
         // FP32 Parakeet encoder needs the external data file.
         val allFiles = if (precision == ModelPrecision.FP32 && sttModel == SttModel.PARAKEET) {
             fileList + ModelFile("Parakeet-TDT-0.6B-ONNX", "parakeet-encoder.onnx.data")

--- a/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
@@ -12,6 +12,7 @@ internal object NativeBridge {
         useInt8: Boolean,
         sttModel: Int,    // SttModel.ordinal: 0=PARAKEET, 1=NEMOTRON_MULTILINGUAL
         sttBackend: Int,  // SttBackend.ordinal: 0=ONNX, 1=LITERT
+        ttsModel: Int,    // TtsModel.ordinal: 0=KOKORO, 1=SUPERTONIC (LiteRT)
         language: String, // prompt locale for Nemotron ("auto", "en-US", ...)
         callback: EventCallback,
         emitPartialTranscriptions: Boolean,

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
@@ -10,6 +10,11 @@ enum class SttModel { PARAKEET, NEMOTRON_MULTILINGUAL }
  *  ships both; Parakeet is ONNX-only. */
 enum class SttBackend { ONNX, LITERT }
 
+/** On-device TTS model. KOKORO (ONNX, 24 kHz) is the default; SUPERTONIC is a
+ *  LiteRT non-autoregressive flow-matching model (Supertonic-3, 44.1 kHz, 31
+ *  languages, G2P-free) — requires the LiteRT backend to be built into the SDK. */
+enum class TtsModel { KOKORO, SUPERTONIC }
+
 data class SpeechConfig(
     /** Path to directory containing ONNX model files. */
     val modelDir: String = "",
@@ -22,6 +27,9 @@ data class SpeechConfig(
 
     /** STT inference backend (Nemotron multilingual supports both). */
     val sttBackend: SttBackend = SttBackend.ONNX,
+
+    /** Which TTS model to load. SUPERTONIC requires the LiteRT backend. */
+    val ttsModel: TtsModel = TtsModel.KOKORO,
 
     /** Language/locale prompt for prompt-conditioned models (Nemotron):
      *  a key from languages.json, e.g. "en-US", "fr", "ja-JP". "auto" lets

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
@@ -89,6 +89,7 @@ internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
         config.precision == ModelPrecision.INT8,
         config.sttModel.ordinal,
         config.sttBackend.ordinal,
+        config.ttsModel.ordinal,
         config.language,
         nativeCallback,
         config.emitPartialTranscriptions,

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelDownloadWorkerTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelDownloadWorkerTest.kt
@@ -49,7 +49,7 @@ class ModelDownloadWorkerTest {
     @Test
     fun doWork_success_returnsModelDirInOutputData() = runBlocking {
         coEvery {
-            ModelManager.ensureModels(any(), any(), any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
         } returns "/fake/model/dir"
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context)
@@ -68,7 +68,7 @@ class ModelDownloadWorkerTest {
         // The worker should bubble transient network/disk failures up to
         // WorkManager so it reschedules with exponential backoff.
         coEvery {
-            ModelManager.ensureModels(any(), any(), any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
         } throws IOException("network down")
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context).build()
@@ -83,7 +83,7 @@ class ModelDownloadWorkerTest {
         // — emit Failure with the message in outputData so the host activity
         // can surface a useful error.
         coEvery {
-            ModelManager.ensureModels(any(), any(), any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
         } throws IllegalStateException("models corrupt")
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context).build()
@@ -97,7 +97,7 @@ class ModelDownloadWorkerTest {
     @Test
     fun doWork_invalidPrecisionInput_defaultsToInt8() = runBlocking {
         coEvery {
-            ModelManager.ensureModels(any(), any(), any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
         } returns "/fake"
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context)
@@ -107,21 +107,21 @@ class ModelDownloadWorkerTest {
         worker.doWork()
 
         coVerify(exactly = 1) {
-            ModelManager.ensureModels(any(), ModelPrecision.INT8, any(), any(), any())
+            ModelManager.ensureModels(any(), ModelPrecision.INT8, any(), any(), any(), any())
         }
     }
 
     @Test
     fun doWork_missingPrecisionInput_defaultsToInt8() = runBlocking {
         coEvery {
-            ModelManager.ensureModels(any(), any(), any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
         } returns "/fake"
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context).build()
         worker.doWork()
 
         coVerify(exactly = 1) {
-            ModelManager.ensureModels(any(), ModelPrecision.INT8, any(), any(), any())
+            ModelManager.ensureModels(any(), ModelPrecision.INT8, any(), any(), any(), any())
         }
     }
 


### PR DESCRIPTION
## Add Supertonic-3 TTS (LiteRT)

Adds **SupertonicTTS-3** as a selectable pipeline TTS — non-autoregressive flow-matching multilingual TTS (44.1 kHz, 31 languages, G2P-free). Kokoro stays the default; opt in with `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (requires the LiteRT backend).

### Changes
- **`SpeechConfig`**: `TtsModel { KOKORO, SUPERTONIC }` + `ttsModel`, threaded `NativeBridge` → `SpeechPipeline` → `ModelManager`.
- **JNI** (`jni_bridge.cpp`): `nativeCreate` gains a `ttsModel` selector building `LiteRTSupertonicTts` (gated on `SPEECH_ANDROID_WITH_LITERT`); `PipelineHandle::tts` generalized from concrete `KokoroTts` to the `TTSInterface` base.
- **`ModelManager`**: Supertonic LiteRT download list (4 graphs + tokenizer assets + 10 voices) from `soniqo/Supertonic-3-LiteRT`.
- **submodule**: `speech-core` bumped to `b50e128` (brings the Supertonic C++).
- **docs**: README model-table row + usage note across all 10 READMEs.

### Validation
- Builds for **arm64-v8a + x86_64** (NDK 27) — Supertonic's C++ + utf8proc compile + link on Android.
- **SDK unit tests pass** (`:sdk:testReleaseUnitTest`, 41 tests) — updated `ModelDownloadWorkerTest` for the new `ensureModels` signature; no regression.
- On-device synthesis is the same Supertonic LiteRT engine already validated in `soniqo/speech-core` (#86) and `soniqo/speech-swift` (#341, full TTS→ASR roundtrip).

Models: https://huggingface.co/soniqo/Supertonic-3-LiteRT
