### PR TITLE
fix: avoid dictation startup ANR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 build/
 *.iml
 .idea/
+.vscode/
 local.properties
 
 # ONNX Runtime (downloaded by setup.sh)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "disabled"
-}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,10 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
 }
 
 dependencies {
@@ -58,4 +62,8 @@ dependencies {
     implementation("androidx.activity:activity-ktx:1.9.0")
     implementation("androidx.work:work-runtime-ktx:2.11.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.robolectric:robolectric:4.13")
+    testImplementation("androidx.test:core:1.6.1")
 }

--- a/app/src/main/kotlin/audio/soniqo/speech/demo/DictationActivity.kt
+++ b/app/src/main/kotlin/audio/soniqo/speech/demo/DictationActivity.kt
@@ -12,6 +12,7 @@ import android.media.AudioFormat
 import android.media.AudioRecord
 import android.media.MediaRecorder
 import android.os.Bundle
+import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.widget.LinearLayout
@@ -30,7 +31,10 @@ import audio.soniqo.speech.ModelPrecision
 import audio.soniqo.speech.SpeechConfig
 import audio.soniqo.speech.SpeechEvent
 import audio.soniqo.speech.SpeechPipeline
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -41,10 +45,11 @@ import kotlinx.coroutines.withContext
  */
 class DictationActivity : ComponentActivity() {
 
-    private var pipeline: SpeechPipeline? = null
+    @Volatile private var pipeline: SpeechPipeline? = null
     private var audioRecord: AudioRecord? = null
+    private var micJob: Job? = null
     @Volatile private var recording = false
-    private var pipelineStarted = false
+    @Volatile private var pipelineStarted = false
     private var observingDownload = false
 
     private lateinit var statusView: TextView
@@ -57,6 +62,10 @@ class DictationActivity : ComponentActivity() {
 
     private val transcript = StringBuilder()
     private var partialText = ""
+
+    internal var pipelineFactory: (SpeechConfig) -> SpeechPipeline = { config ->
+        SpeechPipeline(config)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -177,6 +186,10 @@ class DictationActivity : ComponentActivity() {
     // Pipeline
     // ---------------------------------------------------------------------------
 
+    private companion object {
+        private const val TAG = "DictationActivity"
+    }
+
     private fun loadPipeline() {
         statusView.text = "initializing..."
 
@@ -230,8 +243,12 @@ class DictationActivity : ComponentActivity() {
     }
 
     private fun initPipeline(modelDir: String) {
-        lifecycleScope.launch {
+        lifecycleScope.launch(Dispatchers.Default) {
             try {
+                withContext(Dispatchers.Main) {
+                    statusView.text = "loading models..."
+                }
+
                 val config = SpeechConfig(
                     modelDir = modelDir,
                     useNnapi = false,
@@ -240,7 +257,7 @@ class DictationActivity : ComponentActivity() {
                     partialTranscriptionInterval = 0.5f,
                 )
 
-                val p = SpeechPipeline(config)
+                val p = pipelineFactory(config)
                 pipeline = p
 
                 launch {
@@ -304,9 +321,12 @@ class DictationActivity : ComponentActivity() {
                     updateDisplay()
                 }
 
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
+                if (e is CancellationException) throw e
+                Log.e(TAG, "Dictation pipeline init failed", e)
+                pipelineStarted = false
                 withContext(Dispatchers.Main) {
-                    statusView.text = "error: ${e.message}"
+                    statusView.text = "error: ${e.message ?: e.javaClass.simpleName}"
                 }
             }
         }
@@ -358,23 +378,40 @@ class DictationActivity : ComponentActivity() {
         micButton.setTextColor(Color.parseColor("#4CAF50"))
         statusView.text = "listening..."
 
-        lifecycleScope.launch(Dispatchers.IO) {
+        micJob?.cancel()
+        micJob = lifecycleScope.launch(Dispatchers.IO) {
             val buf = FloatArray(512)
-            while (recording) {
+            while (recording && isActive) {
                 val read = try {
-                    audioRecord?.read(buf, 0, buf.size, AudioRecord.READ_BLOCKING) ?: -1
+                    record.read(buf, 0, buf.size, AudioRecord.READ_BLOCKING)
                 } catch (_: IllegalStateException) {
                     break  // AudioRecord released mid-read
                 }
-                if (read > 0) pipeline?.pushAudio(buf)
+                if (read > 0) {
+                    val samples = if (read == buf.size) buf else buf.copyOf(read)
+                    val p = pipeline ?: continue
+                    try {
+                        p.pushAudio(samples)
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Ignoring mic frame after pipeline shutdown", e)
+                        break
+                    }
+                } else if (read < 0) {
+                    Log.w(TAG, "AudioRecord.read returned $read")
+                    break
+                }
             }
         }
     }
 
     private fun stopMicrophone() {
         recording = false
-        audioRecord?.stop()
-        audioRecord?.release()
+        micJob?.cancel()
+        micJob = null
+        audioRecord?.let { record ->
+            try { record.stop() } catch (_: Exception) {}
+            record.release()
+        }
         audioRecord = null
     }
 
@@ -429,8 +466,11 @@ class DictationActivity : ComponentActivity() {
 
     override fun onDestroy() {
         stopMicrophone()
-        pipeline?.stop()
-        pipeline?.close()
+        pipeline?.let { p ->
+            try { p.stop() } catch (_: Exception) {}
+            try { p.close() } catch (_: Exception) {}
+        }
+        pipeline = null
         super.onDestroy()
     }
 }

--- a/app/src/test/kotlin/audio/soniqo/speech/demo/DictationActivityTest.kt
+++ b/app/src/test/kotlin/audio/soniqo/speech/demo/DictationActivityTest.kt
@@ -1,0 +1,77 @@
+package audio.soniqo.speech.demo
+
+import android.os.Looper
+import audio.soniqo.speech.PipelineState
+import audio.soniqo.speech.SpeechConfig
+import audio.soniqo.speech.SpeechEvent
+import audio.soniqo.speech.SpeechPipeline
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class DictationActivityTest {
+
+    @Test
+    fun initPipeline_loadsNativePipelineOffMainThread() {
+        val controller = Robolectric.buildActivity(DictationActivity::class.java)
+        val activity = controller.get()
+        callPrivate(activity, "buildUI")
+
+        val factoryCalled = CountDownLatch(1)
+        val ranOnMainThread = AtomicBoolean(true)
+        activity.pipelineFactory = { _: SpeechConfig ->
+            ranOnMainThread.set(Looper.myLooper() == Looper.getMainLooper())
+            factoryCalled.countDown()
+            FakePipeline()
+        }
+
+        callPrivate(activity, "initPipeline", "/unused/models")
+        assertTrue("pipeline factory was not called", await(factoryCalled))
+        assertFalse(
+            "DictationActivity must not load SpeechPipeline on the UI thread",
+            ranOnMainThread.get(),
+        )
+
+        controller.destroy()
+    }
+
+    private fun callPrivate(target: Any, name: String, vararg args: Any) {
+        val types = args.map { it.javaClass }.toTypedArray()
+        val method = target.javaClass.getDeclaredMethod(name, *types)
+        method.isAccessible = true
+        method.invoke(target, *args)
+    }
+
+    private fun await(latch: CountDownLatch): Boolean {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (latch.count > 0 && System.nanoTime() < deadline) {
+            shadowOf(Looper.getMainLooper()).idle()
+            Thread.sleep(10)
+        }
+        return latch.await(0, TimeUnit.MILLISECONDS)
+    }
+
+    private class FakePipeline : SpeechPipeline {
+        override val events: SharedFlow<SpeechEvent> = MutableSharedFlow()
+        override val state: PipelineState = PipelineState.Idle
+        override val nnapiFallbackReason: String? = null
+
+        override fun start() = Unit
+        override fun stop() = Unit
+        override fun pushAudio(samples: FloatArray) = Unit
+        override fun resumeListening() = Unit
+        override fun close() = Unit
+    }
+}


### PR DESCRIPTION
Summary
- Move Dictation pipeline/model initialization off the Android main thread to avoid startup ANRs.
- Add a Robolectric regression test that fails if Dictation creates `SpeechPipeline` on the main looper.
- Ignore `.vscode/` and remove the tracked VS Code settings file so user-local paths do not appear in git diffs.

Root cause
- `DictationActivity.initPipeline()` created the native `SpeechPipeline` from a default `lifecycleScope.launch`, which runs on the main thread. Loading native speech models can block long enough for Android to show the app-not-responding/crash dialog.

Test plan
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew :app:testDebugUnitTest :app:assembleDebug :sdk:test`

Related issue
- Fixes #39
