### PR TITLE
Add Android TTS engine and low-memory defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 On-device speech SDK for Android, powered by [ONNX Runtime](https://onnxruntime.ai) and [speech-core](https://github.com/soniqo/speech-core).
 
-Speech recognition (114 languages), text-to-speech (8 languages), voice activity detection, and noise cancellation — all running locally. No cloud APIs, no data leaves the device.
+Low-memory streaming speech recognition (25 languages by default, 114-language TDT optional), text-to-speech, voice activity detection, and noise cancellation — all running locally. No cloud APIs, no data leaves the device.
 
 **[Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Models](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple counterpart) · **[speech-core](https://github.com/soniqo/speech-core)** (pipeline engine + Linux/embedded build)
 
@@ -14,16 +14,22 @@ This repo is the **Android packaging**: Kotlin SDK, JNI bridge, demo app. The C+
 
 ## Models
 
-| Model | Task | INT8 Size | Languages |
-| --- | --- | --- | --- |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Speech recognition | 891 MB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Text-to-speech | 330 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Text-to-speech (LiteRT, flow-matching, G2P-free, 44.1 kHz) | ~380 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Voice activity detection | 2 MB | Any |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Noise cancellation | ~8 MB | Any |
-| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | On-device LLM — structured function / tool calls | 283 MB | EN-tuned |
+| Model | Task | Download | Peak memory | Languages |
+| --- | --- | --- | --- | --- |
+| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | Streaming STT + end-of-utterance (default) | 153 MB | 232 MB | 25 |
+| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Broad-coverage STT (optional) | 891 MB | ~1.1-1.3 GB | 114 |
+| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Text-to-speech (default) | 330 MB | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Text-to-speech (LiteRT, flow-matching, G2P-free, 44.1 kHz) | ~380 MB | 832 MB | 31 |
+| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Voice activity detection | 2 MB | <10 MB | Any |
+| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Noise cancellation | ~8 MB | not loaded by default | Any |
+| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | On-device LLM — structured function / tool calls | 283 MB | app-runtime dependent | EN-tuned |
 
 Models are downloaded automatically on first launch via `ModelManager.ensureModels()`.
+
+`SpeechConfig()` defaults to `SttModel.PARAKEET_EOU` and `TtsModel.KOKORO`
+to keep the demo and system recognizer on the low-memory Android path. Use
+`SpeechConfig(sttModel = SttModel.PARAKEET)` only when you need the larger
+114-language TDT model.
 
 **Supertonic-3** is an opt-in higher-quality multilingual TTS — select it with
 `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (requires the LiteRT backend). The host runs its four
@@ -39,7 +45,7 @@ formatting and call parsing. The model bundle ships as a single 283 MB
 
 ## Try the demo
 
-Download the [signed APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) and install on any arm64 Android device (8+). Models (~1.2 GB) download automatically on first launch.
+Download the [signed APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) and install on any arm64 Android device (8+). The default low-memory model bundle (~500 MB) downloads automatically on first launch.
 
 ## Add dependency
 
@@ -193,7 +199,7 @@ framework callback — useful for confirming the binder round-trip without
 needing logcat.
 
 The service implements `onCheckRecognitionSupport` (API 33+) returning the
-27 BCP-47 languages Parakeet TDT v3 covers, marked
+25 BCP-47 languages Parakeet-EOU covers, marked
 `installedOnDeviceLanguage` once models are present (or
 `pendingOnDeviceLanguage` while they're downloading). Audio focus is
 acquired with `AUDIOFOCUS_GAIN_TRANSIENT` for the duration of a session.
@@ -203,15 +209,47 @@ recognizers and skip the system default. Apps that explicitly call the
 framework `SpeechRecognizer` API (or build their own UI on top of it) are
 the ones that flow through your service.
 
+## System text-to-speech (`TextToSpeechService`)
+
+The demo app also exposes
+`audio.soniqo.speech.service.SpeechTextToSpeechService`, so Android can select
+the app under Settings → System → Languages & input → Text-to-speech output.
+This path uses `ModelManager.ensureTtsModels()` and a separate `models_tts/`
+cache, so framework TTS downloads Kokoro assets only instead of the full
+VAD/STT/enhancer pipeline bundle.
+
+To expose the engine from another app, declare the service:
+
+```xml
+<service
+    android:name="audio.soniqo.speech.service.SpeechTextToSpeechService"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.TTS_SERVICE" />
+    </intent-filter>
+    <meta-data
+        android:name="android.speech.tts"
+        android:resource="@xml/tts_engine" />
+</service>
+```
+
+Add `app/src/main/res/xml/tts_engine.xml`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<tts-engine xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
 ## Performance
 
-Measured on Android emulator (arm64-v8a, no NNAPI). Real hardware is significantly faster.
+Measured on Galaxy S23 Android, CPU only unless noted. Lower RTF is faster.
 
-| Model | Task | Audio | Inference | RTF |
+| Model | Task | RTF | Latency | Peak memory |
 | --- | --- | --- | --- | --- |
-| Parakeet TDT v3 | STT | 1.5s | 175ms | 0.12 |
-| Kokoro 82M | TTS | 1.9s output | 1,075ms | 0.58 |
-| Silero VAD v5 | VAD | 32ms chunk | <1ms | <0.01 |
+| Parakeet-EOU 120M ONNX INT8 | Streaming STT + EOU | 0.21 | streaming partials | 232 MB |
+| Kokoro 82M ONNX FP32 | TTS | 0.53 | sentence-level | 640 MB |
+| Supertonic-3 LiteRT | TTS | 0.34 | ~1.1s TTFA | 832 MB |
+| Silero VAD v5 | VAD | <0.01 | <1ms per 32ms chunk | <10 MB |
 
 ## Pipeline
 

--- a/README_de.md
+++ b/README_de.md
@@ -4,7 +4,7 @@
 
 On-Device Speech-SDK für Android, basierend auf [ONNX Runtime](https://onnxruntime.ai) und [speech-core](https://github.com/soniqo/speech-core).
 
-Spracherkennung (114 Sprachen), Text-to-Speech (8 Sprachen), Sprachaktivitätserkennung und Rauschunterdrückung — alles lokal ausgeführt. Keine Cloud-APIs, keine Daten verlassen das Gerät.
+Speicherarme Streaming-Spracherkennung (standardmäßig 25 Sprachen, optionales TDT mit 114 Sprachen), Text-to-Speech, Sprachaktivitätserkennung und Rauschunterdrückung — alles lokal ausgeführt. Keine Cloud-APIs, keine Daten verlassen das Gerät.
 
 **[Demo-APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modelle](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple-Pendant) · **[speech-core](https://github.com/soniqo/speech-core)** (Pipeline-Engine + Linux/Embedded-Build)
 
@@ -14,21 +14,25 @@ Dieses Repo ist das **Android-Packaging**: Kotlin-SDK, JNI-Bridge, Demo-App. Die
 
 ## Modelle
 
-| Modell | Aufgabe | INT8-Größe | Sprachen |
-| --- | --- | --- | --- |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Spracherkennung | 891 MB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Text-to-Speech | 330 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Text-to-Speech (LiteRT, Flow-Matching, G2P-frei, 44,1 kHz) | ~380 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Sprachaktivitätserkennung | 2 MB | Beliebig |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Rauschunterdrückung | ~8 MB | Beliebig |
+| Modell | Aufgabe | Download | Spitzen-Speicher | Sprachen |
+| --- | --- | --- | --- | --- |
+| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | Streaming-STT + EOU (Standard) | 153 MB | 232 MB | 25 |
+| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Breite STT-Abdeckung (optional) | 891 MB | ~1,1-1,3 GB | 114 |
+| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Text-to-Speech (Standard) | 330 MB | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Text-to-Speech (LiteRT, Flow-Matching, G2P-frei, 44,1 kHz) | ~380 MB | 832 MB | 31 |
+| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Sprachaktivitätserkennung | 2 MB | <10 MB | Beliebig |
+| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Rauschunterdrückung | ~8 MB | standardmäßig nicht geladen | Beliebig |
+| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | On-Device-LLM — strukturierte Funktions-/Tool-Aufrufe | 283 MB | abhängig vom App-Runtime | EN-getunt |
 
 Modelle werden beim ersten Start automatisch über `ModelManager.ensureModels()` heruntergeladen.
+
+`SpeechConfig()` verwendet standardmäßig `SttModel.PARAKEET_EOU` und `TtsModel.KOKORO`, damit Demo und Systemerkennung den speicherarmen Android-Pfad nutzen. Verwende `SpeechConfig(sttModel = SttModel.PARAKEET)` nur, wenn das größere TDT-Modell mit 114 Sprachen benötigt wird.
 
 **Supertonic-3** ist ein optionales, höherwertiges mehrsprachiges TTS — wähle es mit `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` aus (erfordert das LiteRT-Backend). Der Host führt seine vier nicht-autoregressiven Flow-Matching-Graphen mit 44,1 kHz auf dem Gerät aus; das Front-End ist G2P-frei (NFKD + Unicode-Index — kein Phonemizer), sodass alle 31 Sprachen über einen einzigen Pfad laufen.
 
 ## Demo ausprobieren
 
-Lade das [signierte APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) herunter und installiere es auf einem beliebigen arm64-Android-Gerät (8+). Modelle (~1,2 GB) werden beim ersten Start automatisch heruntergeladen.
+Lade das [signierte APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) herunter und installiere es auf einem beliebigen arm64-Android-Gerät (8+). Das standardmäßige speicherarme Modellpaket (~500 MB) wird beim ersten Start automatisch heruntergeladen.
 
 ## Abhängigkeit hinzufügen
 
@@ -130,19 +134,46 @@ adb shell settings put secure voice_recognition_service \
 
 **4. Verifiziere**, indem du den *Recognizer test*-Bildschirm der Demo-App ausführst, der `SpeechRecognizer.createSpeechRecognizer(ctx)` (ohne Komponente) aufruft und jeden Framework-Callback protokolliert — nützlich, um den Binder-Roundtrip ohne logcat zu bestätigen.
 
-Der Dienst implementiert `onCheckRecognitionSupport` (API 33+) und gibt die 27 BCP-47-Sprachen zurück, die Parakeet TDT v3 abdeckt, markiert als `installedOnDeviceLanguage`, sobald Modelle vorhanden sind (oder `pendingOnDeviceLanguage`, während sie heruntergeladen werden). Während einer Sitzung wird Audiofokus mit `AUDIOFOCUS_GAIN_TRANSIENT` angefordert.
+Der Dienst implementiert `onCheckRecognitionSupport` (API 33+) und gibt die 25 BCP-47-Sprachen zurück, die Parakeet-EOU abdeckt, markiert als `installedOnDeviceLanguage`, sobald Modelle vorhanden sind (oder `pendingOnDeviceLanguage`, während sie heruntergeladen werden). Während einer Sitzung wird Audiofokus mit `AUDIOFOCUS_GAIN_TRANSIENT` angefordert.
 
 **Einschränkung:** Gboard, Samsung Keyboard und Google Assistant bringen eigene Erkenner mit und überspringen den System-Standard. Apps, die die Framework-`SpeechRecognizer`-API explizit aufrufen (oder eine eigene UI darauf aufbauen), gehen über deinen Dienst.
 
+## Systemweite Sprachausgabe (`TextToSpeechService`)
+
+Die Demo-App stellt außerdem `audio.soniqo.speech.service.SpeechTextToSpeechService` bereit, sodass Android die App unter Einstellungen → System → Sprachen & Eingabe → Text-in-Sprache-Ausgabe auswählen kann. Dieser Pfad verwendet `ModelManager.ensureTtsModels()` und einen separaten `models_tts/`-Cache, sodass Framework-TTS nur Kokoro-Assets lädt statt des vollständigen VAD/STT/Enhancer-Pipeline-Bundles.
+
+Um die Engine aus einer anderen App bereitzustellen, deklariere den Dienst:
+
+```xml
+<service
+    android:name="audio.soniqo.speech.service.SpeechTextToSpeechService"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.TTS_SERVICE" />
+    </intent-filter>
+    <meta-data
+        android:name="android.speech.tts"
+        android:resource="@xml/tts_engine" />
+</service>
+```
+
+Füge `app/src/main/res/xml/tts_engine.xml` hinzu:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<tts-engine xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
 ## Leistung
 
-Gemessen auf einem Android-Emulator (arm64-v8a, ohne NNAPI). Echte Hardware ist deutlich schneller.
+Gemessen auf Galaxy S23 Android, sofern nicht anders angegeben nur CPU. Niedrigeres RTF ist schneller.
 
-| Modell | Aufgabe | Audio | Inferenz | RTF |
+| Modell | Aufgabe | RTF | Latenz | Spitzen-Speicher |
 | --- | --- | --- | --- | --- |
-| Parakeet TDT v3 | STT | 1,5s | 175ms | 0,12 |
-| Kokoro 82M | TTS | 1,9s Ausgabe | 1.075ms | 0,58 |
-| Silero VAD v5 | VAD | 32ms-Block | <1ms | <0,01 |
+| Parakeet-EOU 120M ONNX INT8 | Streaming-STT + EOU | 0,21 | Streaming-Teilergebnisse | 232 MB |
+| Kokoro 82M ONNX FP32 | TTS | 0,53 | satzweise | 640 MB |
+| Supertonic-3 LiteRT | TTS | 0,34 | ~1,1s TTFA | 832 MB |
+| Silero VAD v5 | VAD | <0,01 | <1ms pro 32ms-Block | <10 MB |
 
 ## Pipeline
 

--- a/README_es.md
+++ b/README_es.md
@@ -4,7 +4,7 @@
 
 SDK de voz en el dispositivo para Android, impulsado por [ONNX Runtime](https://onnxruntime.ai) y [speech-core](https://github.com/soniqo/speech-core).
 
-Reconocimiento de voz (114 idiomas), texto a voz (8 idiomas), detección de actividad de voz y cancelación de ruido — todo ejecutándose localmente. Sin APIs en la nube, ningún dato sale del dispositivo.
+Reconocimiento de voz en streaming de baja memoria (25 idiomas por defecto; TDT de 114 idiomas opcional), texto a voz, detección de actividad de voz y cancelación de ruido — todo ejecutándose localmente. Sin APIs en la nube, ningún dato sale del dispositivo.
 
 **[APK de demostración](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modelos](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (contraparte Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (motor de pipeline + compilación Linux/embebido)
 
@@ -14,21 +14,25 @@ Este repositorio es el **empaquetado para Android**: SDK de Kotlin, puente JNI, 
 
 ## Modelos
 
-| Modelo | Tarea | Tamaño INT8 | Idiomas |
-| --- | --- | --- | --- |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Reconocimiento de voz | 891 MB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Texto a voz | 330 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Texto a voz (LiteRT, flow-matching, G2P-free, 44.1 kHz) | ~380 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Detección de actividad de voz | 2 MB | Cualquiera |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Cancelación de ruido | ~8 MB | Cualquiera |
+| Modelo | Tarea | Descarga | Pico de memoria | Idiomas |
+| --- | --- | --- | --- | --- |
+| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | STT en streaming + EOU (por defecto) | 153 MB | 232 MB | 25 |
+| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | STT de cobertura amplia (opcional) | 891 MB | ~1.1-1.3 GB | 114 |
+| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Texto a voz (por defecto) | 330 MB | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Texto a voz (LiteRT, flow-matching, G2P-free, 44.1 kHz) | ~380 MB | 832 MB | 31 |
+| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Detección de actividad de voz | 2 MB | <10 MB | Cualquiera |
+| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Cancelación de ruido | ~8 MB | no se carga por defecto | Cualquiera |
+| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | LLM en dispositivo — llamadas estructuradas a funciones / herramientas | 283 MB | depende del runtime de la app | Ajustado para EN |
 
 Los modelos se descargan automáticamente al primer inicio vía `ModelManager.ensureModels()`.
+
+`SpeechConfig()` usa `SttModel.PARAKEET_EOU` y `TtsModel.KOKORO` por defecto para mantener la demo y el reconocedor del sistema en la ruta Android de baja memoria. Usa `SpeechConfig(sttModel = SttModel.PARAKEET)` solo si necesitas el modelo TDT más grande de 114 idiomas.
 
 **Supertonic-3** es un TTS multilingüe opcional de mayor calidad — selecciónalo con `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (requiere el backend LiteRT). El host ejecuta sus cuatro grafos de flow-matching no autorregresivos en el dispositivo a 44.1 kHz; el front-end es G2P-free (NFKD + índice Unicode — sin fonemizador), por lo que los 31 idiomas pasan por una sola ruta.
 
 ## Prueba la demo
 
-Descarga el [APK firmado](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) e instálalo en cualquier dispositivo Android arm64 (8+). Los modelos (~1.2 GB) se descargan automáticamente en el primer inicio.
+Descarga el [APK firmado](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) e instálalo en cualquier dispositivo Android arm64 (8+). El paquete de modelos de baja memoria por defecto (~500 MB) se descarga automáticamente en el primer inicio.
 
 ## Añadir dependencia
 
@@ -142,7 +146,7 @@ registra cada callback del framework — útil para confirmar el round-trip del
 binder sin necesitar logcat.
 
 El servicio implementa `onCheckRecognitionSupport` (API 33+) devolviendo los
-27 idiomas BCP-47 que cubre Parakeet TDT v3, marcados como
+25 idiomas BCP-47 que cubre Parakeet-EOU, marcados como
 `installedOnDeviceLanguage` cuando los modelos están presentes (o
 `pendingOnDeviceLanguage` mientras se descargan). Se adquiere foco de audio
 con `AUDIOFOCUS_GAIN_TRANSIENT` durante la sesión.
@@ -152,15 +156,47 @@ propios reconocedores y se saltan el predeterminado del sistema. Las apps
 que llaman explícitamente a la API `SpeechRecognizer` del framework (o
 construyen su propia UI sobre ella) son las que pasan por tu servicio.
 
+## Texto a voz del sistema (`TextToSpeechService`)
+
+La app demo también expone
+`audio.soniqo.speech.service.SpeechTextToSpeechService`, por lo que Android
+puede seleccionar la app en Ajustes → Sistema → Idiomas e introducción →
+Salida de texto a voz. Esta ruta usa `ModelManager.ensureTtsModels()` y una
+caché separada `models_tts/`, de modo que el TTS del framework descarga solo
+los recursos de Kokoro en vez del paquete completo de VAD/STT/enhancer.
+
+Para exponer el motor desde otra app, declara el servicio:
+
+```xml
+<service
+    android:name="audio.soniqo.speech.service.SpeechTextToSpeechService"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.TTS_SERVICE" />
+    </intent-filter>
+    <meta-data
+        android:name="android.speech.tts"
+        android:resource="@xml/tts_engine" />
+</service>
+```
+
+Añade `app/src/main/res/xml/tts_engine.xml`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<tts-engine xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
 ## Rendimiento
 
-Medido en emulador Android (arm64-v8a, sin NNAPI). El hardware real es significativamente más rápido.
+Medido en Galaxy S23 Android, solo CPU salvo indicación. Un RTF menor es más rápido.
 
-| Modelo | Tarea | Audio | Inferencia | RTF |
+| Modelo | Tarea | RTF | Latencia | Pico de memoria |
 | --- | --- | --- | --- | --- |
-| Parakeet TDT v3 | STT | 1.5s | 175ms | 0.12 |
-| Kokoro 82M | TTS | 1.9s salida | 1,075ms | 0.58 |
-| Silero VAD v5 | VAD | bloque 32ms | <1ms | <0.01 |
+| Parakeet-EOU 120M ONNX INT8 | STT en streaming + EOU | 0.21 | parciales en streaming | 232 MB |
+| Kokoro 82M ONNX FP32 | TTS | 0.53 | por frase | 640 MB |
+| Supertonic-3 LiteRT | TTS | 0.34 | ~1.1s TTFA | 832 MB |
+| Silero VAD v5 | VAD | <0.01 | <1ms por bloque de 32ms | <10 MB |
 
 ## Pipeline
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -4,7 +4,7 @@
 
 SDK vocal sur appareil pour Android, propulsé par [ONNX Runtime](https://onnxruntime.ai) et [speech-core](https://github.com/soniqo/speech-core).
 
-Reconnaissance vocale (114 langues), synthèse vocale (8 langues), détection d'activité vocale et suppression de bruit — tout fonctionne en local. Aucune API cloud, aucune donnée ne quitte l'appareil.
+Reconnaissance vocale en streaming à faible mémoire (25 langues par défaut, TDT 114 langues en option), synthèse vocale, détection d'activité vocale et suppression de bruit — tout fonctionne en local. Aucune API cloud, aucune donnée ne quitte l'appareil.
 
 **[APK de démo](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modèles](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (équivalent Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (moteur de pipeline + build Linux/embarqué)
 
@@ -14,21 +14,25 @@ Ce dépôt fournit le **packaging Android** : SDK Kotlin, pont JNI, application 
 
 ## Modèles
 
-| Modèle | Tâche | Taille INT8 | Langues |
-| --- | --- | --- | --- |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Reconnaissance vocale | 891 Mo | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Synthèse vocale | 330 Mo | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Synthèse vocale (LiteRT, flow-matching, G2P-free, 44,1 kHz) | ~380 Mo | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Détection d'activité vocale | 2 Mo | Toutes |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Suppression de bruit | ~8 Mo | Toutes |
+| Modèle | Tâche | Téléchargement | Mémoire max | Langues |
+| --- | --- | --- | --- | --- |
+| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | STT streaming + EOU (défaut) | 153 Mo | 232 Mo | 25 |
+| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | STT large couverture (optionnel) | 891 Mo | ~1,1-1,3 Go | 114 |
+| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Synthèse vocale (défaut) | 330 Mo | 640 Mo | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Synthèse vocale (LiteRT, flow-matching, G2P-free, 44,1 kHz) | ~380 Mo | 832 Mo | 31 |
+| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Détection d'activité vocale | 2 Mo | <10 Mo | Toutes |
+| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Suppression de bruit | ~8 Mo | non chargé par défaut | Toutes |
+| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | LLM sur appareil — appels structurés de fonctions / outils | 283 Mo | dépend du runtime de l'app | Ajusté EN |
 
 Les modèles sont téléchargés automatiquement au premier lancement via `ModelManager.ensureModels()`.
+
+`SpeechConfig()` utilise `SttModel.PARAKEET_EOU` et `TtsModel.KOKORO` par défaut afin que la démo et le service de reconnaissance système restent sur le chemin Android à faible mémoire. Utilisez `SpeechConfig(sttModel = SttModel.PARAKEET)` uniquement si vous avez besoin du modèle TDT plus grand à 114 langues.
 
 **Supertonic-3** est une synthèse vocale multilingue de meilleure qualité, activable en option — sélectionnez-la avec `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (nécessite le backend LiteRT). L'hôte exécute ses quatre graphes de flow-matching non autorégressifs en local à 44,1 kHz ; le front-end est G2P-free (NFKD + index Unicode — aucun phonémiseur), de sorte que les 31 langues passent par un seul chemin.
 
 ## Essayer la démo
 
-Téléchargez l'[APK signé](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) et installez-le sur n'importe quel appareil Android arm64 (8+). Les modèles (~1,2 Go) sont téléchargés automatiquement au premier lancement.
+Téléchargez l'[APK signé](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) et installez-le sur n'importe quel appareil Android arm64 (8+). Le bundle de modèles faible mémoire par défaut (~500 Mo) est téléchargé automatiquement au premier lancement.
 
 ## Ajouter la dépendance
 
@@ -130,19 +134,46 @@ adb shell settings put secure voice_recognition_service \
 
 **4. Vérifiez** en lançant l'écran *Recognizer test* de l'app de démo, qui appelle `SpeechRecognizer.createSpeechRecognizer(ctx)` (sans composant) et journalise chaque callback du framework — utile pour confirmer l'aller-retour binder sans avoir besoin de logcat.
 
-Le service implémente `onCheckRecognitionSupport` (API 33+) renvoyant les 27 langues BCP-47 couvertes par Parakeet TDT v3, marquées `installedOnDeviceLanguage` lorsque les modèles sont présents (ou `pendingOnDeviceLanguage` pendant leur téléchargement). Le focus audio est acquis avec `AUDIOFOCUS_GAIN_TRANSIENT` pendant la durée d'une session.
+Le service implémente `onCheckRecognitionSupport` (API 33+) renvoyant les 25 langues BCP-47 couvertes par Parakeet-EOU, marquées `installedOnDeviceLanguage` lorsque les modèles sont présents (ou `pendingOnDeviceLanguage` pendant leur téléchargement). Le focus audio est acquis avec `AUDIOFOCUS_GAIN_TRANSIENT` pendant la durée d'une session.
 
 **Limitation :** Gboard, Samsung Keyboard et Google Assistant intègrent leurs propres reconnaisseurs et contournent la valeur par défaut système. Les applications qui appellent explicitement l'API `SpeechRecognizer` du framework (ou construisent leur propre UI par-dessus) sont celles qui passent par votre service.
 
+## Synthèse vocale système (`TextToSpeechService`)
+
+L'app de démo expose aussi `audio.soniqo.speech.service.SpeechTextToSpeechService`, ce qui permet à Android de sélectionner l'app dans Paramètres → Système → Langues et saisie → Sortie de synthèse vocale. Ce chemin utilise `ModelManager.ensureTtsModels()` et un cache séparé `models_tts/`, donc le TTS du framework ne télécharge que les ressources Kokoro au lieu du bundle complet VAD/STT/enhancer.
+
+Pour exposer le moteur depuis une autre app, déclarez le service :
+
+```xml
+<service
+    android:name="audio.soniqo.speech.service.SpeechTextToSpeechService"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.TTS_SERVICE" />
+    </intent-filter>
+    <meta-data
+        android:name="android.speech.tts"
+        android:resource="@xml/tts_engine" />
+</service>
+```
+
+Ajoutez `app/src/main/res/xml/tts_engine.xml` :
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<tts-engine xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
 ## Performance
 
-Mesuré sur émulateur Android (arm64-v8a, sans NNAPI). Le matériel réel est nettement plus rapide.
+Mesuré sur Galaxy S23 Android, CPU seul sauf indication. Un RTF plus bas est plus rapide.
 
-| Modèle | Tâche | Audio | Inférence | RTF |
+| Modèle | Tâche | RTF | Latence | Mémoire max |
 | --- | --- | --- | --- | --- |
-| Parakeet TDT v3 | STT | 1,5 s | 175 ms | 0,12 |
-| Kokoro 82M | TTS | 1,9 s en sortie | 1 075 ms | 0,58 |
-| Silero VAD v5 | VAD | bloc 32 ms | <1 ms | <0,01 |
+| Parakeet-EOU 120M ONNX INT8 | STT streaming + EOU | 0,21 | partiels streaming | 232 Mo |
+| Kokoro 82M ONNX FP32 | TTS | 0,53 | par phrase | 640 Mo |
+| Supertonic-3 LiteRT | TTS | 0,34 | ~1,1 s TTFA | 832 Mo |
+| Silero VAD v5 | VAD | <0,01 | <1 ms par bloc 32 ms | <10 Mo |
 
 ## Pipeline
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -4,7 +4,7 @@
 
 Android के लिए ऑन-डिवाइस स्पीच SDK, [ONNX Runtime](https://onnxruntime.ai) और [speech-core](https://github.com/soniqo/speech-core) द्वारा संचालित।
 
-स्पीच रिकग्निशन (114 भाषाएँ), टेक्स्ट-टू-स्पीच (8 भाषाएँ), वॉयस एक्टिविटी डिटेक्शन, और शोर रद्दीकरण — सभी स्थानीय रूप से चलते हैं। कोई क्लाउड API नहीं, कोई डेटा डिवाइस से बाहर नहीं जाता।
+कम-मेमोरी स्ट्रीमिंग स्पीच रिकग्निशन (डिफ़ॉल्ट 25 भाषाएँ, 114-भाषा TDT वैकल्पिक), टेक्स्ट-टू-स्पीच, वॉयस एक्टिविटी डिटेक्शन, और शोर रद्दीकरण — सभी स्थानीय रूप से चलते हैं। कोई क्लाउड API नहीं, कोई डेटा डिवाइस से बाहर नहीं जाता।
 
 **[डेमो APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[मॉडल](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple समकक्ष) · **[speech-core](https://github.com/soniqo/speech-core)** (पाइपलाइन इंजन + Linux/एम्बेडेड बिल्ड)
 
@@ -14,21 +14,25 @@ Android के लिए ऑन-डिवाइस स्पीच SDK, [ONNX Ru
 
 ## मॉडल
 
-| मॉडल | कार्य | INT8 आकार | भाषाएँ |
-| --- | --- | --- | --- |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | स्पीच रिकग्निशन | 891 MB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | टेक्स्ट-टू-स्पीच | 330 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | टेक्स्ट-टू-स्पीच (LiteRT, फ़्लो-मैचिंग, G2P-free, 44.1 kHz) | ~380 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | वॉयस एक्टिविटी डिटेक्शन | 2 MB | कोई भी |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | शोर रद्दीकरण | ~8 MB | कोई भी |
+| मॉडल | कार्य | डाउनलोड | पीक मेमोरी | भाषाएँ |
+| --- | --- | --- | --- | --- |
+| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | स्ट्रीमिंग STT + EOU (डिफ़ॉल्ट) | 153 MB | 232 MB | 25 |
+| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | व्यापक STT (वैकल्पिक) | 891 MB | ~1.1-1.3 GB | 114 |
+| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | टेक्स्ट-टू-स्पीच (डिफ़ॉल्ट) | 330 MB | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | टेक्स्ट-टू-स्पीच (LiteRT, फ़्लो-मैचिंग, G2P-free, 44.1 kHz) | ~380 MB | 832 MB | 31 |
+| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | वॉयस एक्टिविटी डिटेक्शन | 2 MB | <10 MB | कोई भी |
+| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | शोर रद्दीकरण | ~8 MB | डिफ़ॉल्ट रूप से लोड नहीं | कोई भी |
+| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | ऑन-डिवाइस LLM — संरचित फ़ंक्शन / टूल कॉल | 283 MB | ऐप runtime पर निर्भर | EN-tuned |
 
 मॉडल पहले लॉन्च पर `ModelManager.ensureModels()` के माध्यम से स्वचालित रूप से डाउनलोड होते हैं।
+
+`SpeechConfig()` डिफ़ॉल्ट रूप से `SttModel.PARAKEET_EOU` और `TtsModel.KOKORO` इस्तेमाल करता है, ताकि डेमो और सिस्टम रिकग्नाइज़र कम-मेमोरी Android पथ पर रहें। बड़े 114-भाषा TDT मॉडल की ज़रूरत होने पर ही `SpeechConfig(sttModel = SttModel.PARAKEET)` इस्तेमाल करें।
 
 **Supertonic-3** एक ऑप्ट-इन उच्च-गुणवत्ता वाला बहुभाषी TTS है — इसे `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` के साथ चुनें (LiteRT बैकएंड आवश्यक)। होस्ट इसके चार नॉन-ऑटोरिग्रेसिव फ़्लो-मैचिंग ग्राफ़ ऑन-डिवाइस 44.1 kHz पर चलाता है; फ़्रंट-एंड G2P-free है (NFKD + Unicode इंडेक्स — कोई फ़ोनेमाइज़र नहीं), इसलिए सभी 31 भाषाएँ एक ही पथ से होकर गुजरती हैं।
 
 ## डेमो आज़माएँ
 
-[हस्ताक्षरित APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) डाउनलोड करें और किसी भी arm64 Android डिवाइस (8+) पर इंस्टॉल करें। मॉडल (~1.2 GB) पहले लॉन्च पर स्वचालित रूप से डाउनलोड होते हैं।
+[हस्ताक्षरित APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) डाउनलोड करें और किसी भी arm64 Android डिवाइस (8+) पर इंस्टॉल करें। डिफ़ॉल्ट कम-मेमोरी मॉडल बंडल (~500 MB) पहले लॉन्च पर स्वचालित रूप से डाउनलोड होता है।
 
 ## निर्भरता जोड़ें
 
@@ -130,19 +134,48 @@ adb shell settings put secure voice_recognition_service \
 
 **4. सत्यापित करें** डेमो ऐप का *Recognizer test* स्क्रीन चलाकर, जो `SpeechRecognizer.createSpeechRecognizer(ctx)` (बिना कंपोनेंट के) कॉल करता है और हर फ्रेमवर्क कॉलबैक को लॉग करता है — logcat के बिना binder राउंड-ट्रिप की पुष्टि के लिए उपयोगी।
 
-सेवा `onCheckRecognitionSupport` (API 33+) को लागू करती है जो Parakeet TDT v3 द्वारा कवर की गई 27 BCP-47 भाषाओं को लौटाती है, मॉडल मौजूद होने पर `installedOnDeviceLanguage` के रूप में चिह्नित (या डाउनलोड के दौरान `pendingOnDeviceLanguage`)। सत्र की अवधि के लिए `AUDIOFOCUS_GAIN_TRANSIENT` के साथ ऑडियो फोकस प्राप्त किया जाता है।
+सेवा `onCheckRecognitionSupport` (API 33+) को लागू करती है जो Parakeet-EOU द्वारा कवर की गई 25 BCP-47 भाषाओं को लौटाती है, मॉडल मौजूद होने पर `installedOnDeviceLanguage` के रूप में चिह्नित (या डाउनलोड के दौरान `pendingOnDeviceLanguage`)। सत्र की अवधि के लिए `AUDIOFOCUS_GAIN_TRANSIENT` के साथ ऑडियो फोकस प्राप्त किया जाता है।
 
 **सीमा:** Gboard, Samsung Keyboard और Google Assistant अपने स्वयं के पहचानकर्ता बंडल करते हैं और सिस्टम डिफ़ॉल्ट को छोड़ देते हैं। फ्रेमवर्क `SpeechRecognizer` API को स्पष्ट रूप से कॉल करने वाले ऐप (या उसके ऊपर अपना UI बनाने वाले) ही आपकी सेवा से होकर गुजरते हैं।
+
+## सिस्टम टेक्स्ट-टू-स्पीच (`TextToSpeechService`)
+
+डेमो ऐप `audio.soniqo.speech.service.SpeechTextToSpeechService` भी उजागर करता है, इसलिए Android सेटिंग्स → सिस्टम → भाषाएँ और इनपुट → टेक्स्ट-टू-स्पीच आउटपुट में इस ऐप को चुन सकता है। यह पथ `ModelManager.ensureTtsModels()` और अलग `models_tts/` कैश का उपयोग करता है, इसलिए फ्रेमवर्क TTS पूर्ण VAD/STT/enhancer पाइपलाइन बंडल के बजाय केवल Kokoro assets डाउनलोड करता है।
+
+किसी अन्य ऐप से इंजन उजागर करने के लिए सेवा घोषित करें:
+
+```xml
+<service
+    android:name="audio.soniqo.speech.service.SpeechTextToSpeechService"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.TTS_SERVICE" />
+    </intent-filter>
+    <meta-data
+        android:name="android.speech.tts"
+        android:resource="@xml/tts_engine" />
+</service>
+```
+
+`app/src/main/res/xml/tts_engine.xml` जोड़ें:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<tts-engine xmlns:android="http://schemas.android.com/apk/res/android" />
+```
 
 ## प्रदर्शन
 
 Android एमुलेटर (arm64-v8a, NNAPI के बिना) पर मापा गया। वास्तविक हार्डवेयर काफी तेज़ है।
 
-| मॉडल | कार्य | ऑडियो | अनुमान | RTF |
+Galaxy S23 Android पर मापा गया, जब तक अलग से न कहा गया हो CPU-only। कम RTF तेज़ है।
+
+| मॉडल | कार्य | RTF | लेटेंसी | पीक मेमोरी |
 | --- | --- | --- | --- | --- |
-| Parakeet TDT v3 | STT | 1.5 सेकंड | 175 मिलीसेकंड | 0.12 |
-| Kokoro 82M | TTS | 1.9 सेकंड आउटपुट | 1,075 मिलीसेकंड | 0.58 |
-| Silero VAD v5 | VAD | 32 मिलीसेकंड चंक | <1 मिलीसेकंड | <0.01 |
+| Parakeet-EOU 120M ONNX INT8 | स्ट्रीमिंग STT + EOU | 0.21 | streaming partials | 232 MB |
+| Kokoro 82M ONNX FP32 | TTS | 0.53 | वाक्य-स्तर | 640 MB |
+| Supertonic-3 LiteRT | TTS | 0.34 | ~1.1 सेकंड TTFA | 832 MB |
+| Silero VAD v5 | VAD | <0.01 | हर 32 मिलीसेकंड चंक पर <1 मिलीसेकंड | <10 MB |
 
 ## पाइपलाइन
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -4,7 +4,7 @@
 
 [ONNX Runtime](https://onnxruntime.ai) と [speech-core](https://github.com/soniqo/speech-core) を活用した、Android 向けオンデバイス音声 SDK。
 
-音声認識(114 言語)、テキスト読み上げ(8 言語)、音声活動検出、ノイズキャンセリング — すべてローカルで動作。クラウド API 不要、データはデバイスから外に出ません。
+低メモリのストリーミング音声認識(既定 25 言語、114 言語 TDT は任意)、テキスト読み上げ、音声活動検出、ノイズキャンセリング — すべてローカルで動作。クラウド API 不要、データはデバイスから外に出ません。
 
 **[デモ APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[モデル](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 版)· **[speech-core](https://github.com/soniqo/speech-core)**(パイプラインエンジン + Linux/組み込みビルド)
 
@@ -14,21 +14,25 @@
 
 ## モデル
 
-| モデル | タスク | INT8 サイズ | 言語 |
-| --- | --- | --- | --- |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | 音声認識 | 891 MB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | テキスト読み上げ | 330 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | テキスト読み上げ(LiteRT、flow-matching、G2P-free、44.1 kHz) | ~380 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | 音声活動検出 | 2 MB | 任意 |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | ノイズキャンセリング | ~8 MB | 任意 |
+| モデル | タスク | ダウンロード | ピークメモリ | 言語 |
+| --- | --- | --- | --- | --- |
+| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | ストリーミング STT + EOU(既定) | 153 MB | 232 MB | 25 |
+| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | 広範囲 STT(任意) | 891 MB | ~1.1-1.3 GB | 114 |
+| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | テキスト読み上げ(既定) | 330 MB | 640 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | テキスト読み上げ(LiteRT、flow-matching、G2P-free、44.1 kHz) | ~380 MB | 832 MB | 31 |
+| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | 音声活動検出 | 2 MB | <10 MB | 任意 |
+| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | ノイズキャンセリング | ~8 MB | 既定では未ロード | 任意 |
+| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | オンデバイス LLM — 構造化関数 / ツール呼び出し | 283 MB | アプリのランタイム次第 | EN チューニング |
 
 モデルは初回起動時に `ModelManager.ensureModels()` 経由で自動ダウンロードされます。
+
+`SpeechConfig()` は `SttModel.PARAKEET_EOU` と `TtsModel.KOKORO` を既定にして、デモとシステム認識サービスを低メモリ Android パスで動かします。より大きい 114 言語 TDT モデルが必要な場合のみ `SpeechConfig(sttModel = SttModel.PARAKEET)` を使います。
 
 **Supertonic-3** はオプトインの高品質な多言語 TTS です — `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` で選択します(LiteRT バックエンドが必要)。ホストはその 4 つの非自己回帰 flow-matching グラフを 44.1 kHz でオンデバイス実行します。フロントエンドは G2P-free(NFKD + Unicode インデックス — phonemizer なし)なので、31 言語すべてが単一のパスを通ります。
 
 ## デモを試す
 
-[署名済み APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) をダウンロードし、任意の arm64 Android デバイス(8 以降)にインストールします。モデル(~1.2 GB)は初回起動時に自動ダウンロードされます。
+[署名済み APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) をダウンロードし、任意の arm64 Android デバイス(8 以降)にインストールします。既定の低メモリモデルバンドル(~500 MB)は初回起動時に自動ダウンロードされます。
 
 ## 依存関係を追加
 
@@ -130,19 +134,48 @@ adb shell settings put secure voice_recognition_service \
 
 **4. 確認**:デモアプリの *Recognizer test* 画面を実行します。これは `SpeechRecognizer.createSpeechRecognizer(ctx)`(コンポーネントなし)を呼び出し、すべてのフレームワークコールバックをログに記録します — logcat なしで binder のラウンドトリップを確認するのに便利です。
 
-サービスは `onCheckRecognitionSupport`(API 33+)を実装し、Parakeet TDT v3 がカバーする 27 の BCP-47 言語を返します。モデルが存在する場合は `installedOnDeviceLanguage`、ダウンロード中は `pendingOnDeviceLanguage` でマークされます。セッション中は `AUDIOFOCUS_GAIN_TRANSIENT` でオーディオフォーカスを取得します。
+サービスは `onCheckRecognitionSupport`(API 33+)を実装し、Parakeet-EOU がカバーする 25 の BCP-47 言語を返します。モデルが存在する場合は `installedOnDeviceLanguage`、ダウンロード中は `pendingOnDeviceLanguage` でマークされます。セッション中は `AUDIOFOCUS_GAIN_TRANSIENT` でオーディオフォーカスを取得します。
 
 **注意:** Gboard、Samsung Keyboard、Google Assistant は独自の認識エンジンを同梱しており、システムデフォルトをスキップします。あなたのサービスを通過するのは、フレームワーク `SpeechRecognizer` API を明示的に呼び出すアプリ(またはその上に独自 UI を構築するアプリ)です。
+
+## システム音声合成(`TextToSpeechService`)
+
+デモアプリは `audio.soniqo.speech.service.SpeechTextToSpeechService` も公開するため、Android の 設定 → システム → 言語と入力 → テキスト読み上げ出力 でこのアプリを選択できます。この経路は `ModelManager.ensureTtsModels()` と別個の `models_tts/` キャッシュを使用するため、フレームワーク TTS は VAD/STT/enhancer を含む完全なパイプライン一式ではなく Kokoro アセットだけをダウンロードします。
+
+別のアプリでエンジンを公開するには、サービスを宣言します:
+
+```xml
+<service
+    android:name="audio.soniqo.speech.service.SpeechTextToSpeechService"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.TTS_SERVICE" />
+    </intent-filter>
+    <meta-data
+        android:name="android.speech.tts"
+        android:resource="@xml/tts_engine" />
+</service>
+```
+
+`app/src/main/res/xml/tts_engine.xml` を追加します:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<tts-engine xmlns:android="http://schemas.android.com/apk/res/android" />
+```
 
 ## パフォーマンス
 
 Android エミュレータ(arm64-v8a、NNAPI なし)で測定。実機ははるかに高速です。
 
-| モデル | タスク | 音声 | 推論 | RTF |
+Galaxy S23 Android で測定。特記がない限り CPU。RTF は低いほど高速です。
+
+| モデル | タスク | RTF | レイテンシ | ピークメモリ |
 | --- | --- | --- | --- | --- |
-| Parakeet TDT v3 | STT | 1.5 秒 | 175 ミリ秒 | 0.12 |
-| Kokoro 82M | TTS | 1.9 秒出力 | 1,075 ミリ秒 | 0.58 |
-| Silero VAD v5 | VAD | 32 ミリ秒チャンク | <1 ミリ秒 | <0.01 |
+| Parakeet-EOU 120M ONNX INT8 | ストリーミング STT + EOU | 0.21 | streaming partials | 232 MB |
+| Kokoro 82M ONNX FP32 | TTS | 0.53 | 文単位 | 640 MB |
+| Supertonic-3 LiteRT | TTS | 0.34 | ~1.1 秒 TTFA | 832 MB |
+| Silero VAD v5 | VAD | <0.01 | 32 ミリ秒チャンクあたり <1 ミリ秒 | <10 MB |
 
 ## パイプライン
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -4,7 +4,7 @@
 
 [ONNX Runtime](https://onnxruntime.ai)와 [speech-core](https://github.com/soniqo/speech-core) 기반의 Android용 온디바이스 음성 SDK.
 
-음성 인식(114개 언어), 텍스트 음성 변환(8개 언어), 음성 활동 감지, 노이즈 캔슬링 — 모두 로컬에서 실행됩니다. 클라우드 API도, 디바이스 외부로 전송되는 데이터도 없습니다.
+저메모리 스트리밍 음성 인식(기본 25개 언어, 114개 언어 TDT는 선택), 텍스트 음성 변환, 음성 활동 감지, 노이즈 캔슬링 — 모두 로컬에서 실행됩니다. 클라우드 API도, 디바이스 외부로 전송되는 데이터도 없습니다.
 
 **[데모 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[모델](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 버전) · **[speech-core](https://github.com/soniqo/speech-core)**(파이프라인 엔진 + Linux/임베디드 빌드)
 
@@ -14,21 +14,25 @@
 
 ## 모델
 
-| 모델 | 작업 | INT8 크기 | 언어 |
-| --- | --- | --- | --- |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | 음성 인식 | 891 MB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 텍스트 음성 변환 | 330 MB | 8(en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 텍스트 음성 변환(LiteRT, flow-matching, G2P-free, 44.1 kHz) | ~380 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | 음성 활동 감지 | 2 MB | 모든 언어 |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 노이즈 캔슬링 | ~8 MB | 모든 언어 |
+| 모델 | 작업 | 다운로드 | 피크 메모리 | 언어 |
+| --- | --- | --- | --- | --- |
+| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 스트리밍 STT + EOU(기본) | 153 MB | 232 MB | 25 |
+| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | 광범위 STT(선택) | 891 MB | ~1.1-1.3 GB | 114 |
+| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 텍스트 음성 변환(기본) | 330 MB | 640 MB | 8(en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 텍스트 음성 변환(LiteRT, flow-matching, G2P-free, 44.1 kHz) | ~380 MB | 832 MB | 31 |
+| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | 음성 활동 감지 | 2 MB | <10 MB | 모든 언어 |
+| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 노이즈 캔슬링 | ~8 MB | 기본으로 로드하지 않음 | 모든 언어 |
+| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | 온디바이스 LLM — 구조화 함수 / 도구 호출 | 283 MB | 앱 런타임에 따라 다름 | EN 튜닝 |
 
 모델은 `ModelManager.ensureModels()`를 통해 첫 실행 시 자동으로 다운로드됩니다.
+
+`SpeechConfig()`는 `SttModel.PARAKEET_EOU`와 `TtsModel.KOKORO`를 기본값으로 사용해 데모와 시스템 인식 서비스를 저메모리 Android 경로에서 실행합니다. 더 큰 114개 언어 TDT 모델이 필요할 때만 `SpeechConfig(sttModel = SttModel.PARAKEET)`를 사용하세요.
 
 **Supertonic-3**는 옵트인 방식의 더 높은 품질의 다국어 TTS입니다 — `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)`로 선택하세요(LiteRT 백엔드가 필요합니다). 호스트는 4개의 비자기회귀(non-autoregressive) flow-matching 그래프를 44.1 kHz로 온디바이스에서 실행합니다. 프런트엔드는 G2P-free(NFKD + 유니코드 인덱스 — 음소 변환기 없음)이므로 31개 언어 모두 하나의 경로를 통과합니다.
 
 ## 데모 사용해보기
 
-[서명된 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)를 다운로드하여 arm64 Android 기기(8 이상)에 설치하세요. 모델(~1.2 GB)은 첫 실행 시 자동으로 다운로드됩니다.
+[서명된 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)를 다운로드하여 arm64 Android 기기(8 이상)에 설치하세요. 기본 저메모리 모델 번들(~500 MB)은 첫 실행 시 자동으로 다운로드됩니다.
 
 ## 의존성 추가
 
@@ -130,19 +134,48 @@ adb shell settings put secure voice_recognition_service \
 
 **4. 검증**: 데모 앱의 *Recognizer test* 화면을 실행하면 `SpeechRecognizer.createSpeechRecognizer(ctx)`(컴포넌트 없이)를 호출하고 모든 프레임워크 콜백을 기록합니다 — logcat 없이 binder 왕복을 확인하는 데 유용합니다.
 
-서비스는 `onCheckRecognitionSupport`(API 33+)를 구현하여 Parakeet TDT v3가 지원하는 27개 BCP-47 언어를 반환합니다. 모델이 존재하면 `installedOnDeviceLanguage`, 다운로드 중이면 `pendingOnDeviceLanguage`로 표시됩니다. 세션 동안 `AUDIOFOCUS_GAIN_TRANSIENT`로 오디오 포커스를 획득합니다.
+서비스는 `onCheckRecognitionSupport`(API 33+)를 구현하여 Parakeet-EOU가 지원하는 25개 BCP-47 언어를 반환합니다. 모델이 존재하면 `installedOnDeviceLanguage`, 다운로드 중이면 `pendingOnDeviceLanguage`로 표시됩니다. 세션 동안 `AUDIOFOCUS_GAIN_TRANSIENT`로 오디오 포커스를 획득합니다.
 
 **주의:** Gboard, 삼성 키보드, Google Assistant는 자체 인식 엔진을 번들로 제공하며 시스템 기본값을 건너뜁니다. 프레임워크 `SpeechRecognizer` API를 명시적으로 호출하거나 그 위에 자체 UI를 구축하는 앱만이 서비스를 통과합니다.
+
+## 시스템 텍스트 음성 변환(`TextToSpeechService`)
+
+데모 앱은 `audio.soniqo.speech.service.SpeechTextToSpeechService`도 노출하므로 Android 설정 → 시스템 → 언어 및 입력 → 텍스트 음성 변환 출력에서 이 앱을 선택할 수 있습니다. 이 경로는 `ModelManager.ensureTtsModels()`와 별도의 `models_tts/` 캐시를 사용하므로, 프레임워크 TTS는 전체 VAD/STT/enhancer 파이프라인 번들이 아니라 Kokoro 자산만 다운로드합니다.
+
+다른 앱에서 엔진을 노출하려면 서비스를 선언합니다:
+
+```xml
+<service
+    android:name="audio.soniqo.speech.service.SpeechTextToSpeechService"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.TTS_SERVICE" />
+    </intent-filter>
+    <meta-data
+        android:name="android.speech.tts"
+        android:resource="@xml/tts_engine" />
+</service>
+```
+
+`app/src/main/res/xml/tts_engine.xml`을 추가합니다:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<tts-engine xmlns:android="http://schemas.android.com/apk/res/android" />
+```
 
 ## 성능
 
 Android 에뮬레이터(arm64-v8a, NNAPI 없음)에서 측정. 실제 하드웨어는 훨씬 빠릅니다.
 
-| 모델 | 작업 | 오디오 | 추론 | RTF |
+Galaxy S23 Android에서 측정했습니다. 별도 표기가 없으면 CPU 기준입니다. RTF는 낮을수록 빠릅니다.
+
+| 모델 | 작업 | RTF | 지연 시간 | 피크 메모리 |
 | --- | --- | --- | --- | --- |
-| Parakeet TDT v3 | STT | 1.5초 | 175ms | 0.12 |
-| Kokoro 82M | TTS | 1.9초 출력 | 1,075ms | 0.58 |
-| Silero VAD v5 | VAD | 32ms 청크 | <1ms | <0.01 |
+| Parakeet-EOU 120M ONNX INT8 | 스트리밍 STT + EOU | 0.21 | streaming partials | 232 MB |
+| Kokoro 82M ONNX FP32 | TTS | 0.53 | 문장 단위 | 640 MB |
+| Supertonic-3 LiteRT | TTS | 0.34 | ~1.1초 TTFA | 832 MB |
+| Silero VAD v5 | VAD | <0.01 | 32ms 청크당 <1ms | <10 MB |
 
 ## 파이프라인
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -4,7 +4,7 @@
 
 SDK de voz no dispositivo para Android, baseado em [ONNX Runtime](https://onnxruntime.ai) e [speech-core](https://github.com/soniqo/speech-core).
 
-Reconhecimento de fala (114 idiomas), texto para fala (8 idiomas), detecção de atividade vocal e cancelamento de ruído — tudo executado localmente. Sem APIs em nuvem, nenhum dado sai do dispositivo.
+Reconhecimento de fala em streaming com baixa memória (25 idiomas por padrão, TDT de 114 idiomas opcional), texto para fala, detecção de atividade vocal e cancelamento de ruído — tudo executado localmente. Sem APIs em nuvem, nenhum dado sai do dispositivo.
 
 **[APK de demonstração](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modelos](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (contraparte Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (motor de pipeline + build Linux/embarcado)
 
@@ -14,21 +14,25 @@ Este repositório é o **empacotamento Android**: SDK Kotlin, ponte JNI, app de 
 
 ## Modelos
 
-| Modelo | Tarefa | Tamanho INT8 | Idiomas |
-| --- | --- | --- | --- |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Reconhecimento de fala | 891 MB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Texto para fala | 330 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Texto para fala (LiteRT, flow-matching, G2P-free, 44,1 kHz) | ~380 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Detecção de atividade vocal | 2 MB | Qualquer |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Cancelamento de ruído | ~8 MB | Qualquer |
+| Modelo | Tarefa | Download | Pico de memória | Idiomas |
+| --- | --- | --- | --- | --- |
+| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | STT em streaming + EOU (padrão) | 153 MB | 232 MB | 25 |
+| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | STT de ampla cobertura (opcional) | 891 MB | ~1,1-1,3 GB | 114 |
+| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Texto para fala (padrão) | 330 MB | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Texto para fala (LiteRT, flow-matching, G2P-free, 44,1 kHz) | ~380 MB | 832 MB | 31 |
+| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Detecção de atividade vocal | 2 MB | <10 MB | Qualquer |
+| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Cancelamento de ruído | ~8 MB | não carregado por padrão | Qualquer |
+| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | LLM no dispositivo — chamadas estruturadas de função / ferramenta | 283 MB | depende do runtime do app | Ajustado para EN |
 
 Os modelos são baixados automaticamente no primeiro lançamento via `ModelManager.ensureModels()`.
+
+`SpeechConfig()` usa `SttModel.PARAKEET_EOU` e `TtsModel.KOKORO` por padrão para manter a demo e o reconhecedor do sistema no caminho Android de baixa memória. Use `SpeechConfig(sttModel = SttModel.PARAKEET)` apenas quando precisar do modelo TDT maior de 114 idiomas.
 
 O **Supertonic-3** é um TTS multilíngue opcional de maior qualidade — selecione-o com `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (requer o backend LiteRT). O host executa seus quatro grafos de flow-matching não autorregressivos no dispositivo a 44,1 kHz; o front-end é G2P-free (NFKD + índice Unicode — sem phonemizer), de modo que todos os 31 idiomas seguem um único caminho.
 
 ## Experimente a demo
 
-Baixe o [APK assinado](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) e instale em qualquer dispositivo Android arm64 (8+). Os modelos (~1,2 GB) são baixados automaticamente no primeiro lançamento.
+Baixe o [APK assinado](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) e instale em qualquer dispositivo Android arm64 (8+). O pacote padrão de modelos de baixa memória (~500 MB) é baixado automaticamente no primeiro lançamento.
 
 ## Adicionar dependência
 
@@ -141,7 +145,7 @@ cada callback do framework — útil para confirmar o round-trip do binder sem
 precisar do logcat.
 
 O serviço implementa `onCheckRecognitionSupport` (API 33+) retornando os
-27 idiomas BCP-47 cobertos pelo Parakeet TDT v3, marcados como
+25 idiomas BCP-47 cobertos pelo Parakeet-EOU, marcados como
 `installedOnDeviceLanguage` quando os modelos estão presentes (ou
 `pendingOnDeviceLanguage` enquanto eles são baixados). O foco de áudio é
 adquirido com `AUDIOFOCUS_GAIN_TRANSIENT` pela duração de uma sessão.
@@ -151,15 +155,47 @@ próprios reconhecedores e ignoram o padrão do sistema. Apps que chamam
 explicitamente a API `SpeechRecognizer` do framework (ou constroem sua
 própria UI em cima dela) são os que passam pelo seu serviço.
 
+## Texto para fala do sistema (`TextToSpeechService`)
+
+O app de demonstração também expõe
+`audio.soniqo.speech.service.SpeechTextToSpeechService`, então o Android pode
+selecionar o app em Configurações → Sistema → Idiomas e entrada → Saída de
+texto para fala. Esse caminho usa `ModelManager.ensureTtsModels()` e um cache
+separado `models_tts/`, portanto o TTS do framework baixa apenas os recursos
+do Kokoro em vez do pacote completo VAD/STT/enhancer.
+
+Para expor o motor a partir de outro app, declare o serviço:
+
+```xml
+<service
+    android:name="audio.soniqo.speech.service.SpeechTextToSpeechService"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.TTS_SERVICE" />
+    </intent-filter>
+    <meta-data
+        android:name="android.speech.tts"
+        android:resource="@xml/tts_engine" />
+</service>
+```
+
+Adicione `app/src/main/res/xml/tts_engine.xml`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<tts-engine xmlns:android="http://schemas.android.com/apk/res/android" />
+```
+
 ## Desempenho
 
-Medido em emulador Android (arm64-v8a, sem NNAPI). Hardware real é significativamente mais rápido.
+Medido em Galaxy S23 Android, CPU apenas salvo indicação. RTF menor é mais rápido.
 
-| Modelo | Tarefa | Áudio | Inferência | RTF |
+| Modelo | Tarefa | RTF | Latência | Pico de memória |
 | --- | --- | --- | --- | --- |
-| Parakeet TDT v3 | STT | 1,5s | 175ms | 0,12 |
-| Kokoro 82M | TTS | 1,9s saída | 1.075ms | 0,58 |
-| Silero VAD v5 | VAD | bloco 32ms | <1ms | <0,01 |
+| Parakeet-EOU 120M ONNX INT8 | STT em streaming + EOU | 0,21 | parciais em streaming | 232 MB |
+| Kokoro 82M ONNX FP32 | TTS | 0,53 | por frase | 640 MB |
+| Supertonic-3 LiteRT | TTS | 0,34 | ~1,1s TTFA | 832 MB |
+| Silero VAD v5 | VAD | <0,01 | <1ms por bloco de 32ms | <10 MB |
 
 ## Pipeline
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -4,7 +4,7 @@
 
 Локальный речевой SDK для Android, основанный на [ONNX Runtime](https://onnxruntime.ai) и [speech-core](https://github.com/soniqo/speech-core).
 
-Распознавание речи (114 языков), синтез речи (8 языков), определение голосовой активности и шумоподавление — всё работает локально. Никаких облачных API, никакие данные не покидают устройство.
+Потоковое распознавание речи с низким потреблением памяти (25 языков по умолчанию, TDT на 114 языков опционально), синтез речи, определение голосовой активности и шумоподавление — всё работает локально. Никаких облачных API, никакие данные не покидают устройство.
 
 **[Демо APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Модели](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (аналог для Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (движок конвейера + сборка для Linux/встраиваемых систем)
 
@@ -14,21 +14,25 @@
 
 ## Модели
 
-| Модель | Задача | Размер INT8 | Языки |
-| --- | --- | --- | --- |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Распознавание речи | 891 МБ | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Синтез речи | 330 МБ | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Синтез речи (LiteRT, flow-matching, G2P-free, 44,1 кГц) | ~380 МБ | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Определение голосовой активности | 2 МБ | Любой |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Шумоподавление | ~8 МБ | Любой |
+| Модель | Задача | Загрузка | Пиковая память | Языки |
+| --- | --- | --- | --- | --- |
+| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | Потоковый STT + EOU (по умолчанию) | 153 МБ | 232 МБ | 25 |
+| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | STT с широким покрытием (опционально) | 891 МБ | ~1,1-1,3 ГБ | 114 |
+| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Синтез речи (по умолчанию) | 330 МБ | 640 МБ | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Синтез речи (LiteRT, flow-matching, G2P-free, 44,1 кГц) | ~380 МБ | 832 МБ | 31 |
+| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Определение голосовой активности | 2 МБ | <10 МБ | Любой |
+| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Шумоподавление | ~8 МБ | по умолчанию не загружается | Любой |
+| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | Локальная LLM — структурированные вызовы функций / инструментов | 283 МБ | зависит от runtime приложения | EN-tuned |
 
 Модели загружаются автоматически при первом запуске через `ModelManager.ensureModels()`.
+
+`SpeechConfig()` по умолчанию использует `SttModel.PARAKEET_EOU` и `TtsModel.KOKORO`, чтобы демо и системный распознаватель работали по низкопамятному Android-пути. Используйте `SpeechConfig(sttModel = SttModel.PARAKEET)` только если нужна более крупная TDT-модель на 114 языков.
 
 **Supertonic-3** — это опциональный многоязычный TTS повышенного качества: выберите его через `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (требуется бэкенд LiteRT). Хост выполняет его четыре неавторегрессионных flow-matching-графа на устройстве на частоте 44,1 кГц; фронтенд работает G2P-free (NFKD + индекс Unicode — без фонемизатора), поэтому все 31 язык проходят через один путь.
 
 ## Попробовать демо
 
-Скачайте [подписанный APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) и установите на любое arm64-устройство Android (8+). Модели (~1,2 ГБ) загружаются автоматически при первом запуске.
+Скачайте [подписанный APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) и установите на любое arm64-устройство Android (8+). Стандартный низкопамятный набор моделей (~500 МБ) загружается автоматически при первом запуске.
 
 ## Добавить зависимость
 
@@ -130,19 +134,48 @@ adb shell settings put secure voice_recognition_service \
 
 **4. Проверьте**, запустив экран *Recognizer test* в демо-приложении, который вызывает `SpeechRecognizer.createSpeechRecognizer(ctx)` (без компонента) и логирует каждый callback фреймворка — удобно для подтверждения binder round-trip без необходимости в logcat.
 
-Сервис реализует `onCheckRecognitionSupport` (API 33+), возвращающий 27 BCP-47 языков, поддерживаемых Parakeet TDT v3, помеченных как `installedOnDeviceLanguage` при наличии моделей (или `pendingOnDeviceLanguage` во время загрузки). Аудиофокус удерживается с `AUDIOFOCUS_GAIN_TRANSIENT` на время сессии.
+Сервис реализует `onCheckRecognitionSupport` (API 33+), возвращающий 25 BCP-47 языков, поддерживаемых Parakeet-EOU, помеченных как `installedOnDeviceLanguage` при наличии моделей (или `pendingOnDeviceLanguage` во время загрузки). Аудиофокус удерживается с `AUDIOFOCUS_GAIN_TRANSIENT` на время сессии.
 
 **Оговорка:** Gboard, Samsung Keyboard и Google Assistant поставляются с собственными распознавателями и обходят системное значение по умолчанию. Через ваш сервис проходят только те приложения, которые явно вызывают API `SpeechRecognizer` фреймворка (или строят на нём собственный UI).
+
+## Системный синтез речи (`TextToSpeechService`)
+
+Демо-приложение также публикует `audio.soniqo.speech.service.SpeechTextToSpeechService`, поэтому Android может выбрать приложение в Настройки → Система → Языки и ввод → Синтез речи. Этот путь использует `ModelManager.ensureTtsModels()` и отдельный кэш `models_tts/`, поэтому framework TTS загружает только ресурсы Kokoro, а не полный пакет VAD/STT/enhancer.
+
+Чтобы открыть движок из другого приложения, объявите сервис:
+
+```xml
+<service
+    android:name="audio.soniqo.speech.service.SpeechTextToSpeechService"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.TTS_SERVICE" />
+    </intent-filter>
+    <meta-data
+        android:name="android.speech.tts"
+        android:resource="@xml/tts_engine" />
+</service>
+```
+
+Добавьте `app/src/main/res/xml/tts_engine.xml`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<tts-engine xmlns:android="http://schemas.android.com/apk/res/android" />
+```
 
 ## Производительность
 
 Измерено на эмуляторе Android (arm64-v8a, без NNAPI). Реальное оборудование значительно быстрее.
 
-| Модель | Задача | Аудио | Инференс | RTF |
+Измерено на Galaxy S23 Android, CPU-only если не указано иначе. Чем ниже RTF, тем быстрее.
+
+| Модель | Задача | RTF | Задержка | Пиковая память |
 | --- | --- | --- | --- | --- |
-| Parakeet TDT v3 | STT | 1,5 с | 175 мс | 0,12 |
-| Kokoro 82M | TTS | 1,9 с вывод | 1075 мс | 0,58 |
-| Silero VAD v5 | VAD | блок 32 мс | <1 мс | <0,01 |
+| Parakeet-EOU 120M ONNX INT8 | Потоковый STT + EOU | 0,21 | потоковые partials | 232 МБ |
+| Kokoro 82M ONNX FP32 | TTS | 0,53 | по предложениям | 640 МБ |
+| Supertonic-3 LiteRT | TTS | 0,34 | ~1,1 с TTFA | 832 МБ |
+| Silero VAD v5 | VAD | <0,01 | <1 мс на блок 32 мс | <10 МБ |
 
 ## Конвейер
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,7 +4,7 @@
 
 适用于 Android 的设备端语音 SDK,基于 [ONNX Runtime](https://onnxruntime.ai) 和 [speech-core](https://github.com/soniqo/speech-core) 构建。
 
-语音识别(114 种语言)、文本转语音(8 种语言)、语音活动检测和噪声消除——全部在本地运行。无需云端 API,数据不会离开设备。
+低内存流式语音识别(默认 25 种语言,可选 114 语言 TDT)、文本转语音、语音活动检测和噪声消除——全部在本地运行。无需云端 API,数据不会离开设备。
 
 **[演示 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[模型](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 对应版本)· **[speech-core](https://github.com/soniqo/speech-core)**(管线引擎 + Linux/嵌入式构建)
 
@@ -14,21 +14,25 @@
 
 ## 模型
 
-| 模型 | 任务 | INT8 大小 | 语言 |
-| --- | --- | --- | --- |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | 语音识别 | 891 MB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 文本转语音 | 330 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 文本转语音(LiteRT、流匹配、免 G2P、44.1 kHz) | ~380 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | 语音活动检测 | 2 MB | 任意 |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 噪声消除 | ~8 MB | 任意 |
+| 模型 | 任务 | 下载大小 | 峰值内存 | 语言 |
+| --- | --- | --- | --- | --- |
+| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 流式 STT + 端点检测(默认) | 153 MB | 232 MB | 25 |
+| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | 广覆盖 STT(可选) | 891 MB | ~1.1-1.3 GB | 114 |
+| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 文本转语音(默认) | 330 MB | 640 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
+| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 文本转语音(LiteRT、流匹配、免 G2P、44.1 kHz) | ~380 MB | 832 MB | 31 |
+| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | 语音活动检测 | 2 MB | <10 MB | 任意 |
+| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 噪声消除 | ~8 MB | 默认不加载 | 任意 |
+| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | 端侧 LLM — 结构化函数 / 工具调用 | 283 MB | 取决于应用运行时 | EN 调优 |
 
 模型在首次启动时通过 `ModelManager.ensureModels()` 自动下载。
+
+`SpeechConfig()` 默认使用 `SttModel.PARAKEET_EOU` 和 `TtsModel.KOKORO`,让演示应用和系统识别服务走低内存 Android 路径。只有在需要更大的 114 语言 TDT 模型时,才使用 `SpeechConfig(sttModel = SttModel.PARAKEET)`。
 
 **Supertonic-3** 是可选启用的更高质量多语言 TTS — 通过 `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` 选用(需要 LiteRT 后端)。宿主在设备端以 44.1 kHz 运行其四个非自回归流匹配图;前端免 G2P(NFKD + Unicode 索引 — 无音素转换器),因此全部 31 种语言走同一条路径。
 
 ## 试用演示
 
-下载[已签名的 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) 并安装到任何 arm64 Android 设备(8 及以上)。模型(~1.2 GB)在首次启动时自动下载。
+下载[已签名的 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) 并安装到任何 arm64 Android 设备(8 及以上)。默认低内存模型包(~500 MB)在首次启动时自动下载。
 
 ## 添加依赖
 
@@ -129,19 +133,48 @@ adb shell settings put secure voice_recognition_service \
 
 **4. 验证**:运行演示应用的*识别器测试*界面,它调用 `SpeechRecognizer.createSpeechRecognizer(ctx)`(不带组件)并记录每个框架回调 — 无需 logcat 即可确认 binder 往返。
 
-服务实现了 `onCheckRecognitionSupport`(API 33+),返回 Parakeet TDT v3 涵盖的 27 个 BCP-47 语言,在模型存在时标记为 `installedOnDeviceLanguage`(下载中时为 `pendingOnDeviceLanguage`)。会话期间使用 `AUDIOFOCUS_GAIN_TRANSIENT` 获取音频焦点。
+服务实现了 `onCheckRecognitionSupport`(API 33+),返回 Parakeet-EOU 涵盖的 25 个 BCP-47 语言,在模型存在时标记为 `installedOnDeviceLanguage`(下载中时为 `pendingOnDeviceLanguage`)。会话期间使用 `AUDIOFOCUS_GAIN_TRANSIENT` 获取音频焦点。
 
 **注意:** Gboard、三星键盘和 Google Assistant 都自带识别器,会跳过系统默认。显式调用框架 `SpeechRecognizer` API(或在其上构建自己 UI)的应用才会经过你的服务。
+
+## 系统文字转语音(`TextToSpeechService`)
+
+演示应用还暴露 `audio.soniqo.speech.service.SpeechTextToSpeechService`, 因此 Android 可以在 设置 → 系统 → 语言和输入 → 文字转语音输出 中选择该应用。此路径使用 `ModelManager.ensureTtsModels()` 和单独的 `models_tts/` 缓存, 所以框架 TTS 只下载 Kokoro 资源, 而不会拉取完整的 VAD/STT/enhancer 管线包。
+
+要在其他应用中暴露该引擎, 请声明服务:
+
+```xml
+<service
+    android:name="audio.soniqo.speech.service.SpeechTextToSpeechService"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.TTS_SERVICE" />
+    </intent-filter>
+    <meta-data
+        android:name="android.speech.tts"
+        android:resource="@xml/tts_engine" />
+</service>
+```
+
+添加 `app/src/main/res/xml/tts_engine.xml`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<tts-engine xmlns:android="http://schemas.android.com/apk/res/android" />
+```
 
 ## 性能
 
 在 Android 模拟器(arm64-v8a,无 NNAPI)上测量。真实硬件速度显著更快。
 
-| 模型 | 任务 | 音频 | 推理 | RTF |
+在 Galaxy S23 Android 上测量,除非另有说明均为 CPU。RTF 越低越快。
+
+| 模型 | 任务 | RTF | 延迟 | 峰值内存 |
 | --- | --- | --- | --- | --- |
-| Parakeet TDT v3 | STT | 1.5 秒 | 175 毫秒 | 0.12 |
-| Kokoro 82M | TTS | 1.9 秒输出 | 1,075 毫秒 | 0.58 |
-| Silero VAD v5 | VAD | 32 毫秒块 | <1 毫秒 | <0.01 |
+| Parakeet-EOU 120M ONNX INT8 | 流式 STT + EOU | 0.21 | 流式 partials | 232 MB |
+| Kokoro 82M ONNX FP32 | TTS | 0.53 | 句级 | 640 MB |
+| Supertonic-3 LiteRT | TTS | 0.34 | ~1.1 秒 TTFA | 832 MB |
+| Silero VAD v5 | VAD | <0.01 | 每 32 毫秒块 <1 毫秒 | <10 MB |
 
 ## 管线
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,5 +54,16 @@
                 android:name="android.speech"
                 android:resource="@xml/recognition_service" />
         </service>
+
+        <service
+            android:name="audio.soniqo.speech.service.SpeechTextToSpeechService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.TTS_SERVICE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.speech.tts"
+                android:resource="@xml/tts_engine" />
+        </service>
     </application>
 </manifest>

--- a/app/src/main/kotlin/audio/soniqo/speech/demo/SpeechRecognitionSettingsActivity.kt
+++ b/app/src/main/kotlin/audio/soniqo/speech/demo/SpeechRecognitionSettingsActivity.kt
@@ -63,7 +63,7 @@ class SpeechRecognitionSettingsActivity : ComponentActivity() {
         })
 
         root.addView(TextView(this).apply {
-            text = "Recognition runs entirely on-device via Parakeet TDT v3 + Silero VAD. " +
+            text = "Recognition runs entirely on-device via Parakeet-EOU 120M + Silero VAD. " +
                 "No audio leaves the device."
             textSize = 13f
             setTextColor(Color.parseColor("#AAAAAA"))

--- a/app/src/main/res/xml/tts_engine.xml
+++ b/app/src/main/res/xml/tts_engine.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tts-engine xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/app/src/test/kotlin/audio/soniqo/speech/demo/TtsEngineManifestTest.kt
+++ b/app/src/test/kotlin/audio/soniqo/speech/demo/TtsEngineManifestTest.kt
@@ -1,0 +1,40 @@
+package audio.soniqo.speech.demo
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.speech.tts.TextToSpeech
+import androidx.test.core.app.ApplicationProvider
+import audio.soniqo.speech.service.SpeechTextToSpeechService
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class TtsEngineManifestTest {
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun demoManifest_registersFrameworkTtsEngine() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val services = context.packageManager.queryIntentServices(
+            Intent(TextToSpeech.Engine.INTENT_ACTION_TTS_SERVICE),
+            PackageManager.GET_META_DATA,
+        )
+
+        val service = services.firstOrNull {
+            it.serviceInfo.name == SpeechTextToSpeechService::class.java.name
+        }
+
+        assertNotNull("TTS engine service should be discoverable", service)
+        assertEquals(context.packageName, service!!.serviceInfo.packageName)
+        assertTrue(service.serviceInfo.exported)
+        assertTrue(service.serviceInfo.metaData.containsKey(TextToSpeech.Engine.SERVICE_META_DATA))
+        assertTrue(service.serviceInfo.metaData.getInt(TextToSpeech.Engine.SERVICE_META_DATA) != 0)
+    }
+}

--- a/sdk/consumer-rules.pro
+++ b/sdk/consumer-rules.pro
@@ -5,9 +5,13 @@
 
 # Keep all public SDK classes
 -keep class audio.soniqo.speech.SpeechPipeline { *; }
+-keep class audio.soniqo.speech.SpeechSynthesizer { *; }
+-keep class audio.soniqo.speech.SpeechSynthesizerConfig { *; }
+-keep class audio.soniqo.speech.SpeechSynthesisResult { *; }
 -keep class audio.soniqo.speech.SpeechConfig { *; }
 -keep class audio.soniqo.speech.SpeechEvent { *; }
 -keep class audio.soniqo.speech.SpeechEvent$* { *; }
 -keep class audio.soniqo.speech.ModelManager { *; }
 -keep class audio.soniqo.speech.ModelPrecision { *; }
 -keep class audio.soniqo.speech.PipelineState { *; }
+-keep class audio.soniqo.speech.service.SpeechTextToSpeechService { *; }

--- a/sdk/src/main/cpp/jni_bridge.cpp
+++ b/sdk/src/main/cpp/jni_bridge.cpp
@@ -4,6 +4,7 @@
 #include <speech_core/models/deepfilter.h>
 #include <speech_core/models/kokoro_tts.h>
 #include <speech_core/models/onnx_engine.h>
+#include <speech_core/models/onnx_nemotron_streaming_stt.h>
 #include <speech_core/models/parakeet_stt.h>
 #include <speech_core/models/nemotron_multilingual_stt.h>
 #include <speech_core/models/silero_vad.h>
@@ -15,9 +16,14 @@
 #include <speech_core/pipeline/agent_config.h>
 #include <speech_core/pipeline/voice_pipeline.h>
 
+#include <algorithm>
+#include <cmath>
 #include <cstdint>
+#include <mutex>
 #include <memory>
+#include <stdexcept>
 #include <string>
+#include <vector>
 
 #define LOG_TAG "Speech"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
@@ -35,7 +41,7 @@
 
 struct PipelineHandle {
     std::unique_ptr<speech_core::SileroVad> vad;
-    std::unique_ptr<speech_core::STTInterface> stt;  // Parakeet or Nemotron (ONNX/LiteRT)
+    std::unique_ptr<speech_core::STTInterface> stt;  // Parakeet-EOU, Parakeet TDT, or Nemotron
     std::unique_ptr<speech_core::TTSInterface> tts;  // Kokoro (ONNX) or Supertonic (LiteRT)
     std::unique_ptr<speech_core::DeepFilterEnhancer> enhancer;
     std::unique_ptr<speech_core::VoicePipeline> pipeline;
@@ -44,6 +50,46 @@ struct PipelineHandle {
     jobject callback = nullptr;
     jmethodID on_event_mid = nullptr;
 };
+
+struct SynthesizerHandle {
+    std::unique_ptr<speech_core::TTSInterface> tts;
+    std::mutex mutex;
+};
+
+static constexpr int STT_PARAKEET = 0;
+static constexpr int STT_NEMOTRON_MULTILINGUAL = 1;
+static constexpr int STT_PARAKEET_EOU = 2;
+static constexpr int BACKEND_ONNX = 0;
+static constexpr int BACKEND_LITERT = 1;
+static constexpr int TTS_KOKORO = 0;
+static constexpr int TTS_SUPERTONIC = 1;
+
+static std::unique_ptr<speech_core::TTSInterface> create_tts(
+    const std::string& dir, bool nnapi, int ttsModel)
+{
+    if (ttsModel == TTS_SUPERTONIC) {
+#ifdef SPEECH_ANDROID_WITH_LITERT
+        // Assets from soniqo/Supertonic-3-LiteRT: the four graphs + the G2P-free tokenizer
+        // (unicode_indexer.json + tts.json in modelDir) + voice_styles/.
+        return std::make_unique<speech_core::LiteRTSupertonicTts>(
+            dir + "/duration_predictor.tflite",
+            dir + "/text_encoder.tflite",
+            dir + "/vector_estimator.tflite",
+            dir + "/vocoder.tflite",
+            dir,
+            dir + "/voice_styles",
+            nnapi);
+#else
+        throw std::runtime_error("Supertonic TTS requires the LiteRT backend (not built into this SDK)");
+#endif
+    }
+
+    return std::make_unique<speech_core::KokoroTts>(
+        dir + "/kokoro-e2e.onnx",
+        dir + "/voices",
+        dir,
+        nnapi);
+}
 
 // ---------------------------------------------------------------------------
 // JNI thread helper
@@ -151,8 +197,6 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
     bool nnapi = useNnapi;
     std::string suffix = useInt8 ? "-int8" : "";
     std::string lang = jstring_to_string(env, language);
-    enum { STT_PARAKEET = 0, STT_NEMOTRON_MULTILINGUAL = 1 };
-    enum { BACKEND_ONNX = 0, BACKEND_LITERT = 1 };
 
     auto h = std::make_unique<PipelineHandle>();
     env->GetJavaVM(&h->jvm);
@@ -167,8 +211,8 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
         // Load models
         h->vad = std::make_unique<speech_core::SileroVad>(
             dir + "/silero-vad.onnx", /*hw_accel=*/false);
-        // STT — Parakeet (auto-detect) or Nemotron-3.5 multilingual
-        // (prompt-conditioned) on the ONNX or LiteRT backend.
+        // STT — Parakeet-EOU low-memory streaming, Parakeet TDT v3, or
+        // Nemotron-3.5 multilingual (prompt-conditioned) on ONNX/LiteRT.
         if (sttModel == STT_NEMOTRON_MULTILINGUAL) {
             if (sttBackend == BACKEND_LITERT) {
 #ifdef SPEECH_ANDROID_WITH_LITERT
@@ -189,6 +233,13 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
                 if (lang != "auto" && !lang.empty()) m->set_language(lang);
                 h->stt = std::move(m);
             }
+        } else if (sttModel == STT_PARAKEET_EOU) {
+            h->stt = std::make_unique<speech_core::OnnxNemotronStreamingStt>(
+                dir + "/parakeet-eou-encoder.onnx",
+                dir + "/parakeet-eou-decoder.onnx",
+                dir + "/parakeet-eou-joint.onnx",
+                dir + "/vocab.json",
+                nnapi);
         } else {
             h->stt = std::make_unique<speech_core::ParakeetStt>(
                 dir + "/parakeet-encoder" + suffix + ".onnx",
@@ -197,29 +248,7 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
                 nnapi);
         }
         // TTS — Kokoro (ONNX, 24 kHz) or Supertonic-3 (LiteRT flow-matching, 44.1 kHz, G2P-free).
-        enum { TTS_KOKORO = 0, TTS_SUPERTONIC = 1 };
-        if (ttsModel == TTS_SUPERTONIC) {
-#ifdef SPEECH_ANDROID_WITH_LITERT
-            // Assets from soniqo/Supertonic-3-LiteRT: the four graphs + the G2P-free tokenizer
-            // (unicode_indexer.json + tts.json in modelDir) + voice_styles/.
-            h->tts = std::make_unique<speech_core::LiteRTSupertonicTts>(
-                dir + "/duration_predictor.tflite",
-                dir + "/text_encoder.tflite",
-                dir + "/vector_estimator.tflite",
-                dir + "/vocoder.tflite",
-                dir,
-                dir + "/voice_styles",
-                nnapi);
-#else
-            throw std::runtime_error("Supertonic TTS requires the LiteRT backend (not built into this SDK)");
-#endif
-        } else {
-            h->tts = std::make_unique<speech_core::KokoroTts>(
-                dir + "/kokoro-e2e.onnx",
-                dir + "/voices",
-                dir,
-                nnapi);
-        }
+        h->tts = create_tts(dir, nnapi, ttsModel);
 
         speech_core::AgentConfig cfg;
         cfg.vad.min_silence_duration = 0.5f;
@@ -328,6 +357,105 @@ Java_audio_soniqo_speech_NativeBridge_nativeGetState(
     auto* h = reinterpret_cast<PipelineHandle*>(handle);
     if (!h || !h->pipeline) return 0;
     return static_cast<jint>(h->pipeline->state());
+}
+
+JNIEXPORT jlong JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativeCreateSynthesizer(
+    JNIEnv* env, jobject /*thiz*/,
+    jstring modelDir, jboolean useNnapi, jint ttsModel)
+{
+    auto dir = jstring_to_string(env, modelDir);
+    auto h = std::make_unique<SynthesizerHandle>();
+
+    try {
+        h->tts = create_tts(dir, useNnapi, ttsModel);
+        auto& engine = OnnxEngine::get();
+        if (engine.had_nnapi_fallback()) {
+            LOGI("Synthesizer created with NNAPI fallback to CPU: %s",
+                 engine.nnapi_fallback_reason().c_str());
+        } else {
+            LOGI("Synthesizer created (NNAPI=%d)", static_cast<int>(useNnapi));
+        }
+    } catch (const std::exception& e) {
+        LOGE("Synthesizer creation failed: %s", e.what());
+        jclass ex_cls = env->FindClass("java/lang/RuntimeException");
+        if (ex_cls) {
+            std::string msg = std::string("Native synthesizer failed: ") + e.what();
+            env->ThrowNew(ex_cls, msg.c_str());
+        }
+        return 0;
+    }
+
+    return reinterpret_cast<jlong>(h.release());
+}
+
+JNIEXPORT void JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativeDestroySynthesizer(
+    JNIEnv* /*env*/, jobject /*thiz*/, jlong handle)
+{
+    auto* h = reinterpret_cast<SynthesizerHandle*>(handle);
+    delete h;
+}
+
+JNIEXPORT void JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativeStopSynthesizer(
+    JNIEnv* /*env*/, jobject /*thiz*/, jlong handle)
+{
+    auto* h = reinterpret_cast<SynthesizerHandle*>(handle);
+    if (h && h->tts) h->tts->cancel();
+}
+
+JNIEXPORT jint JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativeSynthesizerSampleRate(
+    JNIEnv* /*env*/, jobject /*thiz*/, jlong handle)
+{
+    auto* h = reinterpret_cast<SynthesizerHandle*>(handle);
+    if (!h || !h->tts) return 0;
+    return static_cast<jint>(h->tts->output_sample_rate());
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativeSynthesize(
+    JNIEnv* env, jobject /*thiz*/, jlong handle, jstring text, jstring language)
+{
+    auto* h = reinterpret_cast<SynthesizerHandle*>(handle);
+    if (!h || !h->tts) {
+        jclass ex_cls = env->FindClass("java/lang/IllegalStateException");
+        if (ex_cls) env->ThrowNew(ex_cls, "Native synthesizer is closed");
+        return nullptr;
+    }
+
+    std::string input = jstring_to_string(env, text);
+    std::string lang = jstring_to_string(env, language);
+    std::vector<int16_t> pcm;
+
+    try {
+        std::lock_guard<std::mutex> lock(h->mutex);
+        h->tts->synthesize(input, lang, [&pcm](const float* samples, size_t length, bool /*is_final*/) {
+            pcm.reserve(pcm.size() + length);
+            for (size_t i = 0; i < length; ++i) {
+                const float clamped = std::max(-1.0f, std::min(1.0f, samples[i]));
+                pcm.push_back(static_cast<int16_t>(std::lrintf(clamped * 32767.0f)));
+            }
+        });
+    } catch (const std::exception& e) {
+        LOGE("Synthesis failed: %s", e.what());
+        jclass ex_cls = env->FindClass("java/lang/RuntimeException");
+        if (ex_cls) {
+            std::string msg = std::string("Native synthesis failed: ") + e.what();
+            env->ThrowNew(ex_cls, msg.c_str());
+        }
+        return nullptr;
+    }
+
+    const jsize byte_count = static_cast<jsize>(pcm.size() * sizeof(int16_t));
+    jbyteArray out = env->NewByteArray(byte_count);
+    if (byte_count > 0) {
+        env->SetByteArrayRegion(
+            out, 0, byte_count,
+            reinterpret_cast<const jbyte*>(pcm.data()));
+    }
+    return out;
 }
 
 } // extern "C"

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
@@ -147,8 +147,9 @@ class ModelDownloadWorker(
          *
          *     pct = ((completed + bytesDownloaded / fileTotalBytes) / totalFiles) * 100
          *
-         * This keeps the progress bar moving through the dominant ~840 MB
-         * encoder (issue #30: "stuck at 0/16, 0%"). When [fileTotalBytes] is
+         * This keeps the progress bar moving through large model files
+         * instead of appearing stuck at the previous whole-file count. When
+         * [fileTotalBytes] is
          * unknown (0) it degrades to the previous whole-file behaviour for
          * that file only. Pure + side-effect free so it is unit-testable.
          */

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -22,14 +22,14 @@ object ModelManager {
     private const val BASE_URL = "https://huggingface.co/soniqo"
 
     // Bump when models on HuggingFace are updated to trigger cache invalidation.
-    // v5: Parakeet-TDT-v3-ONNX decoder-joint re-exported to INT32 inputs named
-    // `targets`/`target_length` (was INT64 `prednet_lengths_orig`) to match
-    // speech-core. Filenames are unchanged, so this bump evicts both the old
-    // INT64 v3 decoder and the interim English-only 0.6B set.
-    private const val MODEL_VERSION = 5
+    // v6: default STT switched to Parakeet-EOU-120M-ONNX-INT8, the low-memory
+    // streaming + end-of-utterance bundle. Evict the old default TDT v3 files
+    // so existing installs do not keep ~900 MB of unused ASR weights.
+    private const val MODEL_VERSION = 6
 
     private const val MAX_RETRIES = 5
     private const val RETRY_DELAY_MS = 2000L
+    private const val MODEL_SET_FILENAME = "model-set.txt"
 
     private val client = OkHttpClient.Builder()
         .connectTimeout(30, TimeUnit.SECONDS)
@@ -40,7 +40,7 @@ object ModelManager {
 
     private fun models(
         precision: ModelPrecision,
-        sttModel: SttModel = SttModel.PARAKEET,
+        sttModel: SttModel = SttModel.PARAKEET_EOU,
         sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO,
     ): List<ModelFile> {
@@ -50,10 +50,23 @@ object ModelManager {
             ModelFile("Silero-VAD-v5-ONNX", "silero-vad.onnx"),
         )
 
-        // STT — Parakeet (auto-detect) or Nemotron-3.5 multilingual.
+        // STT — Parakeet-EOU low-memory streaming, Parakeet TDT v3, or
+        // Nemotron-3.5 multilingual.
         when (sttModel) {
-            // Parakeet-TDT-v3-ONNX is the multilingual export (8192-token vocab
-            // with Cyrillic/Greek/accented Latin) — required for non-English STT.
+            // Parakeet-EOU-120M is the Android default: cache-aware streaming
+            // RNN-T with inline <EOU>/<EOB> tokens, 25 European languages, and
+            // a much smaller runtime footprint than the 0.6B TDT path.
+            // Published as INT8-only (encoder INT8, decoder/joint FP32), so
+            // [precision] intentionally does not alter filenames here.
+            SttModel.PARAKEET_EOU -> files += listOf(
+                ModelFile("Parakeet-EOU-120M-ONNX-INT8", "parakeet-eou-encoder.onnx"),
+                ModelFile("Parakeet-EOU-120M-ONNX-INT8", "parakeet-eou-decoder.onnx"),
+                ModelFile("Parakeet-EOU-120M-ONNX-INT8", "parakeet-eou-joint.onnx"),
+                ModelFile("Parakeet-EOU-120M-ONNX-INT8", "vocab.json"),
+                ModelFile("Parakeet-EOU-120M-ONNX-INT8", "config.json"),
+            )
+            // Parakeet-TDT-v3-ONNX is the larger broad-coverage multilingual
+            // export (8192-token vocab with Cyrillic/Greek/accented Latin).
             // Its INT8 decoder-joint was re-exported so `targets`/`target_length`
             // are INT32 (was INT64) and the length input is named `target_length`
             // (was `prednet_lengths_orig`), matching speech-core's
@@ -91,38 +104,39 @@ object ModelManager {
             }
         }
 
-        // TTS — Kokoro (ONNX E2E, 24 kHz) or Supertonic-3 (LiteRT flow-matching, 44.1 kHz, G2P-free).
-        when (ttsModel) {
-            TtsModel.KOKORO -> files += listOf(
-                // E2E model — single file + external weights
-                ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx"),
-                ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx.data"),
-                ModelFile("Kokoro-82M-ONNX", "vocab_index.json"),
-                ModelFile("Kokoro-82M-ONNX", "us_gold.json"),
-                ModelFile("Kokoro-82M-ONNX", "us_silver.json"),
-                ModelFile("Kokoro-82M-ONNX", "dict_fr.json"),
-                ModelFile("Kokoro-82M-ONNX", "dict_es.json"),
-                ModelFile("Kokoro-82M-ONNX", "dict_it.json"),
-                ModelFile("Kokoro-82M-ONNX", "dict_pt.json"),
-                ModelFile("Kokoro-82M-ONNX", "dict_hi.json"),
-                ModelFile("Kokoro-82M-ONNX", "voices/af_heart.bin"),
-            )
-            // Four LiteRT graphs + the G2P-free tokenizer assets + the 10-voice catalog.
-            TtsModel.SUPERTONIC -> files += listOf(
-                "duration_predictor.tflite", "text_encoder.tflite",
-                "vector_estimator.tflite", "vocoder.tflite",
-                "tts.json", "unicode_indexer.json",
-                "voice_styles/F1.json", "voice_styles/F2.json", "voice_styles/F3.json",
-                "voice_styles/F4.json", "voice_styles/F5.json",
-                "voice_styles/M1.json", "voice_styles/M2.json", "voice_styles/M3.json",
-                "voice_styles/M4.json", "voice_styles/M5.json",
-            ).map { ModelFile("Supertonic-3-LiteRT", it) }
-        }
+        files += ttsModels(ttsModel)
 
         // Noise cancellation
         files += ModelFile("DeepFilterNet3-ONNX", "deepfilter-auxiliary.bin")
         return files
         // Note: FP32 Parakeet encoder also needs parakeet-encoder.onnx.data.
+    }
+
+    private fun ttsModels(ttsModel: TtsModel): List<ModelFile> = when (ttsModel) {
+        TtsModel.KOKORO -> listOf(
+            // E2E model — single file + external weights
+            ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx"),
+            ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx.data"),
+            ModelFile("Kokoro-82M-ONNX", "vocab_index.json"),
+            ModelFile("Kokoro-82M-ONNX", "us_gold.json"),
+            ModelFile("Kokoro-82M-ONNX", "us_silver.json"),
+            ModelFile("Kokoro-82M-ONNX", "dict_fr.json"),
+            ModelFile("Kokoro-82M-ONNX", "dict_es.json"),
+            ModelFile("Kokoro-82M-ONNX", "dict_it.json"),
+            ModelFile("Kokoro-82M-ONNX", "dict_pt.json"),
+            ModelFile("Kokoro-82M-ONNX", "dict_hi.json"),
+            ModelFile("Kokoro-82M-ONNX", "voices/af_heart.bin"),
+        )
+        // Four LiteRT graphs + the G2P-free tokenizer assets + the 10-voice catalog.
+        TtsModel.SUPERTONIC -> listOf(
+            "duration_predictor.tflite", "text_encoder.tflite",
+            "vector_estimator.tflite", "vocoder.tflite",
+            "tts.json", "unicode_indexer.json",
+            "voice_styles/F1.json", "voice_styles/F2.json", "voice_styles/F3.json",
+            "voice_styles/F4.json", "voice_styles/F5.json",
+            "voice_styles/M1.json", "voice_styles/M2.json", "voice_styles/M3.json",
+            "voice_styles/M4.json", "voice_styles/M5.json",
+        ).map { ModelFile("Supertonic-3-LiteRT", it) }
     }
 
     data class ModelFile(val repo: String, val filename: String)
@@ -137,8 +151,8 @@ object ModelManager {
     )
 
     // Report intra-file byte progress at most this often. Without throttling,
-    // downloadFile's 64 KB read loop fires the callback ~13k times for the
-    // ~840 MB encoder, flooding WorkManager's setProgress/setForeground.
+    // downloadFile's 64 KB read loop can fire thousands of callbacks for
+    // large model files, flooding WorkManager's setProgress/setForeground.
     private const val PROGRESS_REPORT_INTERVAL_BYTES = 1_000_000L
 
     /**
@@ -154,7 +168,7 @@ object ModelManager {
     fun areModelsReady(
         context: Context,
         precision: ModelPrecision = ModelPrecision.INT8,
-        sttModel: SttModel = SttModel.PARAKEET,
+        sttModel: SttModel = SttModel.PARAKEET_EOU,
         sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO,
     ): Boolean {
@@ -164,6 +178,7 @@ object ModelManager {
         val versionFile = File(dir, "version.txt")
         val cached = versionFile.takeIf { it.exists() }?.readText()?.trim()?.toIntOrNull() ?: 0
         if (cached < MODEL_VERSION) return false
+        if (cachedModelSet(dir) != modelSetKey(precision, sttModel, sttBackend, ttsModel)) return false
 
         val fileList = models(precision, sttModel, sttBackend, ttsModel)
         val allFiles = if (precision == ModelPrecision.FP32 && sttModel == SttModel.PARAKEET) {
@@ -177,15 +192,42 @@ object ModelManager {
         }
     }
 
+    /**
+     * True iff the TTS-only cache contains every file needed for [ttsModel].
+     * This is used by the Android framework TextToSpeechService path, where
+     * downloading VAD/STT/enhancer assets would be unnecessary overhead.
+     */
+    fun areTtsModelsReady(
+        context: Context,
+        ttsModel: TtsModel = TtsModel.KOKORO,
+    ): Boolean {
+        val dir = File(context.filesDir, "models_tts")
+        if (!dir.exists()) return false
+
+        val versionFile = File(dir, "version.txt")
+        val cached = versionFile.takeIf { it.exists() }?.readText()?.trim()?.toIntOrNull() ?: 0
+        if (cached < MODEL_VERSION) return false
+        if (cachedModelSet(dir) != ttsModelSetKey(ttsModel)) return false
+
+        return ttsModels(ttsModel).all { model ->
+            val dest = File(dir, model.filename)
+            dest.exists() && isValidModel(dest, model.filename)
+        }
+    }
+
     /** Path to the model directory for [precision], without downloading. */
     fun modelDir(context: Context): String =
         File(context.filesDir, "models").absolutePath
+
+    /** Path to the TTS-only model directory, without downloading. */
+    fun ttsModelDir(context: Context): String =
+        File(context.filesDir, "models_tts").absolutePath
 
     /** Returns the model directory path, downloading models if needed. */
     suspend fun ensureModels(
         context: Context,
         precision: ModelPrecision = ModelPrecision.INT8,
-        sttModel: SttModel = SttModel.PARAKEET,
+        sttModel: SttModel = SttModel.PARAKEET_EOU,
         sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO,
         onProgress: ((Progress) -> Unit)? = null,
@@ -194,18 +236,18 @@ object ModelManager {
         dir.mkdirs()
         File(dir, "voices").mkdirs()
 
-        // Invalidate cache if model version changed
+        // Invalidate cache if model version or requested model set changed.
         val versionFile = File(dir, "version.txt")
         val cached = versionFile.takeIf { it.exists() }?.readText()?.trim()?.toIntOrNull() ?: 0
-        if (cached < MODEL_VERSION) {
-            dir.listFiles()?.filter { it.name != "voices" }?.forEach { it.delete() }
-            dir.resolve("voices").listFiles()?.forEach { it.delete() }
+        val requestedModelSet = modelSetKey(precision, sttModel, sttBackend, ttsModel)
+        if (cached < MODEL_VERSION || cachedModelSet(dir) != requestedModelSet) {
+            clearModelCache(dir)
         }
 
         // Note: leftover .tmp files are intentionally preserved here. If a
         // previous run was interrupted, downloadFile resumes via Range:
         // bytes=N- on the next attempt. Stale .tmp from an old MODEL_VERSION
-        // is already wiped above.
+        // or from a different model set are already wiped above.
 
         val fileList = models(precision, sttModel, sttBackend, ttsModel)
         // FP32 Parakeet encoder needs the external data file.
@@ -215,6 +257,50 @@ object ModelManager {
             fileList
         }
 
+        downloadMissingModels(dir, allFiles, onProgress)
+
+        // Write manifest
+        File(dir, "precision.txt").writeText(precision.name)
+        versionFile.writeText(MODEL_VERSION.toString())
+        File(dir, MODEL_SET_FILENAME).writeText(requestedModelSet)
+
+        dir.absolutePath
+    }
+
+    /** Returns the TTS-only model directory path, downloading models if needed. */
+    suspend fun ensureTtsModels(
+        context: Context,
+        ttsModel: TtsModel = TtsModel.KOKORO,
+        onProgress: ((Progress) -> Unit)? = null,
+    ): String = withContext(Dispatchers.IO) {
+        val dir = File(context.filesDir, "models_tts")
+        dir.mkdirs()
+        File(dir, "voices").mkdirs()
+        File(dir, "voice_styles").mkdirs()
+
+        val versionFile = File(dir, "version.txt")
+        val cached = versionFile.takeIf { it.exists() }?.readText()?.trim()?.toIntOrNull() ?: 0
+        val requestedModelSet = ttsModelSetKey(ttsModel)
+        if (cached < MODEL_VERSION || cachedModelSet(dir) != requestedModelSet) {
+            clearModelCache(dir)
+            File(dir, "voices").mkdirs()
+            File(dir, "voice_styles").mkdirs()
+        }
+
+        downloadMissingModels(dir, ttsModels(ttsModel), onProgress)
+
+        File(dir, "precision.txt").writeText("TTS")
+        versionFile.writeText(MODEL_VERSION.toString())
+        File(dir, MODEL_SET_FILENAME).writeText(requestedModelSet)
+
+        dir.absolutePath
+    }
+
+    private fun downloadMissingModels(
+        dir: File,
+        allFiles: List<ModelFile>,
+        onProgress: ((Progress) -> Unit)?,
+    ) {
         var completed = 0
         for (model in allFiles) {
             val dest = File(dir, model.filename)
@@ -235,12 +321,38 @@ object ModelManager {
             }
             completed++
         }
+    }
 
-        // Write manifest
-        File(dir, "precision.txt").writeText(precision.name)
-        versionFile.writeText(MODEL_VERSION.toString())
+    private fun modelSetKey(
+        precision: ModelPrecision,
+        sttModel: SttModel,
+        sttBackend: SttBackend,
+        ttsModel: TtsModel,
+    ): String = listOf(
+        "v$MODEL_VERSION",
+        "precision=${precision.name}",
+        "stt=${sttModel.name}",
+        "backend=${sttBackend.name}",
+        "tts=${ttsModel.name}",
+    ).joinToString("|")
 
-        dir.absolutePath
+    private fun ttsModelSetKey(ttsModel: TtsModel): String = listOf(
+        "v$MODEL_VERSION",
+        "profile=TTS",
+        "tts=${ttsModel.name}",
+    ).joinToString("|")
+
+    private fun cachedModelSet(dir: File): String? =
+        File(dir, MODEL_SET_FILENAME).takeIf { it.exists() }?.readText()?.trim()
+
+    private fun clearModelCache(dir: File) {
+        dir.listFiles()?.forEach { entry ->
+            if (entry.name == "voices") {
+                entry.listFiles()?.forEach { it.deleteRecursively() }
+            } else {
+                entry.deleteRecursively()
+            }
+        }
     }
 
     private fun downloadFile(url: String, dest: File, onBytes: (downloaded: Long, fileTotal: Long) -> Unit) {
@@ -351,8 +463,11 @@ object ModelManager {
     private val MIN_SIZES = mapOf(
         "parakeet-encoder-int8.onnx" to 100_000_000L,   // ~840 MB
         "parakeet-decoder-joint-int8.onnx" to 10_000_000L, // ~51 MB
+        "parakeet-eou-encoder.onnx" to 100_000_000L,    // ~132 MB
+        "parakeet-eou-decoder.onnx" to 10_000_000L,     // ~16 MB
+        "parakeet-eou-joint.onnx" to 1_000_000L,        // ~6 MB
         "kokoro-e2e.onnx" to 1_000L,                     // Small (weights in .data file)
-        "kokoro-e2e.onnx.data" to 50_000_000L,           // ~89 MB
+        "kokoro-e2e.onnx.data" to 50_000_000L,           // ~310 MB
         "silero-vad.onnx" to 500_000L,                   // ~2 MB
     )
 

--- a/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
@@ -10,7 +10,7 @@ internal object NativeBridge {
         modelDir: String,
         useNnapi: Boolean,
         useInt8: Boolean,
-        sttModel: Int,    // SttModel.ordinal: 0=PARAKEET, 1=NEMOTRON_MULTILINGUAL
+        sttModel: Int,    // SttModel.ordinal: 0=PARAKEET, 1=NEMOTRON_MULTILINGUAL, 2=PARAKEET_EOU
         sttBackend: Int,  // SttBackend.ordinal: 0=ONNX, 1=LITERT
         ttsModel: Int,    // TtsModel.ordinal: 0=KOKORO, 1=SUPERTONIC (LiteRT)
         language: String, // prompt locale for Nemotron ("auto", "en-US", ...)
@@ -26,6 +26,16 @@ internal object NativeBridge {
     external fun nativePushAudio(handle: Long, samples: FloatArray, count: Int)
     external fun nativeResumeListen(handle: Long)
     external fun nativeGetState(handle: Long): Int
+
+    external fun nativeCreateSynthesizer(
+        modelDir: String,
+        useNnapi: Boolean,
+        ttsModel: Int,    // TtsModel.ordinal: 0=KOKORO, 1=SUPERTONIC (LiteRT)
+    ): Long
+    external fun nativeDestroySynthesizer(handle: Long)
+    external fun nativeStopSynthesizer(handle: Long)
+    external fun nativeSynthesizerSampleRate(handle: Long): Int
+    external fun nativeSynthesize(handle: Long, text: String, language: String): ByteArray
 
     /** Called from native code on the pipeline worker thread. */
     interface EventCallback {

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
@@ -2,9 +2,10 @@ package audio.soniqo.speech
 
 enum class ModelPrecision { FP32, INT8 }
 
-/** On-device STT model. PARAKEET auto-detects language; NEMOTRON_MULTILINGUAL
- *  is prompt-conditioned and uses [SpeechConfig.language]. */
-enum class SttModel { PARAKEET, NEMOTRON_MULTILINGUAL }
+/** On-device STT model. PARAKEET_EOU is the low-memory streaming default.
+ *  PARAKEET is the larger TDT v3 model; NEMOTRON_MULTILINGUAL is
+ *  prompt-conditioned and uses [SpeechConfig.language]. */
+enum class SttModel { PARAKEET, NEMOTRON_MULTILINGUAL, PARAKEET_EOU }
 
 /** Native inference backend for the STT model. Only Nemotron multilingual
  *  ships both; Parakeet is ONNX-only. */
@@ -23,7 +24,7 @@ data class SpeechConfig(
     val useNnapi: Boolean = true,
 
     /** Which STT model to load. */
-    val sttModel: SttModel = SttModel.PARAKEET,
+    val sttModel: SttModel = SttModel.PARAKEET_EOU,
 
     /** STT inference backend (Nemotron multilingual supports both). */
     val sttBackend: SttBackend = SttBackend.ONNX,

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechSynthesizer.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechSynthesizer.kt
@@ -1,0 +1,83 @@
+package audio.soniqo.speech
+
+/**
+ * Configuration for direct text-to-speech synthesis.
+ *
+ * This is the TTS-only counterpart to [SpeechConfig]. It loads only a
+ * [TtsModel] and does not create the VAD/STT voice pipeline.
+ */
+data class SpeechSynthesizerConfig(
+    /** Path to directory containing TTS model files. */
+    val modelDir: String = "",
+
+    /** Enable NNAPI acceleration where the native backend supports it. */
+    val useNnapi: Boolean = true,
+
+    /** Which TTS model to load. SUPERTONIC requires the LiteRT backend. */
+    val ttsModel: TtsModel = TtsModel.KOKORO,
+)
+
+data class SpeechSynthesisResult(
+    /** PCM sample rate in Hz. */
+    val sampleRate: Int,
+
+    /** Signed little-endian PCM16 mono audio. */
+    val pcm16: ByteArray,
+)
+
+/**
+ * Direct on-device text-to-speech synthesizer.
+ *
+ * Construct via `SpeechSynthesizer(config)` after downloading TTS assets with
+ * [ModelManager.ensureTtsModels]. Tests can provide their own implementation
+ * to avoid loading the native library.
+ */
+interface SpeechSynthesizer : AutoCloseable {
+    val sampleRate: Int
+
+    /** Synthesize [text] as PCM16 mono audio. */
+    fun synthesize(text: String, language: String = "en"): SpeechSynthesisResult
+
+    /** Cancel any in-progress synthesis. */
+    fun stop()
+
+    companion object {
+        operator fun invoke(config: SpeechSynthesizerConfig): SpeechSynthesizer =
+            SpeechSynthesizerImpl(config)
+    }
+}
+
+internal class SpeechSynthesizerImpl(config: SpeechSynthesizerConfig) : SpeechSynthesizer {
+    private var handle: Long = NativeBridge.nativeCreateSynthesizer(
+        config.modelDir,
+        config.useNnapi,
+        config.ttsModel.ordinal,
+    ).also { h ->
+        if (h == 0L) throw IllegalStateException(
+            "Failed to create native synthesizer. Models may be corrupt - " +
+                "try clearing app data and reinstalling."
+        )
+    }
+
+    override val sampleRate: Int
+        get() = NativeBridge.nativeSynthesizerSampleRate(handle)
+
+    override fun synthesize(text: String, language: String): SpeechSynthesisResult {
+        check(handle != 0L) { "SpeechSynthesizer is closed" }
+        return SpeechSynthesisResult(
+            sampleRate = sampleRate,
+            pcm16 = NativeBridge.nativeSynthesize(handle, text, language),
+        )
+    }
+
+    override fun stop() {
+        if (handle != 0L) NativeBridge.nativeStopSynthesizer(handle)
+    }
+
+    override fun close() {
+        if (handle != 0L) {
+            NativeBridge.nativeDestroySynthesizer(handle)
+            handle = 0
+        }
+    }
+}

--- a/sdk/src/main/kotlin/audio/soniqo/speech/service/SpeechRecognitionService.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/service/SpeechRecognitionService.kt
@@ -50,8 +50,8 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Settings → System → Languages & input → Voice input.
  *
  * The service reads the microphone itself via [AudioRecord] — callers do not
- * push audio. `EXTRA_LANGUAGE` is currently logged but not enforced; Parakeet
- * v3 auto-detects across 114 languages.
+ * push audio. `EXTRA_LANGUAGE` is currently logged but not enforced; the
+ * default Parakeet-EOU model covers the languages advertised below.
  *
  * Open for test subclassing: [createPipeline], [resolveModelDir], and
  * [newAudioRecord] are protected seams so JVM unit tests can run without
@@ -140,7 +140,6 @@ open class SpeechRecognitionService : RecognitionService() {
         pipeline.start()
         record.startRecording()
         requestAudioFocus()
-        listener.readyForSpeech(Bundle.EMPTY)
 
         val eventJob = scope.launch {
             pipeline.events.collect { ev -> handleEvent(ev, listener) }
@@ -161,6 +160,7 @@ open class SpeechRecognitionService : RecognitionService() {
         }
 
         session = Session(pipeline, record, micJob, eventJob)
+        listener.readyForSpeech(Bundle.EMPTY)
     }
 
     private fun handleEvent(event: SpeechEvent, listener: Callback) {
@@ -367,8 +367,7 @@ open class SpeechRecognitionService : RecognitionService() {
      * surface a "downloading" UX instead of falling back to an online
      * recognizer.
      *
-     * The list is a representative subset of Parakeet TDT v3's claimed
-     * 114-language support — extend [SUPPORTED_LANGUAGES] to advertise more.
+     * The list mirrors Parakeet-EOU-120M's published 25-language coverage.
      */
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCheckRecognitionSupport(
@@ -388,16 +387,15 @@ open class SpeechRecognitionService : RecognitionService() {
         private const val TAG = "SoniqoRecognition"
 
         /**
-         * BCP-47 tags advertised via [onCheckRecognitionSupport]. Parakeet
-         * TDT v3 is multilingual; this is a curated subset of the most-
-         * requested languages — extend as needed.
+         * BCP-47 tags advertised via [onCheckRecognitionSupport]. Keep this
+         * in sync with the default STT model in [SpeechConfig].
          */
         @JvmField
         val SUPPORTED_LANGUAGES: List<String> = listOf(
-            "ar", "cs", "da", "de", "el", "en", "es", "fi",
-            "fr", "he", "hi", "hu", "id", "it", "ja", "ko",
-            "nb", "nl", "pl", "pt", "ru", "sv", "th", "tr",
-            "uk", "vi", "zh",
+            "bg", "cs", "da", "de", "el", "en", "es", "et",
+            "fi", "fr", "hr", "hu", "it", "lt", "lv", "mt",
+            "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sv",
+            "uk",
         )
     }
 }

--- a/sdk/src/main/kotlin/audio/soniqo/speech/service/SpeechTextToSpeechService.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/service/SpeechTextToSpeechService.kt
@@ -1,0 +1,194 @@
+package audio.soniqo.speech.service
+
+import android.media.AudioFormat
+import android.speech.tts.SynthesisCallback
+import android.speech.tts.SynthesisRequest
+import android.speech.tts.TextToSpeech
+import android.speech.tts.TextToSpeechService
+import android.speech.tts.Voice
+import android.util.Log
+import audio.soniqo.speech.ModelManager
+import audio.soniqo.speech.SpeechSynthesizer
+import audio.soniqo.speech.SpeechSynthesizerConfig
+import audio.soniqo.speech.TtsModel
+import kotlinx.coroutines.runBlocking
+import java.util.Locale
+
+/**
+ * Android framework TextToSpeech engine backed by the on-device Kokoro model.
+ *
+ * Apps expose this service from their manifest with
+ * `android.intent.action.TTS_SERVICE` and `android.speech.tts` metadata.
+ */
+open class SpeechTextToSpeechService : TextToSpeechService() {
+
+    private val synthesizerLock = Any()
+
+    @Volatile
+    private var stopped = false
+
+    private var synthesizer: SpeechSynthesizer? = null
+
+    override fun onGetLanguage(): Array<String> =
+        arrayOf(DEFAULT_LANGUAGE_ISO3, DEFAULT_COUNTRY_ISO3, "")
+
+    override fun onIsLanguageAvailable(lang: String?, country: String?, variant: String?): Int =
+        languageAvailability(lang, country, variant)
+
+    override fun onLoadLanguage(lang: String?, country: String?, variant: String?): Int =
+        languageAvailability(lang, country, variant)
+
+    override fun onGetVoices(): MutableList<Voice> =
+        mutableListOf(DEFAULT_VOICE)
+
+    override fun onGetDefaultVoiceNameFor(lang: String?, country: String?, variant: String?): String? =
+        if (languageAvailability(lang, country, variant) == TextToSpeech.LANG_NOT_SUPPORTED) {
+            null
+        } else {
+            DEFAULT_VOICE_NAME
+        }
+
+    override fun onIsValidVoiceName(voiceName: String?): Int =
+        if (voiceName == DEFAULT_VOICE_NAME) TextToSpeech.SUCCESS else TextToSpeech.ERROR
+
+    override fun onLoadVoice(voiceName: String?): Int =
+        onIsValidVoiceName(voiceName)
+
+    override fun onStop() {
+        stopped = true
+        synthesizer?.stop()
+    }
+
+    override fun onSynthesizeText(request: SynthesisRequest, callback: SynthesisCallback) {
+        val text = request.charSequenceText?.toString()?.trim().orEmpty()
+        if (text.isEmpty()) {
+            callback.error(TextToSpeech.ERROR_INVALID_REQUEST)
+            return
+        }
+
+        stopped = false
+        try {
+            val synth = getOrCreateSynthesizer()
+            val result = synth.synthesize(text, normalizeLanguage(request.language))
+            if (stopped) {
+                callback.error()
+                return
+            }
+            if (result.pcm16.isEmpty()) {
+                callback.error(TextToSpeech.ERROR_SYNTHESIS)
+                return
+            }
+
+            val started = callback.start(
+                result.sampleRate,
+                AudioFormat.ENCODING_PCM_16BIT,
+                CHANNEL_COUNT_MONO,
+            )
+            if (started != TextToSpeech.SUCCESS) return
+
+            if (writeAudio(callback, result.pcm16) && !callback.hasFinished()) {
+                callback.done()
+            }
+        } catch (t: Throwable) {
+            Log.e(TAG, "Text-to-speech synthesis failed", t)
+            if (!callback.hasFinished()) callback.error(TextToSpeech.ERROR_SYNTHESIS)
+        }
+    }
+
+    override fun onDestroy() {
+        synchronized(synthesizerLock) {
+            synthesizer?.close()
+            synthesizer = null
+        }
+        super.onDestroy()
+    }
+
+    protected open suspend fun resolveModelDir(): String =
+        ModelManager.ensureTtsModels(applicationContext, TtsModel.KOKORO)
+
+    protected open fun createSynthesizer(config: SpeechSynthesizerConfig): SpeechSynthesizer =
+        SpeechSynthesizer(config)
+
+    private fun getOrCreateSynthesizer(): SpeechSynthesizer {
+        synchronized(synthesizerLock) {
+            synthesizer?.let { return it }
+        }
+
+        val modelDir = runBlocking { resolveModelDir() }
+        return synchronized(synthesizerLock) {
+            synthesizer ?: createSynthesizer(
+                SpeechSynthesizerConfig(
+                    modelDir = modelDir,
+                    useNnapi = true,
+                    ttsModel = TtsModel.KOKORO,
+                )
+            ).also { synthesizer = it }
+        }
+    }
+
+    private fun writeAudio(callback: SynthesisCallback, pcm16: ByteArray): Boolean {
+        val maxBuffer = callback.maxBufferSize.takeIf { it > 0 } ?: DEFAULT_CHUNK_BYTES
+        var offset = 0
+        while (offset < pcm16.size) {
+            if (stopped) {
+                callback.error()
+                return false
+            }
+            val count = minOf(maxBuffer, pcm16.size - offset)
+            val status = callback.audioAvailable(pcm16, offset, count)
+            if (status != TextToSpeech.SUCCESS) return false
+            offset += count
+        }
+        return true
+    }
+
+    companion object {
+        const val DEFAULT_VOICE_NAME = "soniqo-kokoro-af-heart"
+        val DEFAULT_LOCALE: Locale = Locale.US
+
+        private const val TAG = "SpeechTtsService"
+        private const val CHANNEL_COUNT_MONO = 1
+        private const val DEFAULT_CHUNK_BYTES = 8192
+        private const val DEFAULT_LANGUAGE_ISO2 = "en"
+        private const val DEFAULT_LANGUAGE_ISO3 = "eng"
+        private const val DEFAULT_COUNTRY_ISO2 = "US"
+        private const val DEFAULT_COUNTRY_ISO3 = "USA"
+
+        private val VOICE_FEATURES = setOf(TextToSpeech.Engine.KEY_FEATURE_EMBEDDED_SYNTHESIS)
+        private val DEFAULT_VOICE = Voice(
+            DEFAULT_VOICE_NAME,
+            DEFAULT_LOCALE,
+            Voice.QUALITY_NORMAL,
+            Voice.LATENCY_NORMAL,
+            false,
+            VOICE_FEATURES,
+        )
+
+        internal fun languageAvailability(
+            lang: String?,
+            country: String?,
+            variant: String?,
+        ): Int {
+            if (!isEnglishLanguage(lang)) return TextToSpeech.LANG_NOT_SUPPORTED
+            if (country.isNullOrBlank()) return TextToSpeech.LANG_AVAILABLE
+            if (!isUsCountry(country)) return TextToSpeech.LANG_AVAILABLE
+            return if (variant.isNullOrBlank()) {
+                TextToSpeech.LANG_COUNTRY_AVAILABLE
+            } else {
+                TextToSpeech.LANG_COUNTRY_VAR_AVAILABLE
+            }
+        }
+
+        internal fun normalizeLanguage(lang: String?): String =
+            if (isEnglishLanguage(lang)) DEFAULT_LANGUAGE_ISO2 else DEFAULT_LANGUAGE_ISO2
+
+        private fun isEnglishLanguage(lang: String?): Boolean =
+            lang.isNullOrBlank() ||
+                lang.equals(DEFAULT_LANGUAGE_ISO2, ignoreCase = true) ||
+                lang.equals(DEFAULT_LANGUAGE_ISO3, ignoreCase = true)
+
+        private fun isUsCountry(country: String?): Boolean =
+            country.equals(DEFAULT_COUNTRY_ISO2, ignoreCase = true) ||
+                country.equals(DEFAULT_COUNTRY_ISO3, ignoreCase = true)
+    }
+}

--- a/sdk/src/test/kotlin/audio/soniqo/speech/DownloadProgressTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/DownloadProgressTest.kt
@@ -8,17 +8,16 @@ import org.junit.Test
  * Regression test for issue #30 — "download bar appears frozen / hung".
  *
  * Pure-JVM (no Robolectric / device / network): it drives the REAL production
- * percent function [ModelDownloadWorker.progressPercent] over the actual 16-file
- * INT8 size distribution, replaying the byte-stream contract of
+ * percent function [ModelDownloadWorker.progressPercent] over the default
+ * low-memory INT8 size distribution, replaying the byte-stream contract of
  * [ModelManager.ensureModels] (per-file `bytesDownloaded`, `completed`
  * increments only AFTER each file lands).
  *
  * The old behaviour computed `pct = completed * 100 / totalFiles`, which pinned
- * the bar to a single value for the entire ~840 MB `parakeet-encoder-int8.onnx`
- * download (file #2) — indistinguishable from a hang. The fix makes the percent
- * byte-aware, so it advances continuously through the dominant file. These
- * assertions lock that in: the bar must MOVE during the encoder and never go
- * backwards.
+ * the bar to a single value for an entire large model file — indistinguishable
+ * from a hang. The fix makes the percent byte-aware, so it advances
+ * continuously through the dominant file. These assertions lock that in: the
+ * bar must MOVE during the large file and never go backwards.
  *
  * Run: `./gradlew :sdk:test --tests '*DownloadProgressTest*'`
  */
@@ -27,26 +26,28 @@ class DownloadProgressTest {
     private data class Sized(val name: String, val bytes: Long)
 
     private val MB = 1_000_000L
-    private val totalFiles = 16
+    private val totalFiles = 18
 
-    /** Real INT8 manifest order/sizes; file #2 dwarfs the rest (~85% of bytes). */
+    /** Default low-memory INT8 manifest order/sizes. */
     private val manifest = listOf(
         Sized("silero-vad.onnx", 2 * MB),                   // #1
-        Sized("parakeet-encoder-int8.onnx", 840 * MB),      // #2  <-- the giant
-        Sized("parakeet-decoder-joint-int8.onnx", 51 * MB), // #3
-        Sized("vocab.json", 1 * MB),                        // #4
-        Sized("kokoro-e2e.onnx", 1 * MB),                   // #5
-        Sized("kokoro-e2e.onnx.data", 89 * MB),             // #6
-        Sized("vocab_index.json", 1 * MB),                  // #7
-        Sized("us_gold.json", 2 * MB),                      // #8
-        Sized("us_silver.json", 2 * MB),                    // #9
-        Sized("dict_fr.json", 1 * MB),                      // #10
-        Sized("dict_es.json", 1 * MB),                      // #11
-        Sized("dict_it.json", 1 * MB),                      // #12
-        Sized("dict_pt.json", 1 * MB),                      // #13
-        Sized("dict_hi.json", 1 * MB),                      // #14
-        Sized("voices/af_heart.bin", 1 * MB),               // #15
-        Sized("deepfilter-auxiliary.bin", 2 * MB),          // #16
+        Sized("parakeet-eou-encoder.onnx", 132 * MB),       // #2
+        Sized("parakeet-eou-decoder.onnx", 16 * MB),        // #3
+        Sized("parakeet-eou-joint.onnx", 6 * MB),           // #4
+        Sized("vocab.json", 1 * MB),                        // #5
+        Sized("config.json", 1 * MB),                       // #6
+        Sized("kokoro-e2e.onnx", 3 * MB),                   // #7
+        Sized("kokoro-e2e.onnx.data", 325 * MB),            // #8  <-- the giant
+        Sized("vocab_index.json", 1 * MB),                  // #9
+        Sized("us_gold.json", 2 * MB),                      // #10
+        Sized("us_silver.json", 4 * MB),                    // #11
+        Sized("dict_fr.json", 1 * MB),                      // #12
+        Sized("dict_es.json", 1 * MB),                      // #13
+        Sized("dict_it.json", 1 * MB),                      // #14
+        Sized("dict_pt.json", 1 * MB),                      // #15
+        Sized("dict_hi.json", 1 * MB),                      // #16
+        Sized("voices/af_heart.bin", 1 * MB),               // #17
+        Sized("deepfilter-auxiliary.bin", 2 * MB),          // #18
     )
 
     private val CHUNK = 65536L
@@ -86,17 +87,17 @@ class DownloadProgressTest {
     @Test
     fun progressPercent_isByteAware_unitValues() {
         // Whole files done plus the fraction of the file in flight.
-        assertEquals(6, ModelDownloadWorker.progressPercent(1, 16, 0, 840 * MB))        // start of encoder
-        assertEquals(9, ModelDownloadWorker.progressPercent(1, 16, 420 * MB, 840 * MB)) // half the encoder
-        assertEquals(12, ModelDownloadWorker.progressPercent(2, 16, 0, 89 * MB))        // after encoder lands
-        assertEquals(100, ModelDownloadWorker.progressPercent(16, 16, 0, 0))            // all files done
+        assertEquals(5, ModelDownloadWorker.progressPercent(1, 18, 0, 132 * MB))        // start of EOU encoder
+        assertEquals(8, ModelDownloadWorker.progressPercent(1, 18, 66 * MB, 132 * MB))  // half the EOU encoder
+        assertEquals(38, ModelDownloadWorker.progressPercent(7, 18, 0, 325 * MB))       // start of Kokoro weights
+        assertEquals(100, ModelDownloadWorker.progressPercent(18, 18, 0, 0))            // all files done
     }
 
     @Test
     fun progressPercent_unknownFileSize_fallsBackToFileCount() {
         // When the server doesn't advertise a length, the in-flight file adds
         // no fraction — degrades to the old whole-file value for that file only.
-        assertEquals(6, ModelDownloadWorker.progressPercent(1, 16, 12345, 0))
+        assertEquals(5, ModelDownloadWorker.progressPercent(1, 18, 12345, 0))
     }
 
     @Test
@@ -106,35 +107,35 @@ class DownloadProgressTest {
 
     @Test
     fun fixed_barMovesContinuouslyThroughTheEncoder() {
-        val encoder = simulate().filter { it.file == "parakeet-encoder-int8.onnx" }
+        val largeFile = simulate().filter { it.file == "kokoro-e2e.onnx.data" }
 
         // The whole point of the fix: the bar is NO LONGER frozen on the
         // dominant file — it advances through several distinct values.
-        val distinct = encoder.map { it.percent }.toSet()
+        val distinct = largeFile.map { it.percent }.toSet()
         assertTrue(
-            "encoder percent should advance through several values, got $distinct",
+            "large file percent should advance through several values, got $distinct",
             distinct.size >= 6,
         )
-        // It spans roughly 6% -> 12% (one file's worth of the 16-file bar).
-        assertEquals("encoder starts at ~6%", 6, encoder.first().percent)
-        assertEquals("encoder ends at ~12%", 12, encoder.last().percent)
+        // It spans roughly 38% -> 44% (one file's worth of the 18-file bar).
+        assertEquals("large file starts at ~38%", 38, largeFile.first().percent)
+        assertEquals("large file ends at ~44%", 44, largeFile.last().percent)
         // ...and is monotonic non-decreasing within the file.
         assertTrue(
-            "encoder percent must never go backwards",
-            encoder.zipWithNext().all { (a, b) -> b.percent >= a.percent },
+            "large file percent must never go backwards",
+            largeFile.zipWithNext().all { (a, b) -> b.percent >= a.percent },
         )
     }
 
     @Test
-    fun fixed_byHalfTheEncoderBarHasMovedPastTheOldFrozenCeiling() {
-        // Before the fix the bar was pinned at 6 for the entire encoder. Now,
-        // halfway through the encoder bytes it has already climbed past 6.
-        val encoder = simulate().filter { it.file == "parakeet-encoder-int8.onnx" }
-        val midpoint = encoder.first { it.fileBytes >= it.fileTotal / 2 }
+    fun fixed_byHalfTheLargeFileBarHasMovedPastTheOldFrozenCeiling() {
+        // Before the fix the bar was pinned at the whole-file count for the
+        // entire large file. Now, halfway through the bytes it has climbed.
+        val largeFile = simulate().filter { it.file == "kokoro-e2e.onnx.data" }
+        val midpoint = largeFile.first { it.fileBytes >= it.fileTotal / 2 }
         assertTrue(
-            "halfway through the encoder the bar should read >= 9 (was frozen at 6), " +
+            "halfway through the large file the bar should read >= 41 (was frozen at 38), " +
                 "was ${midpoint.percent}",
-            midpoint.percent >= 9,
+            midpoint.percent >= 41,
         )
     }
 

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
@@ -1,6 +1,8 @@
 package audio.soniqo.speech
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 /**
@@ -14,8 +16,69 @@ import org.junit.Test
 class ModelManagerManifestTest {
 
     @Test
+    fun speechConfigDefault_usesLowMemoryParakeetEou() {
+        assertEquals(SttModel.PARAKEET_EOU, SpeechConfig().sttModel)
+    }
+
+    @Test
+    fun defaultSttManifest_usesParakeetEouBundle() {
+        val eouFiles = modelFiles(sttModel = SttModel.PARAKEET_EOU)
+            .filter { it.repo == "Parakeet-EOU-120M-ONNX-INT8" }
+
+        val expected = listOf(
+            ModelManager.ModelFile("Parakeet-EOU-120M-ONNX-INT8", "parakeet-eou-encoder.onnx"),
+            ModelManager.ModelFile("Parakeet-EOU-120M-ONNX-INT8", "parakeet-eou-decoder.onnx"),
+            ModelManager.ModelFile("Parakeet-EOU-120M-ONNX-INT8", "parakeet-eou-joint.onnx"),
+            ModelManager.ModelFile("Parakeet-EOU-120M-ONNX-INT8", "vocab.json"),
+            ModelManager.ModelFile("Parakeet-EOU-120M-ONNX-INT8", "config.json"),
+        )
+
+        assertEquals(expected, eouFiles)
+    }
+
+    @Test
+    fun modelSetKey_changesWhenSttModelChanges() {
+        assertNotEquals(
+            modelSetKey(sttModel = SttModel.PARAKEET_EOU),
+            modelSetKey(sttModel = SttModel.PARAKEET),
+        )
+    }
+
+    @Test
+    fun ttsOnlyManifest_usesKokoroFilesWithoutPipelineAssets() {
+        val files = ttsModelFiles(TtsModel.KOKORO)
+
+        assertEquals(
+            listOf(
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx.data"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "vocab_index.json"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "us_gold.json"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "us_silver.json"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "dict_fr.json"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "dict_es.json"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "dict_it.json"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "dict_pt.json"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "dict_hi.json"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "voices/af_heart.bin"),
+            ),
+            files,
+        )
+        assertFalse(files.any { it.repo.contains("Parakeet") || it.repo.contains("Silero") })
+        assertFalse(files.any { it.filename.startsWith("deepfilter") })
+    }
+
+    @Test
+    fun ttsOnlyModelSetKey_isSeparateFromPipelineCacheKey() {
+        assertNotEquals(
+            modelSetKey(ttsModel = TtsModel.KOKORO),
+            ttsModelSetKey(TtsModel.KOKORO),
+        )
+    }
+
+    @Test
     fun supertonicManifest_includesCompleteVoiceCatalogFromLiteRtRepo() {
-        val styleFiles = modelFiles(TtsModel.SUPERTONIC)
+        val styleFiles = modelFiles(ttsModel = TtsModel.SUPERTONIC)
             .filter { it.filename.startsWith("voice_styles/") }
 
         val expected = listOf(
@@ -35,7 +98,10 @@ class ModelManagerManifestTest {
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun modelFiles(ttsModel: TtsModel): List<ModelManager.ModelFile> {
+    private fun modelFiles(
+        sttModel: SttModel = SttModel.PARAKEET_EOU,
+        ttsModel: TtsModel = TtsModel.KOKORO,
+    ): List<ModelManager.ModelFile> {
         val models = ModelManager::class.java.getDeclaredMethod(
             "models",
             ModelPrecision::class.java,
@@ -47,9 +113,51 @@ class ModelManagerManifestTest {
         return models.invoke(
             ModelManager,
             ModelPrecision.INT8,
-            SttModel.PARAKEET,
+            sttModel,
             SttBackend.ONNX,
             ttsModel,
         ) as List<ModelManager.ModelFile>
+    }
+
+    private fun modelSetKey(
+        precision: ModelPrecision = ModelPrecision.INT8,
+        sttModel: SttModel = SttModel.PARAKEET_EOU,
+        sttBackend: SttBackend = SttBackend.ONNX,
+        ttsModel: TtsModel = TtsModel.KOKORO,
+    ): String {
+        val method = ModelManager::class.java.getDeclaredMethod(
+            "modelSetKey",
+            ModelPrecision::class.java,
+            SttModel::class.java,
+            SttBackend::class.java,
+            TtsModel::class.java,
+        )
+        method.isAccessible = true
+        return method.invoke(
+            ModelManager,
+            precision,
+            sttModel,
+            sttBackend,
+            ttsModel,
+        ) as String
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun ttsModelFiles(ttsModel: TtsModel): List<ModelManager.ModelFile> {
+        val method = ModelManager::class.java.getDeclaredMethod(
+            "ttsModels",
+            TtsModel::class.java,
+        )
+        method.isAccessible = true
+        return method.invoke(ModelManager, ttsModel) as List<ModelManager.ModelFile>
+    }
+
+    private fun ttsModelSetKey(ttsModel: TtsModel): String {
+        val method = ModelManager::class.java.getDeclaredMethod(
+            "ttsModelSetKey",
+            TtsModel::class.java,
+        )
+        method.isAccessible = true
+        return method.invoke(ModelManager, ttsModel) as String
     }
 }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechRecognitionServiceTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechRecognitionServiceTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -183,10 +184,10 @@ class SpeechRecognitionServiceTest {
             "pending should include 'en'",
             support.pendingOnDeviceLanguages.contains("en"),
         )
-        assertTrue(
+        assertEquals(
             "pending should match SUPPORTED_LANGUAGES",
-            support.pendingOnDeviceLanguages
-                .containsAll(SpeechRecognitionService.SUPPORTED_LANGUAGES),
+            SpeechRecognitionService.SUPPORTED_LANGUAGES,
+            support.pendingOnDeviceLanguages,
         )
     }
 

--- a/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechTextToSpeechServiceTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechTextToSpeechServiceTest.kt
@@ -1,0 +1,213 @@
+package audio.soniqo.speech.service
+
+import android.media.AudioFormat
+import android.os.Bundle
+import android.speech.tts.SynthesisCallback
+import android.speech.tts.SynthesisRequest
+import android.speech.tts.TextToSpeech
+import androidx.test.core.app.ApplicationProvider
+import audio.soniqo.speech.SpeechSynthesisResult
+import audio.soniqo.speech.SpeechSynthesizer
+import audio.soniqo.speech.SpeechSynthesizerConfig
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.android.controller.ServiceController
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class SpeechTextToSpeechServiceTest {
+
+    private lateinit var fakeSynthesizer: FakeSynthesizer
+    private lateinit var controller: ServiceController<TestableService>
+    private lateinit var service: TestableService
+
+    @Before
+    fun setUp() {
+        fakeSynthesizer = FakeSynthesizer(
+            byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8, 9),
+        )
+        controller = Robolectric.buildService(TestableService::class.java)
+        service = controller.create().get()
+        service.install(fakeSynthesizer)
+    }
+
+    @After
+    fun tearDown() {
+        controller.destroy()
+    }
+
+    @Test
+    fun languageContract_exposesEmbeddedEnglishVoice() {
+        assertArrayEquals(arrayOf("eng", "USA", ""), service.getLanguage())
+        assertEquals(
+            TextToSpeech.LANG_COUNTRY_AVAILABLE,
+            service.isLanguageAvailable("eng", "USA", ""),
+        )
+        assertEquals(
+            TextToSpeech.LANG_NOT_SUPPORTED,
+            service.isLanguageAvailable("fra", "FRA", ""),
+        )
+
+        val voice = service.getVoices().single()
+        assertEquals(SpeechTextToSpeechService.DEFAULT_VOICE_NAME, voice.name)
+        assertEquals(SpeechTextToSpeechService.DEFAULT_LOCALE, voice.locale)
+        assertTrue(voice.features.contains(TextToSpeech.Engine.KEY_FEATURE_EMBEDDED_SYNTHESIS))
+        assertEquals(
+            SpeechTextToSpeechService.DEFAULT_VOICE_NAME,
+            service.defaultVoiceNameFor("eng", "USA", ""),
+        )
+    }
+
+    @Test
+    fun synthesizeText_streamsPcm16ChunksAndCompletes() {
+        val callback = RecordingSynthesisCallback(maxBufferSize = 4)
+
+        service.synthesize(SynthesisRequest("hello", Bundle.EMPTY), callback)
+
+        assertEquals("/fake/models_tts", service.createdConfig?.modelDir)
+        assertEquals("hello", fakeSynthesizer.lastText)
+        assertEquals("en", fakeSynthesizer.lastLanguage)
+        assertEquals(24_000, callback.sampleRate)
+        assertEquals(AudioFormat.ENCODING_PCM_16BIT, callback.audioFormat)
+        assertEquals(1, callback.channelCount)
+        assertEquals(listOf(4, 4, 1), callback.chunks.map { it.size })
+        assertEquals(1, callback.doneCount)
+        assertEquals(null, callback.errorCode)
+    }
+
+    @Test
+    fun synthesizeText_emptyInputReportsInvalidRequest() {
+        val callback = RecordingSynthesisCallback()
+
+        service.synthesize(SynthesisRequest("  ", Bundle.EMPTY), callback)
+
+        assertEquals(TextToSpeech.ERROR_INVALID_REQUEST, callback.errorCode)
+        assertEquals(0, fakeSynthesizer.synthesizeCalls)
+    }
+
+    @Test
+    fun stop_cancelsSynthesizer() {
+        service.synthesize(SynthesisRequest("hello", Bundle.EMPTY), RecordingSynthesisCallback())
+
+        service.stop()
+
+        assertTrue(fakeSynthesizer.stopped)
+    }
+
+    class TestableService : SpeechTextToSpeechService() {
+        private lateinit var fakeSynthesizer: FakeSynthesizer
+        var createdConfig: SpeechSynthesizerConfig? = null
+            private set
+
+        fun install(synthesizer: FakeSynthesizer) {
+            fakeSynthesizer = synthesizer
+        }
+
+        fun getLanguage(): Array<String> = onGetLanguage()
+
+        fun isLanguageAvailable(lang: String, country: String, variant: String): Int =
+            onIsLanguageAvailable(lang, country, variant)
+
+        fun getVoices() = onGetVoices()
+
+        fun defaultVoiceNameFor(lang: String, country: String, variant: String): String? =
+            onGetDefaultVoiceNameFor(lang, country, variant)
+
+        fun synthesize(request: SynthesisRequest, callback: SynthesisCallback) =
+            onSynthesizeText(request, callback)
+
+        fun stop() = onStop()
+
+        override suspend fun resolveModelDir(): String {
+            ApplicationProvider.getApplicationContext<android.content.Context>()
+            return "/fake/models_tts"
+        }
+
+        override fun createSynthesizer(config: SpeechSynthesizerConfig): SpeechSynthesizer {
+            createdConfig = config
+            return fakeSynthesizer
+        }
+    }
+
+    class FakeSynthesizer(
+        private val output: ByteArray,
+    ) : SpeechSynthesizer {
+        override val sampleRate: Int = 24_000
+        var lastText: String? = null
+        var lastLanguage: String? = null
+        var synthesizeCalls = 0
+        var stopped = false
+        var closed = false
+
+        override fun synthesize(text: String, language: String): SpeechSynthesisResult {
+            synthesizeCalls++
+            lastText = text
+            lastLanguage = language
+            return SpeechSynthesisResult(sampleRate, output)
+        }
+
+        override fun stop() {
+            stopped = true
+        }
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    class RecordingSynthesisCallback(
+        private val maxBufferSize: Int = 8192,
+    ) : SynthesisCallback {
+        var sampleRate: Int? = null
+        var audioFormat: Int? = null
+        var channelCount: Int? = null
+        val chunks = mutableListOf<ByteArray>()
+        var doneCount = 0
+        var errorCode: Int? = null
+        private var started = false
+        private var finished = false
+
+        override fun getMaxBufferSize(): Int = maxBufferSize
+
+        override fun start(sampleRateInHz: Int, audioFormat: Int, channelCount: Int): Int {
+            started = true
+            sampleRate = sampleRateInHz
+            this.audioFormat = audioFormat
+            this.channelCount = channelCount
+            return TextToSpeech.SUCCESS
+        }
+
+        override fun audioAvailable(buffer: ByteArray, offset: Int, length: Int): Int {
+            chunks += buffer.copyOfRange(offset, offset + length)
+            return TextToSpeech.SUCCESS
+        }
+
+        override fun done(): Int {
+            finished = true
+            doneCount++
+            return TextToSpeech.SUCCESS
+        }
+
+        override fun error() {
+            finished = true
+            errorCode = TextToSpeech.ERROR
+        }
+
+        override fun error(errorCode: Int) {
+            finished = true
+            this.errorCode = errorCode
+        }
+
+        override fun hasStarted(): Boolean = started
+
+        override fun hasFinished(): Boolean = finished
+    }
+}


### PR DESCRIPTION
## Summary
- add Android framework TextToSpeechService backed by on-device Kokoro synthesis
- add direct SpeechSynthesizer Kotlin/JNI API for TTS-only use
- add TTS-only model cache/download path so system TTS does not pull VAD/STT/enhancer assets
- switch Android defaults/docs to the low-memory Parakeet-EOU model bundle
- add regression tests for TTS engine manifest discovery, TTS service synthesis callback behavior, and TTS-only model manifests

## Test plan
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew :sdk:test :app:testDebugUnitTest :app:assembleDebug

Fixes #40
