### PR TITLE
Add FunctionGemma tool-calling, TRANSCRIBE_ONLY mode, and resilient LLM download

### DIFF
--- a/sdk/src/main/cpp/jni_bridge.cpp
+++ b/sdk/src/main/cpp/jni_bridge.cpp
@@ -47,6 +47,11 @@ struct PipelineHandle {
     std::unique_ptr<speech_core::DeepFilterEnhancer> enhancer;
     std::unique_ptr<speech_core::VoicePipeline> pipeline;
 
+    // Serializes nativePipelineSynthesize calls on the shared TTS instance.
+    // In TranscribeOnly mode the pipeline itself never touches TTS, so this
+    // only guards against concurrent Kotlin-side synthesize() calls.
+    std::mutex tts_mutex;
+
     JavaVM* jvm = nullptr;
     jobject callback = nullptr;
     jmethodID on_event_mid = nullptr;
@@ -64,6 +69,8 @@ static constexpr int BACKEND_ONNX = 0;
 static constexpr int BACKEND_LITERT = 1;
 static constexpr int TTS_KOKORO = 0;
 static constexpr int TTS_SUPERTONIC = 1;
+static constexpr int MODE_ECHO = 0;
+static constexpr int MODE_TRANSCRIBE_ONLY = 1;
 
 static std::unique_ptr<speech_core::TTSInterface> create_tts(
     const std::string& dir, bool nnapi, int ttsModel)
@@ -204,7 +211,8 @@ JNIEXPORT jlong JNICALL
 Java_audio_soniqo_speech_NativeBridge_nativeCreate(
     JNIEnv* env, jobject /*thiz*/,
     jstring modelDir, jboolean useNnapi, jboolean useInt8,
-    jint sttModel, jint sttBackend, jint ttsModel, jstring language,
+    jint sttModel, jint sttBackend, jint ttsModel, jint pipelineMode,
+    jstring language,
     jobjectArray languageHints,
     jobject callback,
     jboolean emitPartialTranscriptions, jfloat partialTranscriptionInterval)
@@ -280,7 +288,9 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
         cfg.post_playback_guard = 0.15f;
         cfg.emit_partial_transcriptions = emitPartialTranscriptions;
         cfg.partial_transcription_interval = partialTranscriptionInterval;
-        cfg.mode = speech_core::AgentConfig::Mode::Echo;
+        cfg.mode = (pipelineMode == MODE_TRANSCRIBE_ONLY)
+            ? speech_core::AgentConfig::Mode::TranscribeOnly
+            : speech_core::AgentConfig::Mode::Echo;
 
         // Note: DeepFilterNet3 noise cancellation is disabled in the pipeline.
         // DFN operates at 48 kHz but the pipeline pushes 16 kHz audio —
@@ -437,24 +447,18 @@ Java_audio_soniqo_speech_NativeBridge_nativeSynthesizerSampleRate(
     return static_cast<jint>(h->tts->output_sample_rate());
 }
 
-JNIEXPORT jbyteArray JNICALL
-Java_audio_soniqo_speech_NativeBridge_nativeSynthesize(
-    JNIEnv* env, jobject /*thiz*/, jlong handle, jstring text, jstring language)
+// Synthesize with [tts] under [mutex], returning PCM16 mono little-endian
+// bytes. Throws a Java RuntimeException and returns nullptr on failure.
+static jbyteArray synthesize_pcm16(JNIEnv* env, speech_core::TTSInterface& tts,
+                                   std::mutex& mutex, jstring text, jstring language)
 {
-    auto* h = reinterpret_cast<SynthesizerHandle*>(handle);
-    if (!h || !h->tts) {
-        jclass ex_cls = env->FindClass("java/lang/IllegalStateException");
-        if (ex_cls) env->ThrowNew(ex_cls, "Native synthesizer is closed");
-        return nullptr;
-    }
-
     std::string input = jstring_to_string(env, text);
     std::string lang = jstring_to_string(env, language);
     std::vector<int16_t> pcm;
 
     try {
-        std::lock_guard<std::mutex> lock(h->mutex);
-        h->tts->synthesize(input, lang, [&pcm](const float* samples, size_t length, bool /*is_final*/) {
+        std::lock_guard<std::mutex> lock(mutex);
+        tts.synthesize(input, lang, [&pcm](const float* samples, size_t length, bool /*is_final*/) {
             pcm.reserve(pcm.size() + length);
             for (size_t i = 0; i < length; ++i) {
                 const float clamped = std::max(-1.0f, std::min(1.0f, samples[i]));
@@ -479,6 +483,49 @@ Java_audio_soniqo_speech_NativeBridge_nativeSynthesize(
             reinterpret_cast<const jbyte*>(pcm.data()));
     }
     return out;
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativeSynthesize(
+    JNIEnv* env, jobject /*thiz*/, jlong handle, jstring text, jstring language)
+{
+    auto* h = reinterpret_cast<SynthesizerHandle*>(handle);
+    if (!h || !h->tts) {
+        jclass ex_cls = env->FindClass("java/lang/IllegalStateException");
+        if (ex_cls) env->ThrowNew(ex_cls, "Native synthesizer is closed");
+        return nullptr;
+    }
+    return synthesize_pcm16(env, *h->tts, h->mutex, text, language);
+}
+
+JNIEXPORT jint JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativePipelineTtsSampleRate(
+    JNIEnv* /*env*/, jobject /*thiz*/, jlong handle)
+{
+    auto* h = reinterpret_cast<PipelineHandle*>(handle);
+    if (!h || !h->tts) return 0;
+    return static_cast<jint>(h->tts->output_sample_rate());
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativePipelineSynthesize(
+    JNIEnv* env, jobject /*thiz*/, jlong handle, jstring text, jstring language)
+{
+    auto* h = reinterpret_cast<PipelineHandle*>(handle);
+    if (!h || !h->tts) {
+        jclass ex_cls = env->FindClass("java/lang/IllegalStateException");
+        if (ex_cls) env->ThrowNew(ex_cls, "Native pipeline is closed");
+        return nullptr;
+    }
+    return synthesize_pcm16(env, *h->tts, h->tts_mutex, text, language);
+}
+
+JNIEXPORT void JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativePipelineCancelSynthesis(
+    JNIEnv* /*env*/, jobject /*thiz*/, jlong handle)
+{
+    auto* h = reinterpret_cast<PipelineHandle*>(handle);
+    if (h && h->tts) h->tts->cancel();
 }
 
 } // extern "C"

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
@@ -69,6 +69,10 @@ class ModelDownloadWorker(
         val ttsModel = inputData.getString(KEY_TTS_MODEL)
             ?.let { runCatching { TtsModel.valueOf(it) }.getOrNull() }
             ?: TtsModel.KOKORO
+        // When set, the FunctionGemma bundle is downloaded here too, so the
+        // whole ~800 MB setup runs in this foreground worker — surviving doze
+        // and Wi-Fi power-save that would kill an in-app download.
+        val includeLlm = inputData.getBoolean(KEY_INCLUDE_LLM, false)
 
         runCatching { setForeground(buildForegroundInfo(0, "Preparing speech models…")) }
 
@@ -78,6 +82,33 @@ class ModelDownloadWorker(
         // janks the main thread, so we coalesce to visible changes only.
         var lastNotifiedPct = -1
         var lastNotifiedFile = ""
+        val report: (ModelManager.Progress) -> Unit = { p ->
+            val pct = progressPercent(
+                p.completed,
+                p.totalFiles,
+                p.bytesDownloaded,
+                p.fileTotalBytes,
+            )
+            setProgressAsync(workDataOf(
+                KEY_FILE to p.file,
+                KEY_COMPLETED to p.completed,
+                KEY_TOTAL to p.totalFiles,
+                KEY_BYTES_DOWNLOADED to p.bytesDownloaded,
+                KEY_FILE_TOTAL_BYTES to p.fileTotalBytes,
+                KEY_PERCENT to pct,
+            ))
+            if (pct != lastNotifiedPct || p.file != lastNotifiedFile) {
+                lastNotifiedPct = pct
+                lastNotifiedFile = p.file
+                runCatching {
+                    setForegroundAsync(buildForegroundInfo(
+                        percent = pct,
+                        text = "${p.file}  ${formatMb(p.bytesDownloaded)}/${formatMb(p.fileTotalBytes)}" +
+                            "  ·  ${p.completed}/${p.totalFiles}",
+                    ))
+                }
+            }
+        }
 
         return try {
             val modelDir = ModelManager.ensureModels(
@@ -86,34 +117,11 @@ class ModelDownloadWorker(
                 sttModel = sttModel,
                 sttBackend = sttBackend,
                 ttsModel = ttsModel,
-                onProgress = { p ->
-                    val pct = progressPercent(
-                        p.completed,
-                        p.totalFiles,
-                        p.bytesDownloaded,
-                        p.fileTotalBytes,
-                    )
-                    setProgressAsync(workDataOf(
-                        KEY_FILE to p.file,
-                        KEY_COMPLETED to p.completed,
-                        KEY_TOTAL to p.totalFiles,
-                        KEY_BYTES_DOWNLOADED to p.bytesDownloaded,
-                        KEY_FILE_TOTAL_BYTES to p.fileTotalBytes,
-                        KEY_PERCENT to pct,
-                    ))
-                    if (pct != lastNotifiedPct || p.file != lastNotifiedFile) {
-                        lastNotifiedPct = pct
-                        lastNotifiedFile = p.file
-                        runCatching {
-                            setForegroundAsync(buildForegroundInfo(
-                                percent = pct,
-                                text = "${p.file}  ${formatMb(p.bytesDownloaded)}/${formatMb(p.fileTotalBytes)}" +
-                                    "  ·  ${p.completed}/${p.totalFiles}",
-                            ))
-                        }
-                    }
-                },
+                onProgress = report,
             )
+            if (includeLlm) {
+                ModelManager.ensureLlmModels(applicationContext, onProgress = report)
+            }
             Result.success(workDataOf(KEY_MODEL_DIR to modelDir))
         } catch (e: IOException) {
             // Network / disk hiccup — let WorkManager retry with backoff.
@@ -192,6 +200,7 @@ class ModelDownloadWorker(
         const val KEY_STT_MODEL = "sttModel"
         const val KEY_STT_BACKEND = "sttBackend"
         const val KEY_TTS_MODEL = "ttsModel"
+        const val KEY_INCLUDE_LLM = "includeLlm"
 
         // Output keys
         const val KEY_MODEL_DIR = "modelDir"
@@ -223,16 +232,19 @@ class ModelDownloadWorker(
             sttModel: SttModel = SttModel.PARAKEET_EOU,
             sttBackend: SttBackend = SttBackend.ONNX,
             ttsModel: TtsModel = TtsModel.KOKORO,
+            includeLlm: Boolean = false,
         ): String {
             if (
                 precision == ModelPrecision.INT8 &&
                 sttModel == SttModel.PARAKEET_EOU &&
                 sttBackend == SttBackend.ONNX &&
-                ttsModel == TtsModel.KOKORO
+                ttsModel == TtsModel.KOKORO &&
+                !includeLlm
             ) {
                 return UNIQUE_NAME
             }
-            return "$UNIQUE_NAME.${precision.name}.${sttModel.name}.${sttBackend.name}.${ttsModel.name}"
+            val llm = if (includeLlm) ".llm" else ""
+            return "$UNIQUE_NAME.${precision.name}.${sttModel.name}.${sttBackend.name}.${ttsModel.name}$llm"
         }
 
         fun request(
@@ -240,6 +252,7 @@ class ModelDownloadWorker(
             sttModel: SttModel = SttModel.PARAKEET_EOU,
             sttBackend: SttBackend = SttBackend.ONNX,
             ttsModel: TtsModel = TtsModel.KOKORO,
+            includeLlm: Boolean = false,
         ) =
             OneTimeWorkRequestBuilder<ModelDownloadWorker>()
                 .setInputData(workDataOf(
@@ -247,6 +260,7 @@ class ModelDownloadWorker(
                     KEY_STT_MODEL to sttModel.name,
                     KEY_STT_BACKEND to sttBackend.name,
                     KEY_TTS_MODEL to ttsModel.name,
+                    KEY_INCLUDE_LLM to includeLlm,
                 ))
                 .build()
 
@@ -261,10 +275,12 @@ class ModelDownloadWorker(
             sttModel: SttModel = SttModel.PARAKEET_EOU,
             sttBackend: SttBackend = SttBackend.ONNX,
             ttsModel: TtsModel = TtsModel.KOKORO,
+            includeLlm: Boolean = false,
         ): java.util.UUID {
-            val req = request(precision, sttModel, sttBackend, ttsModel)
+            val req = request(precision, sttModel, sttBackend, ttsModel, includeLlm)
             WorkManager.getInstance(context).enqueueUniqueWork(
-                uniqueName(precision, sttModel, sttBackend, ttsModel), ExistingWorkPolicy.KEEP, req,
+                uniqueName(precision, sttModel, sttBackend, ttsModel, includeLlm),
+                ExistingWorkPolicy.KEEP, req,
             )
             return req.id
         }

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -139,6 +139,13 @@ object ModelManager {
         ).map { ModelFile("Supertonic-3-LiteRT", it) }
     }
 
+    // FunctionGemma 270M tool-calling LLM — a single .litertlm bundle for the
+    // LiteRT-LM runtime. Kept out of the pipeline model set: only agent demos
+    // opt in via [ensureLlmModels], so SDK integrations never pull the 283 MB.
+    private fun llmModels(): List<ModelFile> = listOf(
+        ModelFile("FunctionGemma-270M-LiteRT-LM", "model.litertlm"),
+    )
+
     data class ModelFile(val repo: String, val filename: String)
 
     data class Progress(
@@ -215,6 +222,25 @@ object ModelManager {
         }
     }
 
+    /**
+     * True iff the LLM cache contains a valid FunctionGemma bundle.
+     * Cheap and side-effect free — does not start a download.
+     */
+    fun areLlmModelsReady(context: Context): Boolean {
+        val dir = File(context.filesDir, "models_llm")
+        if (!dir.exists()) return false
+
+        val versionFile = File(dir, "version.txt")
+        val cached = versionFile.takeIf { it.exists() }?.readText()?.trim()?.toIntOrNull() ?: 0
+        if (cached < MODEL_VERSION) return false
+        if (cachedModelSet(dir) != llmModelSetKey()) return false
+
+        return llmModels().all { model ->
+            val dest = File(dir, model.filename)
+            dest.exists() && isValidModel(dest, model.filename)
+        }
+    }
+
     /** Path to the model directory for [precision], without downloading. */
     fun modelDir(context: Context): String =
         File(context.filesDir, "models").absolutePath
@@ -222,6 +248,14 @@ object ModelManager {
     /** Path to the TTS-only model directory, without downloading. */
     fun ttsModelDir(context: Context): String =
         File(context.filesDir, "models_tts").absolutePath
+
+    /** Path to the LLM model directory, without downloading. */
+    fun llmModelDir(context: Context): String =
+        File(context.filesDir, "models_llm").absolutePath
+
+    /** Absolute path of the FunctionGemma .litertlm bundle, without downloading. */
+    fun llmModelFile(context: Context): String =
+        File(llmModelDir(context), llmModels().first().filename).absolutePath
 
     /** Returns the model directory path, downloading models if needed. */
     suspend fun ensureModels(
@@ -294,6 +328,46 @@ object ModelManager {
         File(dir, MODEL_SET_FILENAME).writeText(requestedModelSet)
 
         dir.absolutePath
+    }
+
+    /**
+     * Returns the path of the FunctionGemma .litertlm bundle, downloading it
+     * if needed. Separate from [ensureModels] so the 283 MB LLM only lands on
+     * devices whose app actually runs the tool-calling agent.
+     */
+    suspend fun ensureLlmModels(
+        context: Context,
+        onProgress: ((Progress) -> Unit)? = null,
+    ): String = withContext(Dispatchers.IO) {
+        val dir = File(context.filesDir, "models_llm")
+        dir.mkdirs()
+
+        val versionFile = File(dir, "version.txt")
+        val setFile = File(dir, MODEL_SET_FILENAME)
+        val requestedModelSet = llmModelSetKey()
+        val cached = versionFile.takeIf { it.exists() }?.readText()?.trim()?.toIntOrNull() ?: 0
+        val cachedSet = cachedModelSet(dir)
+
+        // Only wipe a genuinely stale/different cached set — never a fresh or
+        // in-progress download. Without this guard the partial .tmp is deleted
+        // on every worker retry / app restart (the version marker is written
+        // only on completion), so a 283 MB download over a flaky connection or
+        // across screen-doze could never resume. Markers present + matching =
+        // resume via HTTP Range in downloadFile.
+        val hadMarkers = versionFile.exists() || setFile.exists()
+        if (hadMarkers && (cached < MODEL_VERSION || cachedSet != requestedModelSet)) {
+            clearModelCache(dir)
+        }
+
+        // Write the set marker up front so a resumed run recognizes this
+        // download and keeps its .tmp. areLlmModelsReady still gates on the
+        // real, fully-downloaded file, so an early marker can't look "ready".
+        setFile.writeText(requestedModelSet)
+        versionFile.writeText(MODEL_VERSION.toString())
+
+        downloadMissingModels(dir, llmModels(), onProgress)
+
+        File(dir, llmModels().first().filename).absolutePath
     }
 
     private fun downloadMissingModels(
@@ -371,6 +445,12 @@ object ModelManager {
         "v$MODEL_VERSION",
         "profile=TTS",
         "tts=${ttsModel.name}",
+    ).joinToString("|")
+
+    private fun llmModelSetKey(): String = listOf(
+        "v$MODEL_VERSION",
+        "profile=LLM",
+        "llm=FUNCTIONGEMMA_270M",
     ).joinToString("|")
 
     private fun cachedModelSet(dir: File): String? =
@@ -500,6 +580,7 @@ object ModelManager {
         "kokoro-e2e.onnx" to 1_000L,                     // Small (weights in .data file)
         "kokoro-e2e.onnx.data" to 50_000_000L,           // ~310 MB
         "silero-vad.onnx" to 500_000L,                   // ~2 MB
+        "model.litertlm" to 200_000_000L,                // ~283 MB FunctionGemma bundle
     )
 
     private fun isValidModel(file: File, filename: String): Boolean {

--- a/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
@@ -13,6 +13,7 @@ internal object NativeBridge {
         sttModel: Int,    // SttModel.ordinal: 0=PARAKEET, 1=NEMOTRON_MULTILINGUAL, 2=PARAKEET_EOU
         sttBackend: Int,  // SttBackend.ordinal: 0=ONNX, 1=LITERT
         ttsModel: Int,    // TtsModel.ordinal: 0=KOKORO, 1=SUPERTONIC (LiteRT)
+        pipelineMode: Int, // PipelineMode.ordinal: 0=ECHO, 1=TRANSCRIBE_ONLY
         language: String, // single language hint ("auto", "en-US", ...)
         languageHints: Array<String>, // shortlist for Parakeet TDT language-token guidance
         callback: EventCallback,
@@ -27,6 +28,12 @@ internal object NativeBridge {
     external fun nativePushAudio(handle: Long, samples: FloatArray, count: Int)
     external fun nativeResumeListen(handle: Long)
     external fun nativeGetState(handle: Long): Int
+
+    // Direct synthesis with the pipeline's already-loaded TTS model — lets a
+    // TRANSCRIBE_ONLY agent loop speak responses without a second TTS copy.
+    external fun nativePipelineTtsSampleRate(handle: Long): Int
+    external fun nativePipelineSynthesize(handle: Long, text: String, language: String): ByteArray
+    external fun nativePipelineCancelSynthesis(handle: Long)
 
     external fun nativeCreateSynthesizer(
         modelDir: String,

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
@@ -16,6 +16,12 @@ enum class SttBackend { ONNX, LITERT }
  *  languages, G2P-free) — requires the LiteRT backend to be built into the SDK. */
 enum class TtsModel { KOKORO, SUPERTONIC }
 
+/** What the pipeline does after a completed transcription. ECHO speaks the
+ *  transcript back via TTS (demo/testing); TRANSCRIBE_ONLY emits
+ *  TranscriptionCompleted and returns to idle — for dictation or an
+ *  app-side agent loop that decides the response itself. */
+enum class PipelineMode { ECHO, TRANSCRIBE_ONLY }
+
 data class SpeechConfig(
     /** Path to directory containing ONNX model files. */
     val modelDir: String = "",
@@ -31,6 +37,9 @@ data class SpeechConfig(
 
     /** Which TTS model to load. SUPERTONIC requires the LiteRT backend. */
     val ttsModel: TtsModel = TtsModel.KOKORO,
+
+    /** Pipeline behavior after transcription. See [PipelineMode]. */
+    val pipelineMode: PipelineMode = PipelineMode.ECHO,
 
     /** Language/locale prompt for prompt-conditioned models and single-language
      *  Parakeet TDT guidance: e.g. "en-US", "fr", "ja-JP". "auto" lets the

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
@@ -46,6 +46,21 @@ interface SpeechPipeline : AutoCloseable {
     /** Signal that response playback finished — resume listening. */
     fun resumeListening()
 
+    /** Sample rate of [synthesize] output, or 0 if unsupported. */
+    val ttsSampleRate: Int get() = 0
+
+    /**
+     * Synthesize [text] with the pipeline's own TTS model — no second model
+     * instance. Intended for [PipelineMode.TRANSCRIBE_ONLY] agent loops that
+     * compose their response app-side; in ECHO mode the pipeline synthesizes
+     * on its own and this must not be called concurrently with a response.
+     */
+    fun synthesize(text: String, language: String = "en"): SpeechSynthesisResult =
+        throw UnsupportedOperationException("This SpeechPipeline does not support direct synthesis")
+
+    /** Cancel an in-progress [synthesize]. */
+    fun cancelSynthesis() {}
+
     companion object {
         operator fun invoke(config: SpeechConfig): SpeechPipeline = SpeechPipelineImpl(config)
     }
@@ -85,6 +100,7 @@ internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
         config.sttModel.ordinal,
         config.sttBackend.ordinal,
         config.ttsModel.ordinal,
+        config.pipelineMode.ordinal,
         config.language,
         config.languageHints.toTypedArray(),
         nativeCallback,
@@ -117,6 +133,21 @@ internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
 
     override fun resumeListening() {
         NativeBridge.nativeResumeListen(handle)
+    }
+
+    override val ttsSampleRate: Int
+        get() = NativeBridge.nativePipelineTtsSampleRate(handle)
+
+    override fun synthesize(text: String, language: String): SpeechSynthesisResult {
+        check(handle != 0L) { "SpeechPipeline is closed" }
+        return SpeechSynthesisResult(
+            sampleRate = ttsSampleRate,
+            pcm16 = NativeBridge.nativePipelineSynthesize(handle, text, language),
+        )
+    }
+
+    override fun cancelSynthesis() {
+        if (handle != 0L) NativeBridge.nativePipelineCancelSynthesis(handle)
     }
 
     override fun close() {

--- a/sdk/src/main/kotlin/audio/soniqo/speech/llm/FunctionGemma.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/llm/FunctionGemma.kt
@@ -31,6 +31,16 @@ class FunctionGemma(
      * litert-lm transitive dependency tree.
      */
     interface Runtime {
+        /**
+         * True if the engine wraps prompts in the Gemma chat template
+         * itself. When true the SDK passes the bare declarations + user
+         * text; when false it builds the full developer/user/model turn
+         * structure via [FunctionGemmaPrompt.formatPrompt]. Both
+         * double-templating and missing templating degrade tool-call
+         * accuracy, so this must match the engine.
+         */
+        val appliesChatTemplate: Boolean get() = false
+
         /** Process a full prompt and return raw model text up to a stop token. */
         fun generate(prompt: String, maxNewTokens: Int): String
 
@@ -46,9 +56,11 @@ class FunctionGemma(
      * that you parse with [parseToolCalls].
      */
     fun generateToolCall(userText: String, tools: List<FunctionDeclaration>): String {
-        val prompt = FunctionGemmaPrompt.formatUserTurn(tools, userText)
-        val wrapped = FunctionGemmaPrompt.applyChatTemplate(prompt)
-        return runtime.generate(wrapped, maxNewTokens)
+        val prompt = if (runtime.appliesChatTemplate)
+            FunctionGemmaPrompt.formatUserTurn(tools, userText)
+        else
+            FunctionGemmaPrompt.formatPrompt(tools, userText)
+        return runtime.generate(prompt, maxNewTokens)
     }
 
     /** Extract structured calls from a raw model response. */

--- a/sdk/src/main/kotlin/audio/soniqo/speech/llm/FunctionGemmaParser.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/llm/FunctionGemmaParser.kt
@@ -24,12 +24,18 @@ object FunctionGemmaParser {
         return result
     }
 
-    private fun parseCallBody(body: String): FunctionCall? {
-        if (!body.startsWith("call:")) return null
+    private fun parseCallBody(rawBody: String): FunctionCall? {
+        // Models (and runtimes) may emit a newline between the marker and the
+        // call body — tolerate surrounding whitespace before matching. The
+        // `call:` prefix from the training format is optional: the released
+        // FunctionGemma-270M weights emit `NAME {args}` without it (verified
+        // against the LiteRT-LM runtime).
+        val body = rawBody.trim()
         val afterCall = body.removePrefix("call:")
         val brace = afterCall.indexOf('{')
         if (brace < 0) return null
         val name = afterCall.substring(0, brace).trim()
+        if (name.isEmpty() || name.any { it.isWhitespace() }) return null
         val parser = Parser(afterCall.substring(brace))
         val value = parser.parseValue()
         if (value !is ArgumentValue.Object) return null

--- a/sdk/src/main/kotlin/audio/soniqo/speech/llm/FunctionGemmaPrompt.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/llm/FunctionGemmaPrompt.kt
@@ -1,10 +1,24 @@
 package audio.soniqo.speech.llm
 
 /**
- * Kotlin port of `function_calls.format_tool_call_prompt` from the Python
- * speech-models export repo. Output is plain text — call
- * [applyChatTemplate] to wrap it in the model's chat-template scaffolding
- * before passing to the LiteRT-LM runtime.
+ * FunctionGemma prompt formatter, matching the canonical template from
+ * Google's "FunctionGemma formatting and best practices" guide (verified
+ * against the released 270M weights on the LiteRT-LM runtime):
+ *
+ * ```
+ * <start_of_turn>developer
+ * You are a model that can do function calling with the following functions
+ * <start_function_declaration>declaration:NAME{description:<escape>..<escape>,
+ * parameters:{properties:{..},required:[..],type:<escape>OBJECT<escape>}}<end_function_declaration><end_of_turn>
+ * <start_of_turn>user
+ * ..<end_of_turn>
+ * <start_of_turn>model
+ * ```
+ *
+ * Object keys serialize in alphabetical order and type names must be the
+ * UPPERCASE variants (`OBJECT`, `STRING`, `INTEGER`, `NUMBER`, `BOOLEAN`,
+ * `ARRAY`) — both taken from the canonical examples; deviations measurably
+ * degrade the 270M model's call syntax.
  */
 object FunctionGemmaPrompt {
 
@@ -18,24 +32,31 @@ object FunctionGemmaPrompt {
     const val FUNCTION_RESPONSE_END       = "<end_function_response>"
     const val ESCAPE                      = "<escape>"
 
+    const val DEVELOPER_PREAMBLE =
+        "You are a model that can do function calling with the following functions"
+
+    /** Developer-turn body: preamble + one declaration block per tool. */
     fun formatDeclarations(tools: List<FunctionDeclaration>): String = buildString {
-        append(FUNCTION_DECLARATIONS_START).append('\n')
+        append(DEVELOPER_PREAMBLE)
         for (tool in tools) {
-            append(FUNCTION_DECLARATION_START).append('\n')
-            append("name:").append(tool.name)
-                .append(",description:").append(ESCAPE).append(tool.description).append(ESCAPE)
-                .append(",parameters:").append(formatValue(tool.parameters))
-            append('\n').append(FUNCTION_DECLARATION_END).append('\n')
+            append(FUNCTION_DECLARATION_START)
+            append("declaration:").append(tool.name)
+            append("{description:").append(ESCAPE).append(tool.description).append(ESCAPE)
+            append(",parameters:").append(formatValue(tool.parameters))
+            append('}')
+            append(FUNCTION_DECLARATION_END)
         }
-        append(FUNCTION_DECLARATIONS_END)
     }
 
+    /** Full chat-templated prompt: developer turn + user turn + model cue. */
+    fun formatPrompt(tools: List<FunctionDeclaration>, userText: String): String =
+        "<start_of_turn>developer\n${formatDeclarations(tools)}<end_of_turn>\n" +
+            "<start_of_turn>user\n$userText<end_of_turn>\n" +
+            "<start_of_turn>model\n"
+
+    /** Un-templated variant for runtimes that add chat scaffolding themselves. */
     fun formatUserTurn(tools: List<FunctionDeclaration>, userText: String): String =
         "${formatDeclarations(tools)}\n$userText"
-
-    /** Wrap the formatted user turn in Gemma 3's chat-template scaffolding. */
-    fun applyChatTemplate(userMessage: String): String =
-        "<start_of_turn>user\n$userMessage<end_of_turn>\n<start_of_turn>model\n"
 
     fun formatResponse(name: String, response: Map<String, Any?>): String =
         "$FUNCTION_RESPONSE_START" + "response:" + name +
@@ -56,14 +77,10 @@ object FunctionGemmaPrompt {
     }
 
     private fun formatObject(dict: Map<String, Any?>): String {
-        // Match the field ordering the Python tokenisation script emits — the
-        // model was trained on those exact field names appearing in this order.
-        val preferred = listOf("type", "description", "properties", "required", "items", "enum")
-        val keys = dict.keys.toMutableList().sortedWith(compareBy(
-            { preferred.indexOf(it).let { idx -> if (idx == -1) Int.MAX_VALUE else idx } },
-            { it },
-        ))
-        val pairs = keys.joinToString(",") { "${it}:${formatValue(dict[it])}" }
+        // Canonical serialization orders object keys alphabetically (e.g.
+        // parameters:{properties:..,required:..,type:..}) — the model was
+        // trained on that exact ordering.
+        val pairs = dict.keys.sorted().joinToString(",") { "${it}:${formatValue(dict[it])}" }
         return "{$pairs}"
     }
 }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
@@ -109,6 +109,33 @@ class ModelManagerManifestTest {
         assertEquals(expected, styleFiles)
     }
 
+    @Test
+    fun llmManifest_isSingleFunctionGemmaBundle() {
+        assertEquals(
+            listOf(ModelManager.ModelFile("FunctionGemma-270M-LiteRT-LM", "model.litertlm")),
+            llmModelFiles(),
+        )
+    }
+
+    @Test
+    fun llmModelSetKey_isSeparateFromPipelineAndTtsCacheKeys() {
+        assertNotEquals(llmModelSetKey(), modelSetKey())
+        assertNotEquals(llmModelSetKey(), ttsModelSetKey(TtsModel.KOKORO))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun llmModelFiles(): List<ModelManager.ModelFile> {
+        val method = ModelManager::class.java.getDeclaredMethod("llmModels")
+        method.isAccessible = true
+        return method.invoke(ModelManager) as List<ModelManager.ModelFile>
+    }
+
+    private fun llmModelSetKey(): String {
+        val method = ModelManager::class.java.getDeclaredMethod("llmModelSetKey")
+        method.isAccessible = true
+        return method.invoke(ModelManager) as String
+    }
+
     @Suppress("UNCHECKED_CAST")
     private fun modelFiles(
         sttModel: SttModel = SttModel.PARAKEET_EOU,

--- a/sdk/src/test/kotlin/audio/soniqo/speech/llm/FunctionGemmaTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/llm/FunctionGemmaTest.kt
@@ -1,0 +1,124 @@
+package audio.soniqo.speech.llm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The chat-template contract of [FunctionGemma.Runtime]: raw runtimes get the
+ * fully templated prompt, runtimes that template internally (litertlm-android
+ * Conversation API) get the bare user turn — double-templating degrades
+ * tool-call accuracy.
+ */
+class FunctionGemmaTest {
+
+    private class CapturingRuntime(
+        override val appliesChatTemplate: Boolean,
+        private val response: String = "",
+    ) : FunctionGemma.Runtime {
+        var lastPrompt: String? = null
+        override fun generate(prompt: String, maxNewTokens: Int): String {
+            lastPrompt = prompt
+            return response
+        }
+        override fun cancel() {}
+    }
+
+    private val tools = listOf(
+        FunctionDeclaration(
+            name = "set_temperature",
+            description = "Set cabin temperature",
+            parameters = mapOf(
+                "type" to "OBJECT",
+                "properties" to mapOf(
+                    "celsius" to mapOf(
+                        "type" to "INTEGER",
+                        "description" to "Target temperature",
+                    ),
+                ),
+                "required" to listOf("celsius"),
+            ),
+        ),
+    )
+
+    @Test
+    fun rawRuntime_receivesCanonicalDeveloperTurnPrompt() {
+        val runtime = CapturingRuntime(appliesChatTemplate = false)
+        FunctionGemma(runtime).generateToolCall("set temp to 21", tools)
+
+        val prompt = runtime.lastPrompt!!
+        assertTrue(prompt.startsWith(
+            "<start_of_turn>developer\n${FunctionGemmaPrompt.DEVELOPER_PREAMBLE}"))
+        assertTrue(prompt.contains(
+            "<start_function_declaration>declaration:set_temperature{description:" +
+            "<escape>Set cabin temperature<escape>,parameters:{properties:{celsius:" +
+            "{description:<escape>Target temperature<escape>,type:<escape>INTEGER<escape>}}," +
+            "required:[<escape>celsius<escape>],type:<escape>OBJECT<escape>}}" +
+            "<end_function_declaration>"))
+        assertTrue(prompt.contains("<start_of_turn>user\nset temp to 21<end_of_turn>"))
+        assertTrue(prompt.endsWith("<start_of_turn>model\n"))
+    }
+
+    @Test
+    fun templatingRuntime_receivesBareDeclarationsAndText() {
+        val runtime = CapturingRuntime(appliesChatTemplate = true)
+        FunctionGemma(runtime).generateToolCall("set temp to 21", tools)
+
+        val prompt = runtime.lastPrompt!!
+        assertFalse(prompt.contains("<start_of_turn>"))
+        assertTrue(prompt.startsWith(FunctionGemmaPrompt.DEVELOPER_PREAMBLE))
+        assertTrue(prompt.endsWith("set temp to 21"))
+    }
+
+    @Test
+    fun parse_acceptsBareFunctionNameWithoutCallPrefix() {
+        // The released FunctionGemma-270M weights emit `NAME {args}` without
+        // the `call:` prefix from the training-format spec (seen on-device).
+        val response = "<start_function_call>call_contact {name:<escape>Anna<escape>," +
+            "say:<escape>Calling Anna.<escape>}<end_function_call>"
+        val calls = FunctionGemmaParser.parseFunctionCalls(response)
+
+        assertEquals(1, calls.size)
+        assertEquals("call_contact", calls[0].name)
+        assertEquals(ArgumentValue.Str("Anna"), calls[0].arguments["name"])
+    }
+
+    @Test
+    fun parse_rejectsBodyWithoutBraceOrWithJunkName() {
+        assertTrue(FunctionGemmaParser.parseFunctionCalls(
+            "<start_function_call>no braces here<end_function_call>").isEmpty())
+        assertTrue(FunctionGemmaParser.parseFunctionCalls(
+            "<start_function_call>some junk text {x:1}<end_function_call>").isEmpty())
+    }
+
+    @Test
+    fun parse_toleratesNewlinesAroundCallBody() {
+        // litertlm-android's Conversation output puts the call body on its
+        // own line after the marker (seen on-device with 0.14.0).
+        val response = "<start_function_call>\n" +
+            "call:find_contact{name:<escape>anna<escape>}\n<end_function_call>"
+        val calls = FunctionGemmaParser.parseFunctionCalls(response)
+
+        assertEquals(1, calls.size)
+        assertEquals("find_contact", calls[0].name)
+        assertEquals(ArgumentValue.Str("anna"), calls[0].arguments["name"])
+    }
+
+    @Test
+    fun generateAndParse_roundTripsAToolCall() {
+        val response = "<start_function_call>call:set_temperature{celsius:21," +
+            "say:<escape>Temperature set to 21 degrees.<escape>}<end_function_call>"
+        val gemma = FunctionGemma(CapturingRuntime(appliesChatTemplate = true, response = response))
+
+        val calls = gemma.parseToolCalls(gemma.generateToolCall("set temp to 21", tools))
+
+        assertEquals(1, calls.size)
+        assertEquals("set_temperature", calls[0].name)
+        assertEquals(ArgumentValue.Int(21), calls[0].arguments["celsius"])
+        assertEquals(
+            ArgumentValue.Str("Temperature set to 21 degrees."),
+            calls[0].arguments["say"],
+        )
+    }
+}


### PR DESCRIPTION
## Summary
SDK support for an app-side voice agent, extracted from the Soniqo Control demo.

- **PipelineMode.TRANSCRIBE_ONLY** in `SpeechConfig`, threaded through `NativeBridge` → `jni_bridge.cpp` (which previously hardcoded `Echo`), so an app can own the response instead of echoing.
- **SpeechPipeline.synthesize()** — speak text through the pipeline's already-loaded TTS (no second model instance).
- **ModelManager.ensureLlmModels()** — download the FunctionGemma-270M `.litertlm` bundle; writes the model-set marker up front and only wipes a genuinely stale set, so a partial download **resumes via HTTP Range** instead of restarting.
- **ModelDownloadWorker.includeLlm** — fetch the LLM in the same foreground worker, so the full setup survives doze / Wi-Fi power-save.
- **FunctionGemmaPrompt/Parser** — canonical developer-turn format (preamble + declaration blocks, alphabetical keys, UPPERCASE types); parser accepts the bare `NAME{...}` calls the released weights emit.

All additions are backward compatible (new `SpeechConfig` field and `SpeechPipeline` methods have defaults).

## Test plan
- `./gradlew :sdk:test :app:testDebugUnitTest` — 75 tests, 0 failures.
- `./gradlew :app:assembleDebug` — demo app builds against the changed SDK (native included).
- Verified end-to-end on a Galaxy S23 (SM-S918B) and arm64 emulator via the Soniqo Control demo.