### PR TITLE
fix: preserve TTS duration on response done

### DIFF
--- a/app/src/main/kotlin/audio/soniqo/speech/demo/MainActivity.kt
+++ b/app/src/main/kotlin/audio/soniqo/speech/demo/MainActivity.kt
@@ -44,7 +44,6 @@ class MainActivity : ComponentActivity() {
     private var mediaPlayer: android.media.MediaPlayer? = null
     @Volatile private var recording = false
     private val ttsBuffer = mutableListOf<ByteArray>()
-    private var lastTtsMs = 0f
     private var speechStartTime = 0L
     private var pipelineStarted = false
     private var observingDownload = false
@@ -335,7 +334,6 @@ class MainActivity : ComponentActivity() {
 
                             is SpeechEvent.ResponseAudioDelta -> {
                                 ttsBuffer.add(event.audio)
-                                lastTtsMs = event.ttsMs
                                 // Save TTS audio for debugging
                                 try {
                                     java.io.File(filesDir, "tts_output.raw").appendBytes(event.audio)
@@ -346,7 +344,7 @@ class MainActivity : ComponentActivity() {
                                 android.util.Log.i("Speech", "ResponseDone -> TTS ready")
                                 val totalBytes = ttsBuffer.sumOf { it.size }
                                 val durationSec = totalBytes / 2f / TTS_SAMPLE_RATE
-                                addSystemLine("tts: ${"%.0f".format(lastTtsMs)}ms → ${"%.1f".format(durationSec)}s audio")
+                                addSystemLine("tts: ${"%.0f".format(event.ttsMs)}ms → ${"%.1f".format(durationSec)}s audio")
 
                                 if (isEmulator) {
                                     // Emulator: skip playback (QEMU audio kills mic)

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechEvent.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechEvent.kt
@@ -9,7 +9,7 @@ sealed class SpeechEvent {
     data object ResponseCreated : SpeechEvent()
     data object ResponseInterrupted : SpeechEvent()
     data class ResponseAudioDelta(val audio: ByteArray, val ttsMs: Float) : SpeechEvent()
-    data object ResponseDone : SpeechEvent()
+    data class ResponseDone(val ttsMs: Float) : SpeechEvent()
     data class Error(val message: String) : SpeechEvent()
 }
 

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
@@ -65,19 +65,14 @@ internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
             type: Int, text: String?, audio: ByteArray?,
             confidence: Float, sttMs: Float, ttsMs: Float,
         ) {
-            val event = when (type) {
-                0  -> SpeechEvent.SessionCreated
-                1  -> SpeechEvent.SpeechStarted
-                2  -> SpeechEvent.SpeechEnded
-                3  -> SpeechEvent.PartialTranscription(text ?: "", confidence)
-                4  -> SpeechEvent.TranscriptionCompleted(text ?: "", confidence, sttMs)
-                5  -> SpeechEvent.ResponseCreated
-                6  -> SpeechEvent.ResponseInterrupted
-                7  -> audio?.let { SpeechEvent.ResponseAudioDelta(it, ttsMs) }
-                8  -> SpeechEvent.ResponseDone
-                11 -> SpeechEvent.Error(text ?: "unknown error")
-                else -> null
-            } ?: return
+            val event = nativeEventToSpeechEvent(
+                type = type,
+                text = text,
+                audio = audio,
+                confidence = confidence,
+                sttMs = sttMs,
+                ttsMs = ttsMs,
+            ) ?: return
 
             _events.tryEmit(event)
         }
@@ -129,4 +124,25 @@ internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
             handle = 0
         }
     }
+}
+
+internal fun nativeEventToSpeechEvent(
+    type: Int,
+    text: String?,
+    audio: ByteArray?,
+    confidence: Float,
+    sttMs: Float,
+    ttsMs: Float,
+): SpeechEvent? = when (type) {
+    0  -> SpeechEvent.SessionCreated
+    1  -> SpeechEvent.SpeechStarted
+    2  -> SpeechEvent.SpeechEnded
+    3  -> SpeechEvent.PartialTranscription(text ?: "", confidence)
+    4  -> SpeechEvent.TranscriptionCompleted(text ?: "", confidence, sttMs)
+    5  -> SpeechEvent.ResponseCreated
+    6  -> SpeechEvent.ResponseInterrupted
+    7  -> audio?.let { SpeechEvent.ResponseAudioDelta(it, ttsMs) }
+    8  -> SpeechEvent.ResponseDone(ttsMs)
+    11 -> SpeechEvent.Error(text ?: "unknown error")
+    else -> null
 }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/SpeechPipelineEventMappingTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/SpeechPipelineEventMappingTest.kt
@@ -1,0 +1,23 @@
+package audio.soniqo.speech
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpeechPipelineEventMappingTest {
+
+    @Test
+    fun `response done preserves native tts duration`() {
+        val event = nativeEventToSpeechEvent(
+            type = 8,
+            text = null,
+            audio = null,
+            confidence = 0f,
+            sttMs = 0f,
+            ttsMs = 2035f,
+        )
+
+        assertTrue(event is SpeechEvent.ResponseDone)
+        assertEquals(2035f, (event as SpeechEvent.ResponseDone).ttsMs, 0.001f)
+    }
+}


### PR DESCRIPTION
## Summary
- carry native TTS generation duration on `SpeechEvent.ResponseDone`
- map JNI event type 8 through a testable Kotlin event conversion helper
- update the demo to display TTS timing from `ResponseDone` instead of audio deltas
- add a JVM regression test for the dropped timing path

## Root cause
`speech-core` already computes `tts_duration_ms` on `ResponseDone`, and the JNI bridge forwards it. The Android SDK dropped the value because `ResponseDone` was a singleton object, so the demo kept reading timing from `ResponseAudioDelta`, where final TTS duration is not populated.

## Impact
Consumers using `is SpeechEvent.ResponseDone` continue to work and can now read `event.ttsMs`. Code that referenced `SpeechEvent.ResponseDone` as a singleton value will need to match the data class form.

Fixes #34

## Test plan
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew :sdk:test`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew :app:assembleDebug`