### PR TITLE
EOU: configurable silence, autodetect, and beam-search contextual biasing

### DIFF
--- a/sdk/src/main/cpp/jni_bridge.cpp
+++ b/sdk/src/main/cpp/jni_bridge.cpp
@@ -229,6 +229,7 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
     std::string suffix = useInt8 ? "-int8" : "";
     std::string lang = jstring_to_string(env, language);
     std::vector<std::string> lang_hints = jstring_array_to_vector(env, languageHints);
+    (void)lang_hints;  // reserved for prompt-conditioned backends; Parakeet autodetects
 
     auto h = std::make_unique<PipelineHandle>();
     env->GetJavaVM(&h->jvm);
@@ -273,16 +274,16 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
                 dir + "/vocab.json",
                 nnapi);
         } else {
+            // Parakeet TDT autodetects its language — there is no forcing
+            // mechanism (the transducer has no decoder prompt, and the
+            // published exports emit no language tokens to steer), matching
+            // every other Parakeet runtime. `language`/`languageHints`
+            // apply to Nemotron's prompt slot and TTS voice selection only.
             auto m = std::make_unique<speech_core::ParakeetStt>(
                 dir + "/parakeet-encoder" + suffix + ".onnx",
                 dir + "/parakeet-decoder-joint" + suffix + ".onnx",
                 dir + "/vocab.json",
                 nnapi);
-            if (lang != "auto" && !lang.empty()) {
-                m->set_language(lang);
-            } else if (!lang_hints.empty()) {
-                m->set_allowed_languages(lang_hints);
-            }
             h->stt = std::move(m);
         }
         // TTS — Kokoro (ONNX, 24 kHz) or Supertonic-3 (LiteRT flow-matching, 44.1 kHz, G2P-free).

--- a/sdk/src/main/cpp/jni_bridge.cpp
+++ b/sdk/src/main/cpp/jni_bridge.cpp
@@ -221,7 +221,8 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
     jstring language,
     jobjectArray languageHints,
     jobject callback,
-    jboolean emitPartialTranscriptions, jfloat partialTranscriptionInterval)
+    jboolean emitPartialTranscriptions, jfloat partialTranscriptionInterval,
+    jfloat endOfSpeechSilenceSec)
 {
     auto dir = jstring_to_string(env, modelDir);
     bool nnapi = useNnapi;
@@ -288,7 +289,10 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
         h->tts = create_tts(dir, nnapi, ttsModel);
 
         speech_core::AgentConfig cfg;
-        cfg.vad.min_silence_duration = 0.5f;
+        // App-tunable end-of-utterance silence; <=0 falls back to the
+        // snappy-command default.
+        cfg.vad.min_silence_duration =
+            endOfSpeechSilenceSec > 0.0f ? endOfSpeechSilenceSec : 0.5f;
         cfg.vad.min_speech_duration = 0.15f;
         cfg.eager_stt = false;
         cfg.post_playback_guard = 0.15f;

--- a/sdk/src/main/cpp/jni_bridge.cpp
+++ b/sdk/src/main/cpp/jni_bridge.cpp
@@ -47,6 +47,11 @@ struct PipelineHandle {
     std::unique_ptr<speech_core::DeepFilterEnhancer> enhancer;
     std::unique_ptr<speech_core::VoicePipeline> pipeline;
 
+    // Non-owning typed view of `stt` when the Parakeet-EOU streaming model is
+    // loaded. set_context_phrases() (contextual biasing) is model-specific, not
+    // on STTInterface, so nativeSetContextPhrases needs the concrete type.
+    speech_core::OnnxNemotronStreamingStt* eou_stt = nullptr;
+
     // Serializes nativePipelineSynthesize calls on the shared TTS instance.
     // In TranscribeOnly mode the pipeline itself never touches TTS, so this
     // only guards against concurrent Kotlin-side synthesize() calls.
@@ -222,7 +227,7 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
     jobjectArray languageHints,
     jobject callback,
     jboolean emitPartialTranscriptions, jfloat partialTranscriptionInterval,
-    jfloat endOfSpeechSilenceSec)
+    jfloat endOfSpeechSilenceSec, jint beamSize)
 {
     auto dir = jstring_to_string(env, modelDir);
     bool nnapi = useNnapi;
@@ -267,12 +272,19 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
                 h->stt = std::move(m);
             }
         } else if (sttModel == STT_PARAKEET_EOU) {
-            h->stt = std::make_unique<speech_core::OnnxNemotronStreamingStt>(
+            // beamSize > 1 enables modified beam search, which contextual
+            // biasing (nativeSetContextPhrases) rides on; <= 1 stays greedy.
+            // The wrapper self-configures the rest from config.json.
+            speech_core::OnnxNemotronStreamingStt::Config eou_cfg;
+            eou_cfg.beam_size = beamSize;
+            auto m = std::make_unique<speech_core::OnnxNemotronStreamingStt>(
                 dir + "/parakeet-eou-encoder.onnx",
                 dir + "/parakeet-eou-decoder.onnx",
                 dir + "/parakeet-eou-joint.onnx",
                 dir + "/vocab.json",
-                nnapi);
+                eou_cfg, nnapi);
+            h->eou_stt = m.get();
+            h->stt = std::move(m);
         } else {
             // Parakeet TDT autodetects its language — there is no forcing
             // mechanism (the transducer has no decoder prompt, and the
@@ -401,6 +413,21 @@ Java_audio_soniqo_speech_NativeBridge_nativeGetState(
     auto* h = reinterpret_cast<PipelineHandle*>(handle);
     if (!h || !h->pipeline) return 0;
     return static_cast<jint>(h->pipeline->state());
+}
+
+// Install contextual-biasing phrases on the Parakeet-EOU streaming STT. No-op
+// unless EOU is the active model and it was created with beamSize > 1. Call
+// between utterances (not mid-decode); rebuild per turn to inject the entities
+// currently on the device. An empty array clears biasing.
+JNIEXPORT void JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativeSetContextPhrases(
+    JNIEnv* env, jobject /*thiz*/, jlong handle, jobjectArray phrases, jfloat maxBonus)
+{
+    auto* h = reinterpret_cast<PipelineHandle*>(handle);
+    if (!h || !h->eou_stt) return;
+    std::vector<std::string> ph = jstring_array_to_vector(env, phrases);
+    h->eou_stt->set_context_phrases(ph, /*per_char=*/1.5f, /*completion=*/3.0f,
+                                    /*max_bonus=*/maxBonus);
 }
 
 JNIEXPORT jlong JNICALL

--- a/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
@@ -14,8 +14,8 @@ internal object NativeBridge {
         sttBackend: Int,  // SttBackend.ordinal: 0=ONNX, 1=LITERT
         ttsModel: Int,    // 0=KOKORO, 1=SUPERTONIC, 2=KOKORO_SHORT_TURN
         pipelineMode: Int, // PipelineMode.ordinal: 0=ECHO, 1=TRANSCRIBE_ONLY
-        language: String, // single language hint ("auto", "en-US", ...)
-        languageHints: Array<String>, // shortlist for Parakeet TDT language-token guidance
+        language: String, // single language hint ("auto", "en-US", ...) — Nemotron prompt + TTS voice
+        languageHints: Array<String>, // reserved; no current backend consumes hints
         callback: EventCallback,
         emitPartialTranscriptions: Boolean,
         partialTranscriptionInterval: Float,

--- a/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
@@ -20,6 +20,7 @@ internal object NativeBridge {
         emitPartialTranscriptions: Boolean,
         partialTranscriptionInterval: Float,
         endOfSpeechSilenceSec: Float,  // seconds of silence ending an utterance
+        beamSize: Int,                 // Parakeet-EOU RNN-T beam width; <=1 = greedy
     ): Long
 
     external fun nativeNnapiFallbackReason(): String?
@@ -29,6 +30,10 @@ internal object NativeBridge {
     external fun nativePushAudio(handle: Long, samples: FloatArray, count: Int)
     external fun nativeResumeListen(handle: Long)
     external fun nativeGetState(handle: Long): Int
+
+    // Contextual biasing for the Parakeet-EOU streaming STT (no-op for other
+    // models or when beamSize <= 1). maxBonus caps each phrase's boost; 0 = off.
+    external fun nativeSetContextPhrases(handle: Long, phrases: Array<String>, maxBonus: Float)
 
     // Direct synthesis with the pipeline's already-loaded TTS model — lets a
     // TRANSCRIBE_ONLY agent loop speak responses without a second TTS copy.

--- a/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
@@ -19,6 +19,7 @@ internal object NativeBridge {
         callback: EventCallback,
         emitPartialTranscriptions: Boolean,
         partialTranscriptionInterval: Float,
+        endOfSpeechSilenceSec: Float,  // seconds of silence ending an utterance
     ): Long
 
     external fun nativeNnapiFallbackReason(): String?

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
@@ -75,6 +75,12 @@ data class SpeechConfig(
      *  [language], and Parakeet TDT always autodetects. */
     val languageHints: List<String> = emptyList(),
 
+    /** RNN-T beam width for the Parakeet-EOU streaming STT. `<= 1` keeps the
+     *  greedy default; `> 1` enables modified beam search, which contextual
+     *  biasing ([SpeechPipeline.setContextPhrases]) rides on. Ignored by other
+     *  STT models. */
+    val beamSize: Int = 0,
+
     /** Seconds of detected silence that end an utterance. The 0.5 s default
      *  favors snappy short commands; raise it (0.8–1.2 s) when users pause
      *  mid-utterance — dictating digit sequences, thinking through a

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
@@ -52,9 +52,10 @@ data class SpeechConfig(
     /** Pipeline behavior after transcription. See [PipelineMode]. */
     val pipelineMode: PipelineMode = PipelineMode.ECHO,
 
-    /** Language/locale prompt for prompt-conditioned models and single-language
-     *  Parakeet TDT guidance: e.g. "en-US", "fr", "ja-JP". "auto" lets the
-     *  model decide, optionally constrained by [languageHints]. */
+    /** Language/locale for prompt-conditioned STT models (Nemotron) and TTS
+     *  voice selection: e.g. "en-US", "fr", "ja-JP". "auto" lets the model
+     *  decide. Parakeet TDT always autodetects — the transducer has no
+     *  forcing mechanism, matching every other Parakeet runtime. */
     val language: String = "auto",
 
     /** Enable noise cancellation (DeepFilterNet3). */
@@ -69,9 +70,9 @@ data class SpeechConfig(
     /** Interval between partial transcriptions in seconds. */
     val partialTranscriptionInterval: Float = 0.5f,
 
-    /** Optional language shortlist for Parakeet TDT language-token guidance.
-     *  Entries may be ISO codes or BCP-47 tags, e.g. listOf("en-US", "fr").
-     *  Ignored when [language] selects a concrete non-auto language. */
+    /** Reserved language shortlist for future prompt-conditioned backends.
+     *  No current STT backend consumes it: Nemotron takes a single
+     *  [language], and Parakeet TDT always autodetects. */
     val languageHints: List<String> = emptyList(),
 
     /** Seconds of detected silence that end an utterance. The 0.5 s default

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
@@ -73,4 +73,10 @@ data class SpeechConfig(
      *  Entries may be ISO codes or BCP-47 tags, e.g. listOf("en-US", "fr").
      *  Ignored when [language] selects a concrete non-auto language. */
     val languageHints: List<String> = emptyList(),
+
+    /** Seconds of detected silence that end an utterance. The 0.5 s default
+     *  favors snappy short commands; raise it (0.8–1.2 s) when users pause
+     *  mid-utterance — dictating digit sequences, thinking through a
+     *  sentence — and get cut off early. */
+    val endOfSpeechSilenceSec: Float = 0.5f,
 )

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
@@ -106,6 +106,7 @@ internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
         nativeCallback,
         config.emitPartialTranscriptions,
         config.partialTranscriptionInterval,
+        config.endOfSpeechSilenceSec,
     ).also { h ->
         if (h == 0L) throw IllegalStateException(
             "Failed to create native pipeline. Models may be corrupt — " +

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
@@ -46,6 +46,17 @@ interface SpeechPipeline : AutoCloseable {
     /** Signal that response playback finished — resume listening. */
     fun resumeListening()
 
+    /**
+     * Install contextual-biasing phrases for the Parakeet-EOU streaming STT
+     * (no-op for other models or when [SpeechConfig.beamSize] `<= 1`). Nudges
+     * recognition toward these surface phrases — command words, a brand name,
+     * the contact / track names currently on the device. Call between
+     * utterances and rebuild per turn to reflect live device state. [maxBonus]
+     * caps each phrase's boost so a long list can't override clear audio; an
+     * empty list clears biasing.
+     */
+    fun setContextPhrases(phrases: List<String>, maxBonus: Float = 6f) {}
+
     /** Sample rate of [synthesize] output, or 0 if unsupported. */
     val ttsSampleRate: Int get() = 0
 
@@ -107,6 +118,7 @@ internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
         config.emitPartialTranscriptions,
         config.partialTranscriptionInterval,
         config.endOfSpeechSilenceSec,
+        config.beamSize,
     ).also { h ->
         if (h == 0L) throw IllegalStateException(
             "Failed to create native pipeline. Models may be corrupt — " +
@@ -134,6 +146,10 @@ internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
 
     override fun resumeListening() {
         NativeBridge.nativeResumeListen(handle)
+    }
+
+    override fun setContextPhrases(phrases: List<String>, maxBonus: Float) {
+        NativeBridge.nativeSetContextPhrases(handle, phrases.toTypedArray(), maxBonus)
     }
 
     override val ttsSampleRate: Int

--- a/sdk/src/test/kotlin/audio/soniqo/speech/SpeechConfigTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/SpeechConfigTest.kt
@@ -1,0 +1,19 @@
+package audio.soniqo.speech
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SpeechConfigTest {
+
+    @Test
+    fun endOfSpeechSilence_usesSnappyCommandDefault() {
+        assertEquals(0.5f, SpeechConfig().endOfSpeechSilenceSec, 0f)
+    }
+
+    @Test
+    fun endOfSpeechSilence_acceptsLongerPauseForDictation() {
+        val config = SpeechConfig(endOfSpeechSilenceSec = 0.8f)
+
+        assertEquals(0.8f, config.endOfSpeechSilenceSec, 0f)
+    }
+}


### PR DESCRIPTION
## Summary

Consumer-side SDK updates that bring speech-android up to speech-core `main` (submodule `787af90`). Three related changes:

1. **Configurable end-of-speech silence.** `SpeechConfig.endOfSpeechSilenceSec` (default `0.5`), plumbed through `NativeBridge` → `SpeechPipeline` → `jni_bridge` into the pipeline VAD's `min_silence_duration`. Lets an app trade snappy short commands against room to pause mid-utterance; `<= 0` falls back to `0.5 s`.

2. **Parakeet autodetects — drop language-forcing call sites.** speech-core removed Parakeet language forcing (no decoder prompt channel, no language tokens emitted, so it was a no-op). Construct `ParakeetStt` without those calls; `SpeechConfig.language` now drives only the Nemotron prompt slot + TTS voice, and `languageHints` is reserved.

3. **EOU beam search + contextual biasing.** speech-core (PR #106) added opt-in RNN-T beam search and contextual biasing to the Parakeet-EOU streaming STT. Surface it: `SpeechConfig.beamSize` (default 0 = greedy), `SpeechPipeline.setContextPhrases(phrases, maxBonus)`, and the JNI `nativeSetContextPhrases` backed by a typed EOU handle. Both are no-ops unless EOU is the active model and `beamSize > 1`.

## Changed
- `sdk/src/main/cpp/jni_bridge.cpp` — `endOfSpeechSilenceSec` + `beamSize` params; direct `ParakeetStt`; typed EOU alias + `nativeSetContextPhrases`.
- `sdk/src/main/kotlin/.../SpeechConfig.kt`, `NativeBridge.kt`, `SpeechPipeline.kt` — new fields/methods + clarified language semantics.
- `sdk/src/main/kotlin/.../SpeechConfigTest.kt` — covers `endOfSpeechSilenceSec`.
- `speech-core` — submodule bump to `787af90`.

## Test plan
- `./gradlew :sdk:test` — passes.
- `./gradlew :app:assembleDebug` — builds and links against speech-core `787af90`.
- speech-core `787af90`: default + ONNX configs build; test suites pass (20/20 default, 19/19 ONNX). Beam + biasing host-verified: `beam_size=4` + the command grammar recovers "set volume eight" from a greedy "said william eight".
- `./gradlew :sdk:connectedAndroidTest` (e2e) not run here — needs a device.

## Note
Public API and default decode paths are unchanged; consumers opt into beam/biasing via `beamSize` + `setContextPhrases()`.
