### PR TITLE
Fix Duolingo recognition service compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,11 @@ framework callback — useful for confirming the binder round-trip without
 needing logcat.
 
 The service implements `onCheckRecognitionSupport` (API 33+) returning the
-25 BCP-47 languages Parakeet-EOU covers, marked
-`installedOnDeviceLanguage` once models are present (or
-`pendingOnDeviceLanguage` while they're downloading). Audio focus is
-acquired with `AUDIOFOCUS_GAIN_TRANSIENT` for the duration of a session.
+25 BCP-47 base languages Parakeet-EOU covers, plus the exact requested
+regional tag when it maps to a supported base language. Languages are marked
+`installedOnDeviceLanguage` once models are present, or
+`supportedOnDeviceLanguage` before download. The service does not take audio
+focus from the calling app.
 
 **Caveat:** Gboard, Samsung Keyboard, and Google Assistant bundle their own
 recognizers and skip the system default. Apps that explicitly call the

--- a/README_de.md
+++ b/README_de.md
@@ -134,7 +134,7 @@ adb shell settings put secure voice_recognition_service \
 
 **4. Verifiziere**, indem du den *Recognizer test*-Bildschirm der Demo-App ausführst, der `SpeechRecognizer.createSpeechRecognizer(ctx)` (ohne Komponente) aufruft und jeden Framework-Callback protokolliert — nützlich, um den Binder-Roundtrip ohne logcat zu bestätigen.
 
-Der Dienst implementiert `onCheckRecognitionSupport` (API 33+) und gibt die 25 BCP-47-Sprachen zurück, die Parakeet-EOU abdeckt, markiert als `installedOnDeviceLanguage`, sobald Modelle vorhanden sind (oder `pendingOnDeviceLanguage`, während sie heruntergeladen werden). Während einer Sitzung wird Audiofokus mit `AUDIOFOCUS_GAIN_TRANSIENT` angefordert.
+Der Dienst implementiert `onCheckRecognitionSupport` (API 33+) und gibt die 25 BCP-47-Basissprachen zurück, die Parakeet-EOU abdeckt, plus das exakt angeforderte regionale Tag, wenn es zu einer unterstützten Basissprache gehört. Sprachen werden als `installedOnDeviceLanguage` markiert, sobald Modelle vorhanden sind, oder vor dem Download als `supportedOnDeviceLanguage`. Der Dienst nimmt der aufrufenden App keinen Audiofokus weg.
 
 **Einschränkung:** Gboard, Samsung Keyboard und Google Assistant bringen eigene Erkenner mit und überspringen den System-Standard. Apps, die die Framework-`SpeechRecognizer`-API explizit aufrufen (oder eine eigene UI darauf aufbauen), gehen über deinen Dienst.
 

--- a/README_es.md
+++ b/README_es.md
@@ -146,10 +146,11 @@ registra cada callback del framework — útil para confirmar el round-trip del
 binder sin necesitar logcat.
 
 El servicio implementa `onCheckRecognitionSupport` (API 33+) devolviendo los
-25 idiomas BCP-47 que cubre Parakeet-EOU, marcados como
-`installedOnDeviceLanguage` cuando los modelos están presentes (o
-`pendingOnDeviceLanguage` mientras se descargan). Se adquiere foco de audio
-con `AUDIOFOCUS_GAIN_TRANSIENT` durante la sesión.
+25 idiomas base BCP-47 que cubre Parakeet-EOU, además de la etiqueta regional
+exacta solicitada cuando corresponde a un idioma base soportado. Los idiomas
+se marcan como `installedOnDeviceLanguage` cuando los modelos están presentes,
+o como `supportedOnDeviceLanguage` antes de descargarlos. El servicio no toma
+el foco de audio de la app que lo invoca.
 
 **Limitación:** Gboard, Samsung Keyboard y Google Assistant incluyen sus
 propios reconocedores y se saltan el predeterminado del sistema. Las apps

--- a/README_fr.md
+++ b/README_fr.md
@@ -134,7 +134,7 @@ adb shell settings put secure voice_recognition_service \
 
 **4. Vérifiez** en lançant l'écran *Recognizer test* de l'app de démo, qui appelle `SpeechRecognizer.createSpeechRecognizer(ctx)` (sans composant) et journalise chaque callback du framework — utile pour confirmer l'aller-retour binder sans avoir besoin de logcat.
 
-Le service implémente `onCheckRecognitionSupport` (API 33+) renvoyant les 25 langues BCP-47 couvertes par Parakeet-EOU, marquées `installedOnDeviceLanguage` lorsque les modèles sont présents (ou `pendingOnDeviceLanguage` pendant leur téléchargement). Le focus audio est acquis avec `AUDIOFOCUS_GAIN_TRANSIENT` pendant la durée d'une session.
+Le service implémente `onCheckRecognitionSupport` (API 33+) et renvoie les 25 langues de base BCP-47 couvertes par Parakeet-EOU, plus le tag régional exact demandé lorsqu'il correspond à une langue de base prise en charge. Les langues sont marquées `installedOnDeviceLanguage` lorsque les modèles sont présents, ou `supportedOnDeviceLanguage` avant téléchargement. Le service ne prend pas le focus audio à l'app appelante.
 
 **Limitation :** Gboard, Samsung Keyboard et Google Assistant intègrent leurs propres reconnaisseurs et contournent la valeur par défaut système. Les applications qui appellent explicitement l'API `SpeechRecognizer` du framework (ou construisent leur propre UI par-dessus) sont celles qui passent par votre service.
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -134,7 +134,7 @@ adb shell settings put secure voice_recognition_service \
 
 **4. सत्यापित करें** डेमो ऐप का *Recognizer test* स्क्रीन चलाकर, जो `SpeechRecognizer.createSpeechRecognizer(ctx)` (बिना कंपोनेंट के) कॉल करता है और हर फ्रेमवर्क कॉलबैक को लॉग करता है — logcat के बिना binder राउंड-ट्रिप की पुष्टि के लिए उपयोगी।
 
-सेवा `onCheckRecognitionSupport` (API 33+) को लागू करती है जो Parakeet-EOU द्वारा कवर की गई 25 BCP-47 भाषाओं को लौटाती है, मॉडल मौजूद होने पर `installedOnDeviceLanguage` के रूप में चिह्नित (या डाउनलोड के दौरान `pendingOnDeviceLanguage`)। सत्र की अवधि के लिए `AUDIOFOCUS_GAIN_TRANSIENT` के साथ ऑडियो फोकस प्राप्त किया जाता है।
+सेवा `onCheckRecognitionSupport` (API 33+) को लागू करती है जो Parakeet-EOU द्वारा कवर की गई 25 BCP-47 आधार भाषाएँ लौटाती है, और समर्थित आधार भाषा से मेल खाने पर अनुरोधित सटीक क्षेत्रीय टैग भी लौटाती है। मॉडल मौजूद होने पर भाषाएँ `installedOnDeviceLanguage` के रूप में, और डाउनलोड से पहले `supportedOnDeviceLanguage` के रूप में चिह्नित होती हैं। सेवा कॉल करने वाले ऐप से ऑडियो फोकस नहीं लेती।
 
 **सीमा:** Gboard, Samsung Keyboard और Google Assistant अपने स्वयं के पहचानकर्ता बंडल करते हैं और सिस्टम डिफ़ॉल्ट को छोड़ देते हैं। फ्रेमवर्क `SpeechRecognizer` API को स्पष्ट रूप से कॉल करने वाले ऐप (या उसके ऊपर अपना UI बनाने वाले) ही आपकी सेवा से होकर गुजरते हैं।
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -134,7 +134,7 @@ adb shell settings put secure voice_recognition_service \
 
 **4. 確認**:デモアプリの *Recognizer test* 画面を実行します。これは `SpeechRecognizer.createSpeechRecognizer(ctx)`(コンポーネントなし)を呼び出し、すべてのフレームワークコールバックをログに記録します — logcat なしで binder のラウンドトリップを確認するのに便利です。
 
-サービスは `onCheckRecognitionSupport`(API 33+)を実装し、Parakeet-EOU がカバーする 25 の BCP-47 言語を返します。モデルが存在する場合は `installedOnDeviceLanguage`、ダウンロード中は `pendingOnDeviceLanguage` でマークされます。セッション中は `AUDIOFOCUS_GAIN_TRANSIENT` でオーディオフォーカスを取得します。
+サービスは `onCheckRecognitionSupport`(API 33+)を実装し、Parakeet-EOU がカバーする 25 の BCP-47 基本言語に加えて、対応する基本言語に一致する場合は要求された正確な地域タグも返します。モデルが存在する場合は `installedOnDeviceLanguage`、ダウンロード前は `supportedOnDeviceLanguage` でマークされます。サービスは呼び出し元アプリからオーディオフォーカスを奪いません。
 
 **注意:** Gboard、Samsung Keyboard、Google Assistant は独自の認識エンジンを同梱しており、システムデフォルトをスキップします。あなたのサービスを通過するのは、フレームワーク `SpeechRecognizer` API を明示的に呼び出すアプリ(またはその上に独自 UI を構築するアプリ)です。
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -134,7 +134,7 @@ adb shell settings put secure voice_recognition_service \
 
 **4. 검증**: 데모 앱의 *Recognizer test* 화면을 실행하면 `SpeechRecognizer.createSpeechRecognizer(ctx)`(컴포넌트 없이)를 호출하고 모든 프레임워크 콜백을 기록합니다 — logcat 없이 binder 왕복을 확인하는 데 유용합니다.
 
-서비스는 `onCheckRecognitionSupport`(API 33+)를 구현하여 Parakeet-EOU가 지원하는 25개 BCP-47 언어를 반환합니다. 모델이 존재하면 `installedOnDeviceLanguage`, 다운로드 중이면 `pendingOnDeviceLanguage`로 표시됩니다. 세션 동안 `AUDIOFOCUS_GAIN_TRANSIENT`로 오디오 포커스를 획득합니다.
+서비스는 `onCheckRecognitionSupport`(API 33+)를 구현하여 Parakeet-EOU가 지원하는 25개 BCP-47 기본 언어와, 지원되는 기본 언어에 매핑되는 경우 요청된 정확한 지역 태그를 반환합니다. 모델이 존재하면 `installedOnDeviceLanguage`, 다운로드 전에는 `supportedOnDeviceLanguage`로 표시됩니다. 서비스는 호출 앱의 오디오 포커스를 가져가지 않습니다.
 
 **주의:** Gboard, 삼성 키보드, Google Assistant는 자체 인식 엔진을 번들로 제공하며 시스템 기본값을 건너뜁니다. 프레임워크 `SpeechRecognizer` API를 명시적으로 호출하거나 그 위에 자체 UI를 구축하는 앱만이 서비스를 통과합니다.
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -145,10 +145,11 @@ cada callback do framework — útil para confirmar o round-trip do binder sem
 precisar do logcat.
 
 O serviço implementa `onCheckRecognitionSupport` (API 33+) retornando os
-25 idiomas BCP-47 cobertos pelo Parakeet-EOU, marcados como
-`installedOnDeviceLanguage` quando os modelos estão presentes (ou
-`pendingOnDeviceLanguage` enquanto eles são baixados). O foco de áudio é
-adquirido com `AUDIOFOCUS_GAIN_TRANSIENT` pela duração de uma sessão.
+25 idiomas base BCP-47 cobertos pelo Parakeet-EOU, além da etiqueta regional
+exata solicitada quando ela corresponde a um idioma base suportado. Os idiomas
+são marcados como `installedOnDeviceLanguage` quando os modelos estão
+presentes, ou como `supportedOnDeviceLanguage` antes do download. O serviço
+não toma o foco de áudio do app chamador.
 
 **Limitação:** Gboard, Samsung Keyboard e Google Assistant agrupam seus
 próprios reconhecedores e ignoram o padrão do sistema. Apps que chamam

--- a/README_ru.md
+++ b/README_ru.md
@@ -134,7 +134,7 @@ adb shell settings put secure voice_recognition_service \
 
 **4. Проверьте**, запустив экран *Recognizer test* в демо-приложении, который вызывает `SpeechRecognizer.createSpeechRecognizer(ctx)` (без компонента) и логирует каждый callback фреймворка — удобно для подтверждения binder round-trip без необходимости в logcat.
 
-Сервис реализует `onCheckRecognitionSupport` (API 33+), возвращающий 25 BCP-47 языков, поддерживаемых Parakeet-EOU, помеченных как `installedOnDeviceLanguage` при наличии моделей (или `pendingOnDeviceLanguage` во время загрузки). Аудиофокус удерживается с `AUDIOFOCUS_GAIN_TRANSIENT` на время сессии.
+Сервис реализует `onCheckRecognitionSupport` (API 33+), возвращающий 25 базовых BCP-47 языков, поддерживаемых Parakeet-EOU, а также точный запрошенный региональный тег, если он соответствует поддерживаемому базовому языку. Языки помечаются как `installedOnDeviceLanguage`, когда модели уже есть на устройстве, или как `supportedOnDeviceLanguage` до загрузки. Сервис не забирает аудиофокус у вызывающего приложения.
 
 **Оговорка:** Gboard, Samsung Keyboard и Google Assistant поставляются с собственными распознавателями и обходят системное значение по умолчанию. Через ваш сервис проходят только те приложения, которые явно вызывают API `SpeechRecognizer` фреймворка (или строят на нём собственный UI).
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -133,7 +133,7 @@ adb shell settings put secure voice_recognition_service \
 
 **4. 验证**:运行演示应用的*识别器测试*界面,它调用 `SpeechRecognizer.createSpeechRecognizer(ctx)`(不带组件)并记录每个框架回调 — 无需 logcat 即可确认 binder 往返。
 
-服务实现了 `onCheckRecognitionSupport`(API 33+),返回 Parakeet-EOU 涵盖的 25 个 BCP-47 语言,在模型存在时标记为 `installedOnDeviceLanguage`(下载中时为 `pendingOnDeviceLanguage`)。会话期间使用 `AUDIOFOCUS_GAIN_TRANSIENT` 获取音频焦点。
+服务实现了 `onCheckRecognitionSupport`(API 33+),返回 Parakeet-EOU 涵盖的 25 个 BCP-47 基础语言;如果请求的精确地区标签映射到受支持的基础语言,也会返回该标签。模型存在时语言会标记为 `installedOnDeviceLanguage`,下载前标记为 `supportedOnDeviceLanguage`。服务不会从调用应用抢占音频焦点。
 
 **注意:** Gboard、三星键盘和 Google Assistant 都自带识别器,会跳过系统默认。显式调用框架 `SpeechRecognizer` API(或在其上构建自己 UI)的应用才会经过你的服务。
 

--- a/sdk/src/main/kotlin/audio/soniqo/speech/service/SpeechRecognitionService.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/service/SpeechRecognitionService.kt
@@ -1,12 +1,11 @@
 package audio.soniqo.speech.service
 
 import android.Manifest
+import android.content.Context
+import android.content.ContextParams
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.media.AudioAttributes
-import android.media.AudioFocusRequest
 import android.media.AudioFormat
-import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.MediaRecorder
 import android.os.Build
@@ -37,6 +36,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.io.IOException
+import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -69,9 +69,6 @@ open class SpeechRecognitionService : RecognitionService() {
     // create a parallel session that leaks AudioRecord and the pipeline.
     private val starting = AtomicBoolean(false)
 
-    @Volatile
-    private var audioFocusRequest: AudioFocusRequest? = null
-
     private class Session(
         val pipeline: SpeechPipeline,
         val audioRecord: AudioRecord,
@@ -92,21 +89,39 @@ open class SpeechRecognitionService : RecognitionService() {
 
         val wantPartial = recognizerIntent
             ?.getBooleanExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, false) ?: false
-        val requestedLang = recognizerIntent?.getStringExtra(RecognizerIntent.EXTRA_LANGUAGE)
+        val requestedLang = recognizerIntent?.let(::requestedLanguageTag)
         if (requestedLang != null) {
-            Log.i(TAG, "EXTRA_LANGUAGE=$requestedLang (auto-detected by STT, hint not enforced)")
+            Log.i(TAG, "EXTRA_LANGUAGE=$requestedLang")
+        }
+        if (requestedLang != null && !isSupportedLanguageTag(requestedLang)) {
+            Log.i(TAG, "unsupported requested language: $requestedLang")
+            starting.set(false)
+            listener.error(SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED)
+            return
+        }
+        if (!areRecognitionModelsReady()) {
+            Log.i(TAG, "models not ready for startListening; scheduling download")
+            runCatching { enqueueRecognitionModelDownload(recognizerIntent) }
+                .onFailure { Log.w(TAG, "failed to enqueue model download: ${it.message}") }
+            starting.set(false)
+            listener.error(SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE)
+            return
         }
 
         scope.launch {
             try {
-                startSession(listener, wantPartial)
+                startSession(listener, wantPartial, requestedLang)
             } finally {
                 starting.set(false)
             }
         }
     }
 
-    private suspend fun startSession(listener: Callback, wantPartial: Boolean) {
+    private suspend fun startSession(
+        listener: Callback,
+        wantPartial: Boolean,
+        requestedLang: String?,
+    ) {
         val pipeline: SpeechPipeline
         val record: AudioRecord
         try {
@@ -114,11 +129,12 @@ open class SpeechRecognitionService : RecognitionService() {
             pipeline = createPipeline(
                 SpeechConfig(
                     modelDir = modelDir,
+                    language = requestedLang?.let(::languageBaseTag) ?: "auto",
                     emitPartialTranscriptions = wantPartial,
                 )
             )
 
-            val newRecord = newAudioRecord()
+            val newRecord = newAudioRecord(newAudioRecordContext(listener))
             if (newRecord == null) {
                 listener.error(SpeechRecognizer.ERROR_AUDIO)
                 pipeline.close()
@@ -139,7 +155,6 @@ open class SpeechRecognitionService : RecognitionService() {
 
         pipeline.start()
         record.startRecording()
-        requestAudioFocus()
 
         val eventJob = scope.launch {
             pipeline.events.collect { ev -> handleEvent(ev, listener) }
@@ -235,7 +250,6 @@ open class SpeechRecognitionService : RecognitionService() {
         runCatching { s.audioRecord.release() }
         runCatching { s.pipeline.stop() }
         runCatching { s.pipeline.close() }
-        abandonAudioFocus()
     }
 
     override fun onDestroy() {
@@ -262,6 +276,14 @@ open class SpeechRecognitionService : RecognitionService() {
     protected open fun createPipeline(config: SpeechConfig): SpeechPipeline =
         SpeechPipeline(config)
 
+    /** Cheap readiness check used before binding a third-party recognition request. */
+    protected open fun areRecognitionModelsReady(): Boolean =
+        ModelManager.areModelsReady(applicationContext, ModelPrecision.INT8)
+
+    /** Schedule model download without blocking the current framework request. */
+    protected open fun enqueueRecognitionModelDownload(recognizerIntent: Intent?): java.util.UUID =
+        ModelDownloadWorker.enqueue(applicationContext, ModelPrecision.INT8)
+
     /**
      * Resolve the model directory. If models aren't on disk yet we delegate
      * to [ModelDownloadWorker] (which runs as a foreground service so the
@@ -274,11 +296,11 @@ open class SpeechRecognitionService : RecognitionService() {
      */
     protected open suspend fun resolveModelDir(): String {
         val ctx = applicationContext
-        if (ModelManager.areModelsReady(ctx, ModelPrecision.INT8)) {
+        if (areRecognitionModelsReady()) {
             return ModelManager.modelDir(ctx)
         }
         Log.i(TAG, "models not ready — delegating to ModelDownloadWorker")
-        val workId = ModelDownloadWorker.enqueue(ctx, ModelPrecision.INT8)
+        val workId = enqueueRecognitionModelDownload(null)
         val info = WorkManager.getInstance(ctx)
             .getWorkInfoByIdFlow(workId)
             .filterNotNull()
@@ -301,12 +323,25 @@ open class SpeechRecognitionService : RecognitionService() {
      * device (negative [AudioRecord.getMinBufferSize]). Overridden in tests so
      * Robolectric doesn't have to stand up a real recorder.
      */
-    protected open fun newAudioRecord(): AudioRecord? {
+    protected open fun newAudioRecord(context: Context): AudioRecord? {
         val sampleRate = 16_000
+        val format = AudioFormat.Builder()
+            .setSampleRate(sampleRate)
+            .setChannelMask(AudioFormat.CHANNEL_IN_MONO)
+            .setEncoding(AudioFormat.ENCODING_PCM_FLOAT)
+            .build()
         val minBuf = AudioRecord.getMinBufferSize(
             sampleRate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_FLOAT
         )
         if (minBuf <= 0) return null
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return AudioRecord.Builder()
+                .setContext(context)
+                .setAudioSource(MediaRecorder.AudioSource.VOICE_RECOGNITION)
+                .setAudioFormat(format)
+                .setBufferSizeInBytes(minBuf * 4)
+                .build()
+        }
         return AudioRecord(
             MediaRecorder.AudioSource.VOICE_RECOGNITION,
             sampleRate,
@@ -316,56 +351,27 @@ open class SpeechRecognitionService : RecognitionService() {
         )
     }
 
-    // -- audio focus ---------------------------------------------------------
-
     /**
-     * Acquire transient audio focus while we're listening so music ducks /
-     * pauses, and we get notified when something more important needs the
-     * mic (incoming call, navigation prompt). Best-effort; logs and proceeds
-     * if the system denies the request.
+     * Attribute microphone access to the app that requested recognition. This
+     * matches the RecognitionService contract on Android 12+ and avoids
+     * stricter clients treating the recognizer as an unrelated mic user.
      */
-    private fun requestAudioFocus() {
-        val am = getSystemService(AudioManager::class.java) ?: return
-        val attrs = AudioAttributes.Builder()
-            .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
-            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-            .build()
-        val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
-            .setAudioAttributes(attrs)
-            .setOnAudioFocusChangeListener { change ->
-                when (change) {
-                    AudioManager.AUDIOFOCUS_LOSS,
-                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT,
-                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
-                        Log.i(TAG, "audio focus lost ($change), tearing down session")
-                        tearDownSession()
-                    }
-                    else -> Unit
-                }
-            }
-            .build()
-        audioFocusRequest = request
-        val result = am.requestAudioFocus(request)
-        if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-            Log.w(TAG, "audio focus request denied (result=$result) — proceeding anyway")
-        }
-    }
-
-    private fun abandonAudioFocus() {
-        val am = getSystemService(AudioManager::class.java) ?: return
-        val req = audioFocusRequest ?: return
-        audioFocusRequest = null
-        runCatching { am.abandonAudioFocusRequest(req) }
+    protected open fun newAudioRecordContext(listener: Callback): Context {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return this
+        return createContext(
+            ContextParams.Builder()
+                .setNextAttributionSource(listener.callingAttributionSource)
+                .build()
+        )
     }
 
     // -- onCheckRecognitionSupport (API 33+) --------------------------------
 
     /**
      * Tell the framework which BCP-47 languages we can recognize on-device.
-     * If the models are already present we report them as installed; if
-     * they're still pending download we mark them pending so the caller can
-     * surface a "downloading" UX instead of falling back to an online
-     * recognizer.
+     * If the models are already present we report them as installed; otherwise
+     * we report them as supported so the caller can trigger model download
+     * instead of falling back to an online recognizer.
      *
      * The list mirrors Parakeet-EOU-120M's published 25-language coverage.
      */
@@ -374,13 +380,25 @@ open class SpeechRecognitionService : RecognitionService() {
         recognizerIntent: Intent,
         listener: SupportCallback,
     ) {
+        val languages = supportLanguagesFor(recognizerIntent)
+        if (languages.isEmpty()) {
+            listener.onError(SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED)
+            return
+        }
         val builder = RecognitionSupport.Builder()
-        val ready = ModelManager.areModelsReady(this, ModelPrecision.INT8)
-        SUPPORTED_LANGUAGES.forEach { tag ->
+        val ready = areRecognitionModelsReady()
+        languages.forEach { tag ->
             if (ready) builder.addInstalledOnDeviceLanguage(tag)
-            else builder.addPendingOnDeviceLanguage(tag)
+            else builder.addSupportedOnDeviceLanguage(tag)
         }
         listener.onSupportResult(builder.build())
+    }
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    override fun onTriggerModelDownload(recognizerIntent: Intent) {
+        if (supportLanguagesFor(recognizerIntent).isNotEmpty()) {
+            enqueueRecognitionModelDownload(recognizerIntent)
+        }
     }
 
     companion object {
@@ -397,5 +415,39 @@ open class SpeechRecognitionService : RecognitionService() {
             "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sv",
             "uk",
         )
+
+        private val SUPPORTED_LANGUAGE_BASES: Set<String> =
+            SUPPORTED_LANGUAGES.mapTo(linkedSetOf()) { it.lowercase(Locale.US) }
+
+        internal fun isSupportedLanguageTag(tag: String): Boolean =
+            languageBaseTag(tag) in SUPPORTED_LANGUAGE_BASES
+
+        internal fun supportLanguagesFor(intent: Intent): List<String> {
+            val requested = requestedLanguageTag(intent) ?: return SUPPORTED_LANGUAGES
+            if (!isSupportedLanguageTag(requested)) return emptyList()
+            val canonical = canonicalLanguageTag(requested)
+            val base = languageBaseTag(requested)
+            return listOf(canonical, base).distinct()
+        }
+
+        private fun requestedLanguageTag(intent: Intent): String? =
+            listOf(
+                intent.getStringExtra(RecognizerIntent.EXTRA_LANGUAGE),
+                intent.getStringExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE),
+            ).firstNotNullOfOrNull { tag -> tag?.trim()?.takeIf { it.isNotEmpty() } }
+
+        internal fun canonicalLanguageTag(tag: String): String {
+            val normalized = tag.trim().replace('_', '-')
+            val locale = Locale.forLanguageTag(normalized)
+            return locale.takeIf { it.language.isNotBlank() }?.toLanguageTag() ?: normalized
+        }
+
+        internal fun languageBaseTag(tag: String): String {
+            val canonical = canonicalLanguageTag(tag)
+            val locale = Locale.forLanguageTag(canonical)
+            return locale.language.takeIf { it.isNotBlank() }
+                ?.lowercase(Locale.US)
+                ?: canonical.substringBefore('-').lowercase(Locale.US)
+        }
     }
 }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechRecognitionServiceTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechRecognitionServiceTest.kt
@@ -2,12 +2,13 @@ package audio.soniqo.speech.service
 
 import android.Manifest
 import android.app.Application
+import android.content.Context
 import android.content.Intent
-import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.media.AudioRecord
 import android.speech.RecognitionService
 import android.speech.RecognitionSupport
+import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
 import androidx.test.core.app.ApplicationProvider
 import audio.soniqo.speech.PipelineState
@@ -24,6 +25,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -99,6 +101,47 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
+    fun startListening_requestedRegionalLanguageIsAccepted() {
+        val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE, "fr-FR")
+
+        service.startListening(intent, listener)
+
+        verify(timeout = 1500) { listener.readyForSpeech(any()) }
+        assertEquals("fr", service.lastConfig?.language)
+    }
+
+    @Test
+    fun startListening_requestedLanguagePreferenceIsAccepted() {
+        val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, "en-US")
+
+        service.startListening(intent, listener)
+
+        verify(timeout = 1500) { listener.readyForSpeech(any()) }
+        assertEquals("en", service.lastConfig?.language)
+    }
+
+    @Test
+    fun startListening_unsupportedLanguageReportsLanguageNotSupported() {
+        val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE, "ja-JP")
+
+        service.startListening(intent, listener)
+
+        verify { listener.error(SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED) }
+        assertEquals(0, fakePipeline.startCalls)
+    }
+
+    @Test
+    fun startListening_modelsNotReadyReportsLanguageUnavailableAndSchedulesDownload() {
+        service.modelsReady = false
+
+        service.startListening(Intent(), listener)
+
+        verify { listener.error(SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE) }
+        assertEquals(1, service.downloadRequests)
+        assertEquals(0, fakePipeline.startCalls)
+    }
+
+    @Test
     fun stopListening_flushesPipelineWithSilence() {
         // Regression test for the stop-hang fix: VAD detects end-of-utterance
         // from silence in the audio stream, and nativeStop does not flush. We
@@ -137,39 +180,18 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun startListening_requestsAudioFocus() {
+    fun startListening_doesNotRequestAudioFocusFromCallingApp() {
         service.startListening(Intent(), listener)
         verify(timeout = 1500) { listener.readyForSpeech(any()) }
 
         val app = ApplicationProvider.getApplicationContext<Application>()
         val am = app.getSystemService(AudioManager::class.java)
-        val granted = shadowOf(am).lastAudioFocusRequest
-        assertTrue(
-            "expected an AudioFocusRequest after startListening, got $granted",
-            granted != null,
-        )
+        assertNull(shadowOf(am).lastAudioFocusRequest)
     }
 
     @Test
-    fun audioFocusLoss_tearsDownSession() {
-        service.startListening(Intent(), listener)
-        verify(timeout = 1500) { listener.readyForSpeech(any()) }
-
-        // Simulate the system handing audio focus to a phone call: invoke
-        // the listener that was registered at startListening time.
-        val app = ApplicationProvider.getApplicationContext<Application>()
-        val am = app.getSystemService(AudioManager::class.java)
-        val recordedReq = shadowOf(am).lastAudioFocusRequest!!
-        recordedReq.listener.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS)
-
-        // tearDownSession() runs synchronously on the main thread; the
-        // pipeline's close() is part of it, so we can assert on closeCalls
-        // without polling for long.
-        waitFor(1_000) { fakePipeline.closeCalls > 0 }
-    }
-
-    @Test
-    fun onCheckRecognitionSupport_modelsNotReady_marksLanguagesPending() {
+    fun onCheckRecognitionSupport_modelsNotReady_marksLanguagesSupportedForDownload() {
+        service.modelsReady = false
         val callback = mockk<RecognitionService.SupportCallback>(relaxed = true)
         service.checkRecognitionSupport(Intent(), callback)
 
@@ -178,17 +200,60 @@ class SpeechRecognitionServiceTest {
         val support = supportSlot.captured
 
         // Models aren't on disk in the test, so all advertised languages
-        // should be pending — never installed.
+        // should be supported for download — never installed.
         assertTrue("installed should be empty", support.installedOnDeviceLanguages.isEmpty())
         assertTrue(
-            "pending should include 'en'",
-            support.pendingOnDeviceLanguages.contains("en"),
+            "supported should include 'en'",
+            support.supportedOnDeviceLanguages.contains("en"),
         )
         assertEquals(
-            "pending should match SUPPORTED_LANGUAGES",
+            "supported should match SUPPORTED_LANGUAGES",
             SpeechRecognitionService.SUPPORTED_LANGUAGES,
-            support.pendingOnDeviceLanguages,
+            support.supportedOnDeviceLanguages,
         )
+    }
+
+    @Test
+    fun onCheckRecognitionSupport_requestedRegionalLanguageReturnsExactLocale() {
+        val callback = mockk<RecognitionService.SupportCallback>(relaxed = true)
+        val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE, "en-US")
+
+        service.checkRecognitionSupport(intent, callback)
+
+        val supportSlot = slot<RecognitionSupport>()
+        verify(timeout = 1500) { callback.onSupportResult(capture(supportSlot)) }
+        assertEquals(
+            listOf("en-US", "en"),
+            supportSlot.captured.installedOnDeviceLanguages,
+        )
+    }
+
+    @Test
+    fun onCheckRecognitionSupport_unsupportedRequestedLanguageReportsError() {
+        val callback = mockk<RecognitionService.SupportCallback>(relaxed = true)
+        val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE, "ja-JP")
+
+        service.checkRecognitionSupport(intent, callback)
+
+        verify { callback.onError(SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED) }
+    }
+
+    @Test
+    fun triggerModelDownload_supportedLanguageEnqueuesDownload() {
+        val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE, "de-DE")
+
+        service.triggerModelDownload(intent)
+
+        assertEquals(1, service.downloadRequests)
+    }
+
+    @Test
+    fun triggerModelDownload_unsupportedLanguageDoesNotEnqueueDownload() {
+        val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE, "ja-JP")
+
+        service.triggerModelDownload(intent)
+
+        assertEquals(0, service.downloadRequests)
     }
 
     private fun waitFor(timeoutMs: Long, predicate: () -> Boolean) {
@@ -208,6 +273,9 @@ class SpeechRecognitionServiceTest {
     class TestableService : SpeechRecognitionService() {
         private lateinit var pipelineToInject: SpeechPipeline
         private lateinit var recordToInject: AudioRecord
+        var modelsReady = true
+        var downloadRequests = 0
+        var lastConfig: SpeechConfig? = null
 
         fun install(pipeline: SpeechPipeline, record: AudioRecord) {
             pipelineToInject = pipeline
@@ -222,11 +290,25 @@ class SpeechRecognitionServiceTest {
         fun checkRecognitionSupport(intent: Intent, callback: SupportCallback) =
             onCheckRecognitionSupport(intent, callback)
 
-        override fun createPipeline(config: SpeechConfig): SpeechPipeline = pipelineToInject
+        fun triggerModelDownload(intent: Intent) = onTriggerModelDownload(intent)
+
+        override fun createPipeline(config: SpeechConfig): SpeechPipeline {
+            lastConfig = config
+            return pipelineToInject
+        }
+
+        override fun areRecognitionModelsReady(): Boolean = modelsReady
+
+        override fun enqueueRecognitionModelDownload(recognizerIntent: Intent?): java.util.UUID {
+            downloadRequests++
+            return java.util.UUID.randomUUID()
+        }
 
         override suspend fun resolveModelDir(): String = "/fake/models"
 
-        override fun newAudioRecord(): AudioRecord = recordToInject
+        override fun newAudioRecordContext(listener: Callback): Context = this
+
+        override fun newAudioRecord(context: Context): AudioRecord = recordToInject
     }
 
     /** Minimal SpeechPipeline that records calls and lets the test push events. */


### PR DESCRIPTION
Refs #41

## Summary
- avoid taking audio focus from the app using the recognition service
- attribute microphone capture to the recognition caller on Android 12+
- handle regional language requests, unsupported-language errors, and unavailable-model errors explicitly
- update recognition-support documentation across README translations

## Test plan
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew :sdk:test :app:testDebugUnitTest :app:assembleDebug
- git diff --check