### PR TITLE
fix: release mic when backgrounded + survive rotation (demo app)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,9 +22,15 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".MainActivity" android:exported="false" />
-        <activity android:name=".DictationActivity" android:exported="false" />
-        <activity android:name=".SpeechRecognizerTestActivity" android:exported="false" />
+        <!-- configChanges: handle rotation/UI changes in-place instead of
+             recreating the Activity, which would build a second SpeechPipeline
+             (heavy native models) and leak the old one. -->
+        <activity android:name=".MainActivity" android:exported="false"
+            android:configChanges="orientation|screenSize|smallestScreenSize|keyboardHidden|uiMode" />
+        <activity android:name=".DictationActivity" android:exported="false"
+            android:configChanges="orientation|screenSize|smallestScreenSize|keyboardHidden|uiMode" />
+        <activity android:name=".SpeechRecognizerTestActivity" android:exported="false"
+            android:configChanges="orientation|screenSize|smallestScreenSize|keyboardHidden|uiMode" />
 
         <!-- Settings entry the system Voice-input picker opens via the gear -->
         <activity

--- a/app/src/main/kotlin/audio/soniqo/speech/demo/DictationActivity.kt
+++ b/app/src/main/kotlin/audio/soniqo/speech/demo/DictationActivity.kt
@@ -43,7 +43,7 @@ class DictationActivity : ComponentActivity() {
 
     private var pipeline: SpeechPipeline? = null
     private var audioRecord: AudioRecord? = null
-    private var recording = false
+    @Volatile private var recording = false
     private var pipelineStarted = false
     private var observingDownload = false
 
@@ -336,14 +336,24 @@ class DictationActivity : ComponentActivity() {
         val sr = 16000
         val bufSize = AudioRecord.getMinBufferSize(
             sr, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_FLOAT)
+        if (bufSize <= 0) {
+            statusView.text = "mic error (PCM_FLOAT unsupported)"
+            return
+        }
 
-        audioRecord = AudioRecord(
+        val record = AudioRecord(
             MediaRecorder.AudioSource.VOICE_RECOGNITION,
             sr, AudioFormat.CHANNEL_IN_MONO,
             AudioFormat.ENCODING_PCM_FLOAT, bufSize * 4
         )
+        if (record.state != AudioRecord.STATE_INITIALIZED) {
+            record.release()
+            statusView.text = "mic init failed"
+            return
+        }
+        audioRecord = record
 
-        audioRecord?.startRecording()
+        record.startRecording()
         recording = true
         micButton.setTextColor(Color.parseColor("#4CAF50"))
         statusView.text = "listening..."
@@ -351,7 +361,11 @@ class DictationActivity : ComponentActivity() {
         lifecycleScope.launch(Dispatchers.IO) {
             val buf = FloatArray(512)
             while (recording) {
-                val read = audioRecord?.read(buf, 0, buf.size, AudioRecord.READ_BLOCKING) ?: -1
+                val read = try {
+                    audioRecord?.read(buf, 0, buf.size, AudioRecord.READ_BLOCKING) ?: -1
+                } catch (_: IllegalStateException) {
+                    break  // AudioRecord released mid-read
+                }
                 if (read > 0) pipeline?.pushAudio(buf)
             }
         }
@@ -402,6 +416,16 @@ class DictationActivity : ComponentActivity() {
     // ---------------------------------------------------------------------------
     // Lifecycle
     // ---------------------------------------------------------------------------
+
+    override fun onStop() {
+        super.onStop()
+        // Release the mic when backgrounded so we don't hold it or drain battery.
+        if (recording) {
+            stopMicrophone()
+            micButton.setTextColor(Color.parseColor("#555555"))
+            statusView.text = "paused"
+        }
+    }
 
     override fun onDestroy() {
         stopMicrophone()

--- a/app/src/main/kotlin/audio/soniqo/speech/demo/MainActivity.kt
+++ b/app/src/main/kotlin/audio/soniqo/speech/demo/MainActivity.kt
@@ -42,7 +42,7 @@ class MainActivity : ComponentActivity() {
     private var audioRecord: AudioRecord? = null
     private var audioTrack: AudioTrack? = null
     private var mediaPlayer: android.media.MediaPlayer? = null
-    private var recording = false
+    @Volatile private var recording = false
     private val ttsBuffer = mutableListOf<ByteArray>()
     private var lastTtsMs = 0f
     private var speechStartTime = 0L
@@ -366,6 +366,13 @@ class MainActivity : ComponentActivity() {
                                     val delayMs = (durationSec * 1000).toLong() + 200
                                     lifecycleScope.launch {
                                         kotlinx.coroutines.delay(delayMs)
+                                        // If the app was backgrounded during playback, onStop
+                                        // already released the mic — don't restart the pipeline
+                                        // in the background or paint a false "listening" state.
+                                        if (!lifecycle.currentState.isAtLeast(
+                                                androidx.lifecycle.Lifecycle.State.STARTED)) {
+                                            return@launch
+                                        }
                                         stopAudioTrack()
                                         micPaused = false
                                         p.stop()
@@ -701,49 +708,66 @@ class MainActivity : ComponentActivity() {
         val sampleRate = 16000
         val bufferSize = AudioRecord.getMinBufferSize(
             sampleRate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_FLOAT)
+        if (bufferSize <= 0) {
+            addSystemLine("mic unavailable (PCM_FLOAT unsupported, code $bufferSize)")
+            setStatus("mic error")
+            return
+        }
 
-        audioRecord = AudioRecord(
+        val record = AudioRecord(
             MediaRecorder.AudioSource.MIC, sampleRate,
             AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_FLOAT, bufferSize)
+        if (record.state != AudioRecord.STATE_INITIALIZED) {
+            record.release()
+            addSystemLine("mic init failed")
+            setStatus("mic error")
+            return
+        }
+        audioRecord = record
 
         recording = true
-        audioRecord?.startRecording()
-        android.util.Log.i("Speech", "Mic started, state=${audioRecord?.state}")
+        record.startRecording()
+        android.util.Log.i("Speech", "Mic started, state=${record.state}")
         setStatus("listening...")
         setMicColor("#4CAF50")
 
         // Record mic to file for debugging
         val recFile = java.io.File(filesDir, "mic_recording.raw")
-        val recStream = java.io.FileOutputStream(recFile)
 
         lifecycleScope.launch(Dispatchers.IO) {
-            val buffer = FloatArray(512)
             var totalFrames = 0L
             var maxPeak = 0f
-            while (recording) {
-                val read = audioRecord?.read(buffer, 0, buffer.size, AudioRecord.READ_BLOCKING) ?: 0
-                if (read > 0) {
-                    if (!micPaused) {
-                        p.pushAudio(buffer)
+            // use{} guarantees the stream is closed even if the loop body throws.
+            java.io.FileOutputStream(recFile).use { recStream ->
+                val buffer = FloatArray(512)
+                while (recording) {
+                    val read = try {
+                        audioRecord?.read(buffer, 0, buffer.size, AudioRecord.READ_BLOCKING) ?: 0
+                    } catch (_: IllegalStateException) {
+                        break  // AudioRecord released mid-read (stopped on another thread)
                     }
-                    val peak = if (micPaused) 0f else (buffer.take(read).maxOfOrNull { kotlin.math.abs(it) } ?: 0f)
-                    if (peak > maxPeak) maxPeak = peak
-                    vadView.addLevel(peak)
+                    if (read > 0) {
+                        if (!micPaused) {
+                            p.pushAudio(buffer)
+                        }
+                        val peak = if (micPaused) 0f else (buffer.take(read).maxOfOrNull { kotlin.math.abs(it) } ?: 0f)
+                        if (peak > maxPeak) maxPeak = peak
+                        vadView.addLevel(peak)
 
-                    // Save to file
-                    val bytes = java.nio.ByteBuffer.allocate(read * 4)
-                        .order(java.nio.ByteOrder.LITTLE_ENDIAN)
-                    bytes.asFloatBuffer().put(buffer, 0, read)
-                    recStream.write(bytes.array())
+                        // Save to file
+                        val bytes = java.nio.ByteBuffer.allocate(read * 4)
+                            .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+                        bytes.asFloatBuffer().put(buffer, 0, read)
+                        recStream.write(bytes.array())
 
-                    totalFrames += read
-if (totalFrames % 16000 == 0L) {
-                        android.util.Log.i("Speech", "Mic: ${totalFrames/16000}s peak=${"%.4f".format(maxPeak)}")
-                        maxPeak = 0f
+                        totalFrames += read
+                        if (totalFrames % 16000 == 0L) {
+                            android.util.Log.i("Speech", "Mic: ${totalFrames/16000}s peak=${"%.4f".format(maxPeak)}")
+                            maxPeak = 0f
+                        }
                     }
                 }
             }
-            recStream.close()
             android.util.Log.i("Speech", "Mic stopped, recorded ${totalFrames} frames to ${recFile.absolutePath}")
         }
     }
@@ -756,16 +780,6 @@ if (totalFrames % 16000 == 0L) {
     }
 
     @Volatile private var micPaused = false
-
-    private fun pauseMicrophone() {
-        micPaused = true
-        android.util.Log.i("Speech", "Mic paused for TTS playback")
-    }
-
-    private fun resumeMicrophone() {
-        micPaused = false
-        android.util.Log.i("Speech", "Mic resumed after TTS playback")
-    }
 
     // ---------------------------------------------------------------------------
     // Helpers
@@ -784,6 +798,20 @@ if (totalFrames % 16000 == 0L) {
     // ---------------------------------------------------------------------------
     // Cleanup
     // ---------------------------------------------------------------------------
+
+    override fun onStop() {
+        super.onStop()
+        // Release the mic and stop playback when the app is no longer visible so
+        // we don't hold the microphone or drain the battery in the background.
+        // The model download (a foreground worker) is unaffected.
+        if (recording) {
+            stopMicrophone()
+            setStatus("tap to talk")
+            setMicColor("#555555")
+        }
+        micPaused = false
+        stopAudioTrack()
+    }
 
     override fun onDestroy() {
         stopMicrophone()


### PR DESCRIPTION
Demo-app robustness follow-ups surfaced while testing #30 (separate from that issue's four complaints — flagged in the review sweep and deferred).

## Changes
- **Mic released on background** — `onStop()` in `MainActivity` and `DictationActivity` stops the mic and playback when the app is no longer visible, so it no longer holds the microphone or drains the battery in the background. (The model download is a foreground worker and is unaffected.)
- **Survive rotation** — `android:configChanges` on the three mode activities so a rotation/UI change is handled in place instead of recreating the Activity, which would build a **second `SpeechPipeline`** (heavy native models) and leak the old one.
- **AudioRecord init validation** — check `getMinBufferSize` / `STATE_INITIALIZED` before recording, instead of silently producing a dead mic.
- **Record-loop hardening** — `FileOutputStream` wrapped in `use{}` (no leak on throw); `read()` guarded against release-mid-read (`onStop` now exercises this path routinely); `recording` marked `@Volatile`.
- **TTS-restart race fix** — the delayed restart coroutine is gated on the lifecycle, so backgrounding *during* playback no longer restarts the pipeline in the background or paints a false "listening" state on return. (Caught by an adversarial review of the diff.)
- Removed the unused `pauseMicrophone`/`resumeMicrophone` helpers.

## Test plan
- `./gradlew :app:assembleDebug` → BUILD SUCCESSFUL (native rebuilt incl. Supertonic).
- Adversarial 2-reviewer diff review; the one medium finding (TTS-restart race) fixed.
- **On-device (arm64 emulator, android-35-ext14):**
  - **Rotation:** `MainActivity` instance identical before/after; "Pipeline created" count stays **1** (no recreate → no leaked pipeline); no crash.
  - **Background:** `Mic started` → HOME → **`Mic stopped`** (mic released on `onStop`); app stays alive.
  - Mic toggle, Echo/Dictation/Recognizer switcher, and Back-to-picker all work; **0 `FATAL EXCEPTION`** across the session.

Follow-up to #30; does not touch the Supertonic TTS work from #32.