### PR TITLE
Make realtime Kokoro the Android default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repo is the **Android packaging**: Kotlin SDK, JNI bridge, demo app. The C+
 
 Models are downloaded automatically on first launch via `ModelManager.ensureModels()`.
 
-`SpeechConfig()` defaults to `SttModel.PARAKEET_EOU` and `TtsModel.KOKORO`
+`SpeechConfig()` defaults to `SttModel.PARAKEET_EOU` and `TtsModel.KOKORO_SHORT_TURN`
 to keep SDK integrations and the system recognizer on the low-memory Android
 path. The demo app opts into `SttModel.PARAKEET` so its echo and dictation
 screens exercise the larger 114-language TDT model.
@@ -65,7 +65,7 @@ dependencies {
 val modelDir = ModelManager.ensureModels(context)
 
 val pipeline = SpeechPipeline(
-    SpeechConfig(modelDir = modelDir, useNnapi = true)
+    SpeechConfig(modelDir = modelDir, useNnapi = false)
 )
 
 pipeline.events.collect { event ->
@@ -248,12 +248,15 @@ Add `app/src/main/res/xml/tts_engine.xml`:
 
 ## Performance
 
-Measured on Galaxy S23 Android, CPU only unless noted. Lower RTF is faster.
+Measured on a Galaxy S23 Ultra (SM-S918B), CPU only unless noted. RTF is
+wall time ÷ emitted-audio duration: lower is faster, and <1.0 is faster than
+real time.
 
 | Model | Task | RTF | Latency | Peak memory |
 | --- | --- | --- | --- | --- |
 | Parakeet-EOU 120M ONNX INT8 | Streaming STT + EOU | 0.21 | streaming partials | 232 MB |
-| Kokoro 82M ONNX FP32 | TTS | 0.53 | sentence-level | 640 MB |
+| Kokoro 82M full graph (published, two CPU threads) | TTS | 1.81 | sentence-level | ~604 MB |
+| Kokoro 82M short-turn (3.0 s graph, default) | TTS | 0.75–0.88 | bounded replies; safe retry | ~527 MB |
 | Supertonic-3 LiteRT | TTS | 0.34 | ~1.1s TTFA | 832 MB |
 | Silero VAD v5 | VAD | <0.01 | <1ms per 32ms chunk | <10 MB |
 

--- a/README_de.md
+++ b/README_de.md
@@ -26,7 +26,7 @@ Dieses Repo ist das **Android-Packaging**: Kotlin-SDK, JNI-Bridge, Demo-App. Die
 
 Modelle werden beim ersten Start automatisch über `ModelManager.ensureModels()` heruntergeladen.
 
-`SpeechConfig()` verwendet standardmäßig `SttModel.PARAKEET_EOU` und `TtsModel.KOKORO`, damit SDK-Integrationen und Systemerkennung den speicherarmen Android-Pfad nutzen. Die Demo-App wählt `SttModel.PARAKEET`, sodass Echo- und Diktieransicht das größere TDT-Modell mit 114 Sprachen verwenden.
+`SpeechConfig()` verwendet standardmäßig `SttModel.PARAKEET_EOU` und `TtsModel.KOKORO_SHORT_TURN`, damit SDK-Integrationen und Systemerkennung den speicherarmen Android-Pfad nutzen. Die Demo-App wählt `SttModel.PARAKEET`, sodass Echo- und Diktieransicht das größere TDT-Modell mit 114 Sprachen verwenden.
 
 Für sprachfokussierte Erkennung verwende `SpeechConfig(sttModel = SttModel.PARAKEET, languageHints = listOf("en", "fr"))`. Setze `language = "en"`, wenn genau eine Sprache fest vorgegeben werden soll.
 
@@ -50,7 +50,7 @@ dependencies {
 val modelDir = ModelManager.ensureModels(context)
 
 val pipeline = SpeechPipeline(
-    SpeechConfig(modelDir = modelDir, useNnapi = true)
+    SpeechConfig(modelDir = modelDir, useNnapi = false)
 )
 
 pipeline.events.collect { event ->
@@ -169,12 +169,14 @@ Füge `app/src/main/res/xml/tts_engine.xml` hinzu:
 
 ## Leistung
 
-Gemessen auf Galaxy S23 Android, sofern nicht anders angegeben nur CPU. Niedrigeres RTF ist schneller.
+Gemessen auf einem Galaxy S23 Ultra (SM-S918B), sofern nicht anders angegeben nur CPU. RTF ist
+Wandzeit ÷ Dauer des ausgegebenen Audios: niedriger ist schneller, und <1,0 ist schneller als Echtzeit.
 
 | Modell | Aufgabe | RTF | Latenz | Spitzen-Speicher |
 | --- | --- | --- | --- | --- |
 | Parakeet-EOU 120M ONNX INT8 | Streaming-STT + EOU | 0,21 | Streaming-Teilergebnisse | 232 MB |
-| Kokoro 82M ONNX FP32 | TTS | 0,53 | satzweise | 640 MB |
+| Kokoro 82M vollständiger Graph (veröffentlicht, CPU mit zwei Threads) | TTS | 1,81 | satzweise | ~604 MB |
+| Kokoro 82M kurze Antwort (3,0-s-Graph, Standard) | TTS | 0,75–0,88 | begrenzte Antworten; sicherer Retry | ~527 MB |
 | Supertonic-3 LiteRT | TTS | 0,34 | ~1,1s TTFA | 832 MB |
 | Silero VAD v5 | VAD | <0,01 | <1ms pro 32ms-Block | <10 MB |
 

--- a/README_es.md
+++ b/README_es.md
@@ -26,7 +26,7 @@ Este repositorio es el **empaquetado para Android**: SDK de Kotlin, puente JNI, 
 
 Los modelos se descargan automáticamente al primer inicio vía `ModelManager.ensureModels()`.
 
-`SpeechConfig()` usa `SttModel.PARAKEET_EOU` y `TtsModel.KOKORO` por defecto para mantener las integraciones del SDK y el reconocedor del sistema en la ruta Android de baja memoria. La app demo opta por `SttModel.PARAKEET` para que las pantallas de eco y dictado usen el modelo TDT más grande de 114 idiomas.
+`SpeechConfig()` usa `SttModel.PARAKEET_EOU` y `TtsModel.KOKORO_SHORT_TURN` por defecto para mantener las integraciones del SDK y el reconocedor del sistema en la ruta Android de baja memoria. La app demo opta por `SttModel.PARAKEET` para que las pantallas de eco y dictado usen el modelo TDT más grande de 114 idiomas.
 
 Para reconocimiento enfocado por idioma, usa `SpeechConfig(sttModel = SttModel.PARAKEET, languageHints = listOf("en", "fr"))`. Define `language = "en"` si quieres fijar un único idioma.
 
@@ -50,7 +50,7 @@ dependencies {
 val modelDir = ModelManager.ensureModels(context)
 
 val pipeline = SpeechPipeline(
-    SpeechConfig(modelDir = modelDir, useNnapi = true)
+    SpeechConfig(modelDir = modelDir, useNnapi = false)
 )
 
 pipeline.events.collect { event ->
@@ -193,12 +193,15 @@ Añade `app/src/main/res/xml/tts_engine.xml`:
 
 ## Rendimiento
 
-Medido en Galaxy S23 Android, solo CPU salvo indicación. Un RTF menor es más rápido.
+Medido en un Galaxy S23 Ultra (SM-S918B), solo CPU salvo indicación. RTF es
+tiempo de pared ÷ duración del audio emitido: cuanto menor, más rápido; <1,0
+es más rápido que tiempo real.
 
 | Modelo | Tarea | RTF | Latencia | Pico de memoria |
 | --- | --- | --- | --- | --- |
 | Parakeet-EOU 120M ONNX INT8 | STT en streaming + EOU | 0.21 | parciales en streaming | 232 MB |
-| Kokoro 82M ONNX FP32 | TTS | 0.53 | por frase | 640 MB |
+| Kokoro 82M grafo completo (publicado, CPU de dos hilos) | TTS | 1.81 | por frase | ~604 MB |
+| Kokoro 82M turno corto (grafo de 3.0 s, predeterminado) | TTS | 0.75–0.88 | respuestas acotadas; reintento seguro | ~527 MB |
 | Supertonic-3 LiteRT | TTS | 0.34 | ~1.1s TTFA | 832 MB |
 | Silero VAD v5 | VAD | <0.01 | <1ms por bloque de 32ms | <10 MB |
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -26,7 +26,7 @@ Ce dépôt fournit le **packaging Android** : SDK Kotlin, pont JNI, application 
 
 Les modèles sont téléchargés automatiquement au premier lancement via `ModelManager.ensureModels()`.
 
-`SpeechConfig()` utilise `SttModel.PARAKEET_EOU` et `TtsModel.KOKORO` par défaut afin que les intégrations SDK et le service de reconnaissance système restent sur le chemin Android à faible mémoire. L'application de démo sélectionne `SttModel.PARAKEET` pour que les écrans écho et dictée utilisent le modèle TDT plus grand à 114 langues.
+`SpeechConfig()` utilise `SttModel.PARAKEET_EOU` et `TtsModel.KOKORO_SHORT_TURN` par défaut afin que les intégrations SDK et le service de reconnaissance système restent sur le chemin Android à faible mémoire. L'application de démo sélectionne `SttModel.PARAKEET` pour que les écrans écho et dictée utilisent le modèle TDT plus grand à 114 langues.
 
 Pour une reconnaissance centrée sur certaines langues, utilisez `SpeechConfig(sttModel = SttModel.PARAKEET, languageHints = listOf("en", "fr"))`. Définissez `language = "en"` pour fixer une seule langue.
 
@@ -50,7 +50,7 @@ dependencies {
 val modelDir = ModelManager.ensureModels(context)
 
 val pipeline = SpeechPipeline(
-    SpeechConfig(modelDir = modelDir, useNnapi = true)
+    SpeechConfig(modelDir = modelDir, useNnapi = false)
 )
 
 pipeline.events.collect { event ->
@@ -169,12 +169,14 @@ Ajoutez `app/src/main/res/xml/tts_engine.xml` :
 
 ## Performance
 
-Mesuré sur Galaxy S23 Android, CPU seul sauf indication. Un RTF plus bas est plus rapide.
+Mesuré sur un Galaxy S23 Ultra (SM-S918B), CPU seul sauf indication. Le RTF est le
+temps mural ÷ la durée audio émise : plus bas est plus rapide, et <1,0 est plus rapide que le temps réel.
 
 | Modèle | Tâche | RTF | Latence | Mémoire max |
 | --- | --- | --- | --- | --- |
 | Parakeet-EOU 120M ONNX INT8 | STT streaming + EOU | 0,21 | partiels streaming | 232 Mo |
-| Kokoro 82M ONNX FP32 | TTS | 0,53 | par phrase | 640 Mo |
+| Kokoro 82M graphe complet (publié, CPU à deux threads) | TTS | 1,81 | par phrase | ~604 Mo |
+| Kokoro 82M tour court (graphe de 3,0 s, par défaut) | TTS | 0,75–0,88 | réponses bornées ; nouvelle tentative sûre | ~527 Mo |
 | Supertonic-3 LiteRT | TTS | 0,34 | ~1,1 s TTFA | 832 Mo |
 | Silero VAD v5 | VAD | <0,01 | <1 ms par bloc 32 ms | <10 Mo |
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -26,7 +26,7 @@ Android के लिए ऑन-डिवाइस स्पीच SDK, [ONNX Ru
 
 मॉडल पहले लॉन्च पर `ModelManager.ensureModels()` के माध्यम से स्वचालित रूप से डाउनलोड होते हैं।
 
-`SpeechConfig()` डिफ़ॉल्ट रूप से `SttModel.PARAKEET_EOU` और `TtsModel.KOKORO` इस्तेमाल करता है, ताकि SDK इंटीग्रेशन और सिस्टम रिकग्नाइज़र कम-मेमोरी Android पथ पर रहें। डेमो ऐप `SttModel.PARAKEET` चुनता है, इसलिए इको और डिक्टेशन स्क्रीन बड़े 114-भाषा TDT मॉडल का उपयोग करती हैं।
+`SpeechConfig()` डिफ़ॉल्ट रूप से `SttModel.PARAKEET_EOU` और `TtsModel.KOKORO_SHORT_TURN` इस्तेमाल करता है, ताकि SDK इंटीग्रेशन और सिस्टम रिकग्नाइज़र कम-मेमोरी Android पथ पर रहें। डेमो ऐप `SttModel.PARAKEET` चुनता है, इसलिए इको और डिक्टेशन स्क्रीन बड़े 114-भाषा TDT मॉडल का उपयोग करती हैं।
 
 भाषा-केंद्रित रिकग्निशन के लिए `SpeechConfig(sttModel = SttModel.PARAKEET, languageHints = listOf("en", "fr"))` इस्तेमाल करें। केवल एक भाषा तय करनी हो तो `language = "en"` सेट करें।
 
@@ -50,7 +50,7 @@ dependencies {
 val modelDir = ModelManager.ensureModels(context)
 
 val pipeline = SpeechPipeline(
-    SpeechConfig(modelDir = modelDir, useNnapi = true)
+    SpeechConfig(modelDir = modelDir, useNnapi = false)
 )
 
 pipeline.events.collect { event ->
@@ -169,14 +169,13 @@ adb shell settings put secure voice_recognition_service \
 
 ## प्रदर्शन
 
-Android एमुलेटर (arm64-v8a, NNAPI के बिना) पर मापा गया। वास्तविक हार्डवेयर काफी तेज़ है।
-
-Galaxy S23 Android पर मापा गया, जब तक अलग से न कहा गया हो CPU-only। कम RTF तेज़ है।
+Galaxy S23 Ultra (SM-S918B) पर केवल CPU के साथ मापा गया। RTF = दीवार-समय ÷ जनरेट किए गए ऑडियो की अवधि; कम बेहतर है और <1.0 रीयल-टाइम से तेज़ है।
 
 | मॉडल | कार्य | RTF | लेटेंसी | पीक मेमोरी |
 | --- | --- | --- | --- | --- |
 | Parakeet-EOU 120M ONNX INT8 | स्ट्रीमिंग STT + EOU | 0.21 | streaming partials | 232 MB |
-| Kokoro 82M ONNX FP32 | TTS | 0.53 | वाक्य-स्तर | 640 MB |
+| Kokoro 82M पूर्ण ग्राफ़ (प्रकाशित, CPU के दो थ्रेड) | TTS | 1.81 | वाक्य-स्तर | ~604 MB |
+| Kokoro 82M छोटा टर्न (3.0 सेकंड ग्राफ़, डिफ़ॉल्ट) | TTS | 0.75–0.88 | सीमित उत्तर; सुरक्षित पुनःप्रयास | ~527 MB |
 | Supertonic-3 LiteRT | TTS | 0.34 | ~1.1 सेकंड TTFA | 832 MB |
 | Silero VAD v5 | VAD | <0.01 | हर 32 मिलीसेकंड चंक पर <1 मिलीसेकंड | <10 MB |
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -26,7 +26,7 @@
 
 モデルは初回起動時に `ModelManager.ensureModels()` 経由で自動ダウンロードされます。
 
-`SpeechConfig()` は `SttModel.PARAKEET_EOU` と `TtsModel.KOKORO` を既定にして、SDK 組み込みとシステム認識サービスを低メモリ Android パスで動かします。デモアプリは `SttModel.PARAKEET` を選択し、エコー画面とディクテーション画面でより大きい 114 言語 TDT モデルを使います。
+`SpeechConfig()` は `SttModel.PARAKEET_EOU` と `TtsModel.KOKORO_SHORT_TURN` を既定にして、SDK 組み込みとシステム認識サービスを低メモリ Android パスで動かします。デモアプリは `SttModel.PARAKEET` を選択し、エコー画面とディクテーション画面でより大きい 114 言語 TDT モデルを使います。
 
 言語を絞った認識には `SpeechConfig(sttModel = SttModel.PARAKEET, languageHints = listOf("en", "fr"))` を使います。単一の言語に固定したい場合は `language = "en"` を設定します。
 
@@ -50,7 +50,7 @@ dependencies {
 val modelDir = ModelManager.ensureModels(context)
 
 val pipeline = SpeechPipeline(
-    SpeechConfig(modelDir = modelDir, useNnapi = true)
+    SpeechConfig(modelDir = modelDir, useNnapi = false)
 )
 
 pipeline.events.collect { event ->
@@ -169,14 +169,13 @@ adb shell settings put secure voice_recognition_service \
 
 ## パフォーマンス
 
-Android エミュレータ(arm64-v8a、NNAPI なし)で測定。実機ははるかに高速です。
-
-Galaxy S23 Android で測定。特記がない限り CPU。RTF は低いほど高速です。
+Galaxy S23 Ultra（SM-S918B）で CPU のみを使用して測定。RTF は実行時間÷生成音声時間で、低いほど速く、<1.0 はリアルタイムより高速です。
 
 | モデル | タスク | RTF | レイテンシ | ピークメモリ |
 | --- | --- | --- | --- | --- |
 | Parakeet-EOU 120M ONNX INT8 | ストリーミング STT + EOU | 0.21 | streaming partials | 232 MB |
-| Kokoro 82M ONNX FP32 | TTS | 0.53 | 文単位 | 640 MB |
+| Kokoro 82M フルグラフ（公開版、CPU 2 スレッド） | TTS | 1.81 | 文単位 | ~604 MB |
+| Kokoro 82M 短ターン（3.0 秒グラフ、デフォルト） | TTS | 0.75–0.88 | 制限付き応答、安全な再試行 | ~527 MB |
 | Supertonic-3 LiteRT | TTS | 0.34 | ~1.1 秒 TTFA | 832 MB |
 | Silero VAD v5 | VAD | <0.01 | 32 ミリ秒チャンクあたり <1 ミリ秒 | <10 MB |
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -26,7 +26,7 @@
 
 모델은 `ModelManager.ensureModels()`를 통해 첫 실행 시 자동으로 다운로드됩니다.
 
-`SpeechConfig()`는 `SttModel.PARAKEET_EOU`와 `TtsModel.KOKORO`를 기본값으로 사용해 SDK 통합과 시스템 인식 서비스를 저메모리 Android 경로에서 실행합니다. 데모 앱은 `SttModel.PARAKEET`를 선택해 에코와 받아쓰기 화면에서 더 큰 114개 언어 TDT 모델을 사용합니다.
+`SpeechConfig()`는 `SttModel.PARAKEET_EOU`와 `TtsModel.KOKORO_SHORT_TURN`를 기본값으로 사용해 SDK 통합과 시스템 인식 서비스를 저메모리 Android 경로에서 실행합니다. 데모 앱은 `SttModel.PARAKEET`를 선택해 에코와 받아쓰기 화면에서 더 큰 114개 언어 TDT 모델을 사용합니다.
 
 언어 중심 인식에는 `SpeechConfig(sttModel = SttModel.PARAKEET, languageHints = listOf("en", "fr"))`를 사용하세요. 하나의 언어로 고정하려면 `language = "en"`을 설정하세요.
 
@@ -50,7 +50,7 @@ dependencies {
 val modelDir = ModelManager.ensureModels(context)
 
 val pipeline = SpeechPipeline(
-    SpeechConfig(modelDir = modelDir, useNnapi = true)
+    SpeechConfig(modelDir = modelDir, useNnapi = false)
 )
 
 pipeline.events.collect { event ->
@@ -169,14 +169,13 @@ adb shell settings put secure voice_recognition_service \
 
 ## 성능
 
-Android 에뮬레이터(arm64-v8a, NNAPI 없음)에서 측정. 실제 하드웨어는 훨씬 빠릅니다.
-
-Galaxy S23 Android에서 측정했습니다. 별도 표기가 없으면 CPU 기준입니다. RTF는 낮을수록 빠릅니다.
+Galaxy S23 Ultra(SM-S918B)에서 CPU만 사용해 측정했습니다. RTF는 경과 시간÷생성 오디오 길이이며, 낮을수록 빠르고 <1.0이면 실시간보다 빠릅니다.
 
 | 모델 | 작업 | RTF | 지연 시간 | 피크 메모리 |
 | --- | --- | --- | --- | --- |
 | Parakeet-EOU 120M ONNX INT8 | 스트리밍 STT + EOU | 0.21 | streaming partials | 232 MB |
-| Kokoro 82M ONNX FP32 | TTS | 0.53 | 문장 단위 | 640 MB |
+| Kokoro 82M 전체 그래프(공개 버전, CPU 2 스레드) | TTS | 1.81 | 문장 단위 | ~604 MB |
+| Kokoro 82M 짧은 턴(3.0초 그래프, 기본값) | TTS | 0.75–0.88 | 제한된 응답, 안전한 재시도 | ~527 MB |
 | Supertonic-3 LiteRT | TTS | 0.34 | ~1.1초 TTFA | 832 MB |
 | Silero VAD v5 | VAD | <0.01 | 32ms 청크당 <1ms | <10 MB |
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -26,7 +26,7 @@ Este repositório é o **empacotamento Android**: SDK Kotlin, ponte JNI, app de 
 
 Os modelos são baixados automaticamente no primeiro lançamento via `ModelManager.ensureModels()`.
 
-`SpeechConfig()` usa `SttModel.PARAKEET_EOU` e `TtsModel.KOKORO` por padrão para manter integrações do SDK e o reconhecedor do sistema no caminho Android de baixa memória. O app demo seleciona `SttModel.PARAKEET` para que as telas de eco e ditado usem o modelo TDT maior de 114 idiomas.
+`SpeechConfig()` usa `SttModel.PARAKEET_EOU` e `TtsModel.KOKORO_SHORT_TURN` por padrão para manter integrações do SDK e o reconhecedor do sistema no caminho Android de baixa memória. O app demo seleciona `SttModel.PARAKEET` para que as telas de eco e ditado usem o modelo TDT maior de 114 idiomas.
 
 Para reconhecimento focado em idiomas, use `SpeechConfig(sttModel = SttModel.PARAKEET, languageHints = listOf("en", "fr"))`. Defina `language = "en"` quando quiser fixar um único idioma.
 
@@ -50,7 +50,7 @@ dependencies {
 val modelDir = ModelManager.ensureModels(context)
 
 val pipeline = SpeechPipeline(
-    SpeechConfig(modelDir = modelDir, useNnapi = true)
+    SpeechConfig(modelDir = modelDir, useNnapi = false)
 )
 
 pipeline.events.collect { event ->
@@ -192,12 +192,14 @@ Adicione `app/src/main/res/xml/tts_engine.xml`:
 
 ## Desempenho
 
-Medido em Galaxy S23 Android, CPU apenas salvo indicação. RTF menor é mais rápido.
+Medido em um Galaxy S23 Ultra (SM-S918B), apenas CPU salvo indicação. RTF é
+tempo de parede ÷ duração do áudio emitido: menor é mais rápido, e <1,0 é mais rápido que o tempo real.
 
 | Modelo | Tarefa | RTF | Latência | Pico de memória |
 | --- | --- | --- | --- | --- |
 | Parakeet-EOU 120M ONNX INT8 | STT em streaming + EOU | 0,21 | parciais em streaming | 232 MB |
-| Kokoro 82M ONNX FP32 | TTS | 0,53 | por frase | 640 MB |
+| Kokoro 82M grafo completo (publicado, CPU com dois threads) | TTS | 1,81 | por frase | ~604 MB |
+| Kokoro 82M turno curto (grafo de 3,0 s, padrão) | TTS | 0,75–0,88 | respostas delimitadas; nova tentativa segura | ~527 MB |
 | Supertonic-3 LiteRT | TTS | 0,34 | ~1,1s TTFA | 832 MB |
 | Silero VAD v5 | VAD | <0,01 | <1ms por bloco de 32ms | <10 MB |
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -26,7 +26,7 @@
 
 Модели загружаются автоматически при первом запуске через `ModelManager.ensureModels()`.
 
-`SpeechConfig()` по умолчанию использует `SttModel.PARAKEET_EOU` и `TtsModel.KOKORO`, чтобы интеграции SDK и системный распознаватель работали по низкопамятному Android-пути. Демо-приложение выбирает `SttModel.PARAKEET`, поэтому экраны эха и диктовки используют более крупную TDT-модель на 114 языков.
+`SpeechConfig()` по умолчанию использует `SttModel.PARAKEET_EOU` и `TtsModel.KOKORO_SHORT_TURN`, чтобы интеграции SDK и системный распознаватель работали по низкопамятному Android-пути. Демо-приложение выбирает `SttModel.PARAKEET`, поэтому экраны эха и диктовки используют более крупную TDT-модель на 114 языков.
 
 Для распознавания с фокусом на языки используйте `SpeechConfig(sttModel = SttModel.PARAKEET, languageHints = listOf("en", "fr"))`. Задайте `language = "en"`, если нужно зафиксировать один язык.
 
@@ -50,7 +50,7 @@ dependencies {
 val modelDir = ModelManager.ensureModels(context)
 
 val pipeline = SpeechPipeline(
-    SpeechConfig(modelDir = modelDir, useNnapi = true)
+    SpeechConfig(modelDir = modelDir, useNnapi = false)
 )
 
 pipeline.events.collect { event ->
@@ -169,14 +169,14 @@ adb shell settings put secure voice_recognition_service \
 
 ## Производительность
 
-Измерено на эмуляторе Android (arm64-v8a, без NNAPI). Реальное оборудование значительно быстрее.
-
-Измерено на Galaxy S23 Android, CPU-only если не указано иначе. Чем ниже RTF, тем быстрее.
+Измерено на Galaxy S23 Ultra (SM-S918B), только CPU если не указано иное. RTF — это
+настенное время ÷ длительность выданного аудио: чем ниже, тем быстрее; <1,0 быстрее реального времени.
 
 | Модель | Задача | RTF | Задержка | Пиковая память |
 | --- | --- | --- | --- | --- |
 | Parakeet-EOU 120M ONNX INT8 | Потоковый STT + EOU | 0,21 | потоковые partials | 232 МБ |
-| Kokoro 82M ONNX FP32 | TTS | 0,53 | по предложениям | 640 МБ |
+| Kokoro 82M полный граф (опубликованный, CPU с двумя потоками) | TTS | 1,81 | по предложениям | ~604 МБ |
+| Kokoro 82M короткий ход (граф 3,0 с, по умолчанию) | TTS | 0,75–0,88 | ограниченные ответы; безопасный повтор | ~527 МБ |
 | Supertonic-3 LiteRT | TTS | 0,34 | ~1,1 с TTFA | 832 МБ |
 | Silero VAD v5 | VAD | <0,01 | <1 мс на блок 32 мс | <10 МБ |
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -26,7 +26,7 @@
 
 模型在首次启动时通过 `ModelManager.ensureModels()` 自动下载。
 
-`SpeechConfig()` 默认使用 `SttModel.PARAKEET_EOU` 和 `TtsModel.KOKORO`,让 SDK 集成和系统识别服务走低内存 Android 路径。演示应用会选用 `SttModel.PARAKEET`,使回声和听写界面使用更大的 114 语言 TDT 模型。
+`SpeechConfig()` 默认使用 `SttModel.PARAKEET_EOU` 和 `TtsModel.KOKORO_SHORT_TURN`,让 SDK 集成和系统识别服务走低内存 Android 路径。演示应用会选用 `SttModel.PARAKEET`,使回声和听写界面使用更大的 114 语言 TDT 模型。
 
 需要聚焦特定语言时,使用 `SpeechConfig(sttModel = SttModel.PARAKEET, languageHints = listOf("en", "fr"))`。如果只想固定单一语言,设置 `language = "en"`。
 
@@ -50,7 +50,7 @@ dependencies {
 val modelDir = ModelManager.ensureModels(context)
 
 val pipeline = SpeechPipeline(
-    SpeechConfig(modelDir = modelDir, useNnapi = true)
+    SpeechConfig(modelDir = modelDir, useNnapi = false)
 )
 
 pipeline.events.collect { event ->
@@ -168,14 +168,13 @@ adb shell settings put secure voice_recognition_service \
 
 ## 性能
 
-在 Android 模拟器(arm64-v8a,无 NNAPI)上测量。真实硬件速度显著更快。
-
-在 Galaxy S23 Android 上测量,除非另有说明均为 CPU。RTF 越低越快。
+在 Galaxy S23 Ultra（SM-S918B）上测量，仅 CPU。RTF 为墙钟时间÷生成音频时长；数值越低越快，<1.0 表示快于实时。
 
 | 模型 | 任务 | RTF | 延迟 | 峰值内存 |
 | --- | --- | --- | --- | --- |
 | Parakeet-EOU 120M ONNX INT8 | 流式 STT + EOU | 0.21 | 流式 partials | 232 MB |
-| Kokoro 82M ONNX FP32 | TTS | 0.53 | 句级 | 640 MB |
+| Kokoro 82M 完整图（公开版，CPU 双线程） | TTS | 1.81 | 句级 | ~604 MB |
+| Kokoro 82M 短回合（3.0 秒图，默认） | TTS | 0.75–0.88 | 受限回复；安全重试 | ~527 MB |
 | Supertonic-3 LiteRT | TTS | 0.34 | ~1.1 秒 TTFA | 832 MB |
 | Silero VAD v5 | VAD | <0.01 | 每 32 毫秒块 <1 毫秒 | <10 MB |
 

--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/KokoroShortTurnProfileTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/KokoroShortTurnProfileTest.kt
@@ -1,0 +1,63 @@
+package audio.soniqo.speech
+
+import android.os.SystemClock
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Gated physical-device coverage for the bounded Kokoro graph and JNI model ID.
+ *
+ * Run with `-e kokoroModelDir <app-readable-model-directory>`. The directory
+ * must contain `kokoro-e2e-realtime.onnx`, the shared
+ * `kokoro-e2e.onnx.data`, dictionaries, vocabulary, and voices.
+ */
+@RunWith(AndroidJUnit4::class)
+class KokoroShortTurnProfileTest {
+
+    @Test
+    fun directSynthesizerLoadsShortTurnGraphAndRetriesSafely() {
+        val args = InstrumentationRegistry.getArguments()
+        val modelDir = args.getString("kokoroModelDir")
+        assumeTrue("set -e kokoroModelDir to run the Kokoro device test", !modelDir.isNullOrBlank())
+        assumeTrue(File(modelDir!!, "kokoro-e2e-realtime.onnx").isFile)
+        assumeTrue(File(modelDir, "kokoro-e2e.onnx.data").isFile)
+
+        SpeechSynthesizer(
+            SpeechSynthesizerConfig(
+                modelDir = modelDir,
+                useNnapi = false,
+                ttsModel = TtsModel.KOKORO_SHORT_TURN,
+            )
+        ).use { synthesizer ->
+            assertEquals(24_000, synthesizer.sampleRate)
+
+            val shortStart = SystemClock.elapsedRealtimeNanos()
+            val short = synthesizer.synthesize(
+                "The quick brown fox jumps over the lazy dog",
+                "en",
+            )
+            val shortMs = (SystemClock.elapsedRealtimeNanos() - shortStart) / 1_000_000.0
+            assertEquals(24_000, short.sampleRate)
+            assertTrue("short-turn PCM must not be empty", short.pcm16.isNotEmpty())
+            assertTrue("short-turn PCM must contain audio", short.pcm16.any { it != 0.toByte() })
+
+            val retry = synthesizer.synthesize(
+                "The package arrives tomorrow morning safely today.",
+                "en",
+            )
+            assertEquals(24_000, retry.sampleRate)
+            assertTrue("retry PCM must not be empty", retry.pcm16.isNotEmpty())
+            assertTrue("retry PCM must contain audio", retry.pcm16.any { it != 0.toByte() })
+
+            val audioSeconds = short.pcm16.size / 2.0 / short.sampleRate
+            val rtf = (shortMs / 1_000.0) / audioSeconds
+            println("KOKORO_SHORT_TURN short_ms=$shortMs audio_s=$audioSeconds rtf=$rtf")
+        }
+    }
+}

--- a/sdk/src/main/cpp/jni_bridge.cpp
+++ b/sdk/src/main/cpp/jni_bridge.cpp
@@ -71,6 +71,7 @@ static constexpr int TTS_KOKORO = 0;
 static constexpr int TTS_SUPERTONIC = 1;
 static constexpr int MODE_ECHO = 0;
 static constexpr int MODE_TRANSCRIBE_ONLY = 1;
+static constexpr int TTS_KOKORO_SHORT_TURN = 2;
 
 static std::unique_ptr<speech_core::TTSInterface> create_tts(
     const std::string& dir, bool nnapi, int ttsModel)
@@ -92,11 +93,16 @@ static std::unique_ptr<speech_core::TTSInterface> create_tts(
 #endif
     }
 
+    if (ttsModel == TTS_KOKORO_SHORT_TURN) {
+        return std::make_unique<speech_core::KokoroTts>(
+            dir + "/kokoro-e2e-realtime.onnx",
+            dir + "/voices",
+            dir,
+            nnapi);
+    }
+
     return std::make_unique<speech_core::KokoroTts>(
-        dir + "/kokoro-e2e.onnx",
-        dir + "/voices",
-        dir,
-        nnapi);
+        dir + "/kokoro-e2e.onnx", dir + "/voices", dir, nnapi);
 }
 
 // ---------------------------------------------------------------------------

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
@@ -68,7 +68,7 @@ class ModelDownloadWorker(
             ?: SttBackend.ONNX
         val ttsModel = inputData.getString(KEY_TTS_MODEL)
             ?.let { runCatching { TtsModel.valueOf(it) }.getOrNull() }
-            ?: TtsModel.KOKORO
+            ?: TtsModel.KOKORO_SHORT_TURN
         // When set, the FunctionGemma bundle is downloaded here too, so the
         // whole ~800 MB setup runs in this foreground worker — surviving doze
         // and Wi-Fi power-save that would kill an in-app download.
@@ -231,27 +231,28 @@ class ModelDownloadWorker(
             precision: ModelPrecision = ModelPrecision.INT8,
             sttModel: SttModel = SttModel.PARAKEET_EOU,
             sttBackend: SttBackend = SttBackend.ONNX,
-            ttsModel: TtsModel = TtsModel.KOKORO,
+            ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
             includeLlm: Boolean = false,
         ): String {
             if (
                 precision == ModelPrecision.INT8 &&
                 sttModel == SttModel.PARAKEET_EOU &&
                 sttBackend == SttBackend.ONNX &&
-                ttsModel == TtsModel.KOKORO &&
+                ttsModel.isKokoro &&
                 !includeLlm
             ) {
                 return UNIQUE_NAME
             }
             val llm = if (includeLlm) ".llm" else ""
-            return "$UNIQUE_NAME.${precision.name}.${sttModel.name}.${sttBackend.name}.${ttsModel.name}$llm"
+            val ttsName = if (ttsModel.isKokoro) TtsModel.KOKORO.name else ttsModel.name
+            return "$UNIQUE_NAME.${precision.name}.${sttModel.name}.${sttBackend.name}.$ttsName$llm"
         }
 
         fun request(
             precision: ModelPrecision = ModelPrecision.INT8,
             sttModel: SttModel = SttModel.PARAKEET_EOU,
             sttBackend: SttBackend = SttBackend.ONNX,
-            ttsModel: TtsModel = TtsModel.KOKORO,
+            ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
             includeLlm: Boolean = false,
         ) =
             OneTimeWorkRequestBuilder<ModelDownloadWorker>()
@@ -274,7 +275,7 @@ class ModelDownloadWorker(
             precision: ModelPrecision = ModelPrecision.INT8,
             sttModel: SttModel = SttModel.PARAKEET_EOU,
             sttBackend: SttBackend = SttBackend.ONNX,
-            ttsModel: TtsModel = TtsModel.KOKORO,
+            ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
             includeLlm: Boolean = false,
         ): java.util.UUID {
             val req = request(precision, sttModel, sttBackend, ttsModel, includeLlm)

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -42,7 +42,7 @@ object ModelManager {
         precision: ModelPrecision,
         sttModel: SttModel = SttModel.PARAKEET_EOU,
         sttBackend: SttBackend = SttBackend.ONNX,
-        ttsModel: TtsModel = TtsModel.KOKORO,
+        ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
     ): List<ModelFile> {
         val suffix = if (precision == ModelPrecision.INT8) "-int8" else ""
         val files = mutableListOf(
@@ -113,9 +113,12 @@ object ModelManager {
     }
 
     private fun ttsModels(ttsModel: TtsModel): List<ModelFile> = when (ttsModel) {
-        TtsModel.KOKORO -> listOf(
-            // E2E model — single file + external weights
+        TtsModel.KOKORO, TtsModel.KOKORO_SHORT_TURN -> listOf(
+            // Both graph profiles share one external weight blob. Keeping both
+            // protos in the same cache makes profile switches a ~2.6 MB fetch,
+            // never a second ~310 MB weights download.
             ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx"),
+            ModelFile("Kokoro-82M-ONNX", "kokoro-e2e-realtime.onnx"),
             ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx.data"),
             ModelFile("Kokoro-82M-ONNX", "vocab_index.json"),
             ModelFile("Kokoro-82M-ONNX", "us_gold.json"),
@@ -177,7 +180,7 @@ object ModelManager {
         precision: ModelPrecision = ModelPrecision.INT8,
         sttModel: SttModel = SttModel.PARAKEET_EOU,
         sttBackend: SttBackend = SttBackend.ONNX,
-        ttsModel: TtsModel = TtsModel.KOKORO,
+        ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
     ): Boolean {
         val dir = modelDirFile(context, precision, sttModel, sttBackend, ttsModel)
         if (!dir.exists()) return false
@@ -206,7 +209,7 @@ object ModelManager {
      */
     fun areTtsModelsReady(
         context: Context,
-        ttsModel: TtsModel = TtsModel.KOKORO,
+        ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
     ): Boolean {
         val dir = File(context.filesDir, "models_tts")
         if (!dir.exists()) return false
@@ -263,7 +266,7 @@ object ModelManager {
         precision: ModelPrecision = ModelPrecision.INT8,
         sttModel: SttModel = SttModel.PARAKEET_EOU,
         sttBackend: SttBackend = SttBackend.ONNX,
-        ttsModel: TtsModel = TtsModel.KOKORO,
+        ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
         onProgress: ((Progress) -> Unit)? = null,
     ): String = withContext(Dispatchers.IO) {
         val dir = modelDirFile(context, precision, sttModel, sttBackend, ttsModel)
@@ -304,7 +307,7 @@ object ModelManager {
     /** Returns the TTS-only model directory path, downloading models if needed. */
     suspend fun ensureTtsModels(
         context: Context,
-        ttsModel: TtsModel = TtsModel.KOKORO,
+        ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
         onProgress: ((Progress) -> Unit)? = null,
     ): String = withContext(Dispatchers.IO) {
         val dir = File(context.filesDir, "models_tts")
@@ -407,7 +410,7 @@ object ModelManager {
         "precision=${precision.name}",
         "stt=${sttModel.name}",
         "backend=${sttBackend.name}",
-        "tts=${ttsModel.name}",
+        "tts=${ttsCacheName(ttsModel)}",
     ).joinToString("|")
 
     private fun modelDirFile(
@@ -428,7 +431,7 @@ object ModelManager {
             precision == ModelPrecision.INT8 &&
             sttModel == SttModel.PARAKEET_EOU &&
             sttBackend == SttBackend.ONNX &&
-            ttsModel == TtsModel.KOKORO
+            ttsModel.isKokoro
         ) {
             return "models"
         }
@@ -437,15 +440,18 @@ object ModelManager {
             precision.name,
             sttModel.name,
             sttBackend.name,
-            ttsModel.name,
+            ttsCacheName(ttsModel),
         ).joinToString("-").lowercase()
     }
 
     private fun ttsModelSetKey(ttsModel: TtsModel): String = listOf(
         "v$MODEL_VERSION",
         "profile=TTS",
-        "tts=${ttsModel.name}",
+        "tts=${ttsCacheName(ttsModel)}",
     ).joinToString("|")
+
+    private fun ttsCacheName(ttsModel: TtsModel): String =
+        if (ttsModel.isKokoro) TtsModel.KOKORO.name else ttsModel.name
 
     private fun llmModelSetKey(): String = listOf(
         "v$MODEL_VERSION",
@@ -578,6 +584,7 @@ object ModelManager {
         "parakeet-eou-decoder.onnx" to 10_000_000L,     // ~16 MB
         "parakeet-eou-joint.onnx" to 1_000_000L,        // ~6 MB
         "kokoro-e2e.onnx" to 1_000L,                     // Small (weights in .data file)
+        "kokoro-e2e-realtime.onnx" to 1_000_000L,        // ~2.5 MB shared-weight graph
         "kokoro-e2e.onnx.data" to 50_000_000L,           // ~310 MB
         "silero-vad.onnx" to 500_000L,                   // ~2 MB
         "model.litertlm" to 200_000_000L,                // ~283 MB FunctionGemma bundle

--- a/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
@@ -12,7 +12,7 @@ internal object NativeBridge {
         useInt8: Boolean,
         sttModel: Int,    // SttModel.ordinal: 0=PARAKEET, 1=NEMOTRON_MULTILINGUAL, 2=PARAKEET_EOU
         sttBackend: Int,  // SttBackend.ordinal: 0=ONNX, 1=LITERT
-        ttsModel: Int,    // TtsModel.ordinal: 0=KOKORO, 1=SUPERTONIC (LiteRT)
+        ttsModel: Int,    // 0=KOKORO, 1=SUPERTONIC, 2=KOKORO_SHORT_TURN
         pipelineMode: Int, // PipelineMode.ordinal: 0=ECHO, 1=TRANSCRIBE_ONLY
         language: String, // single language hint ("auto", "en-US", ...)
         languageHints: Array<String>, // shortlist for Parakeet TDT language-token guidance
@@ -38,7 +38,7 @@ internal object NativeBridge {
     external fun nativeCreateSynthesizer(
         modelDir: String,
         useNnapi: Boolean,
-        ttsModel: Int,    // TtsModel.ordinal: 0=KOKORO, 1=SUPERTONIC (LiteRT)
+        ttsModel: Int,    // 0=KOKORO, 1=SUPERTONIC, 2=KOKORO_SHORT_TURN
     ): Long
     external fun nativeDestroySynthesizer(handle: Long)
     external fun nativeStopSynthesizer(handle: Long)

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
@@ -11,10 +11,18 @@ enum class SttModel { PARAKEET, NEMOTRON_MULTILINGUAL, PARAKEET_EOU }
  *  ships both; Parakeet is ONNX-only. */
 enum class SttBackend { ONNX, LITERT }
 
-/** On-device TTS model. KOKORO (ONNX, 24 kHz) is the default; SUPERTONIC is a
- *  LiteRT non-autoregressive flow-matching model (Supertonic-3, 44.1 kHz, 31
- *  languages, G2P-free) — requires the LiteRT backend to be built into the SDK. */
-enum class TtsModel { KOKORO, SUPERTONIC }
+/** On-device TTS model. [KOKORO_SHORT_TURN] uses the same Kokoro weights with
+ *  a shorter unrolled graph for bounded, low-latency voice-agent replies.
+ *  [KOKORO] keeps the full-capacity graph; [SUPERTONIC] is a LiteRT
+ *  flow-matching model (44.1 kHz, 31 languages, G2P-free). */
+enum class TtsModel(internal val nativeId: Int) {
+    KOKORO(0),
+    SUPERTONIC(1),
+    KOKORO_SHORT_TURN(2),
+}
+
+internal val TtsModel.isKokoro: Boolean
+    get() = this == TtsModel.KOKORO || this == TtsModel.KOKORO_SHORT_TURN
 
 /** What the pipeline does after a completed transcription. ECHO speaks the
  *  transcript back via TTS (demo/testing); TRANSCRIBE_ONLY emits
@@ -26,8 +34,9 @@ data class SpeechConfig(
     /** Path to directory containing ONNX model files. */
     val modelDir: String = "",
 
-    /** Enable NNAPI acceleration (Qualcomm Hexagon NPU / Samsung NPU). */
-    val useNnapi: Boolean = true,
+    /** Try the deprecated NNAPI execution provider. CPU is the measured,
+     *  portable default; hardware-provider experiments are opt-in. */
+    val useNnapi: Boolean = false,
 
     /** Which STT model to load. */
     val sttModel: SttModel = SttModel.PARAKEET_EOU,
@@ -35,8 +44,10 @@ data class SpeechConfig(
     /** STT inference backend (Nemotron multilingual supports both). */
     val sttBackend: SttBackend = SttBackend.ONNX,
 
-    /** Which TTS model to load. SUPERTONIC requires the LiteRT backend. */
-    val ttsModel: TtsModel = TtsModel.KOKORO,
+    /** Which TTS model/profile to load. The short-turn Kokoro graph is the
+     *  Android default because measured in-profile replies stay faster than
+     *  real time on CPU; oversized replies are split and retried safely. */
+    val ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
 
     /** Pipeline behavior after transcription. See [PipelineMode]. */
     val pipelineMode: PipelineMode = PipelineMode.ECHO,

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
@@ -99,7 +99,7 @@ internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
         config.precision == ModelPrecision.INT8,
         config.sttModel.ordinal,
         config.sttBackend.ordinal,
-        config.ttsModel.ordinal,
+        config.ttsModel.nativeId,
         config.pipelineMode.ordinal,
         config.language,
         config.languageHints.toTypedArray(),

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechSynthesizer.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechSynthesizer.kt
@@ -10,11 +10,11 @@ data class SpeechSynthesizerConfig(
     /** Path to directory containing TTS model files. */
     val modelDir: String = "",
 
-    /** Enable NNAPI acceleration where the native backend supports it. */
-    val useNnapi: Boolean = true,
+    /** Try the deprecated NNAPI execution provider. The CPU path is default. */
+    val useNnapi: Boolean = false,
 
-    /** Which TTS model to load. SUPERTONIC requires the LiteRT backend. */
-    val ttsModel: TtsModel = TtsModel.KOKORO,
+    /** Which TTS model/profile to load. SUPERTONIC requires LiteRT. */
+    val ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
 )
 
 data class SpeechSynthesisResult(
@@ -51,7 +51,7 @@ internal class SpeechSynthesizerImpl(config: SpeechSynthesizerConfig) : SpeechSy
     private var handle: Long = NativeBridge.nativeCreateSynthesizer(
         config.modelDir,
         config.useNnapi,
-        config.ttsModel.ordinal,
+        config.ttsModel.nativeId,
     ).also { h ->
         if (h == 0L) throw IllegalStateException(
             "Failed to create native synthesizer. Models may be corrupt - " +

--- a/sdk/src/main/kotlin/audio/soniqo/speech/service/SpeechTextToSpeechService.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/service/SpeechTextToSpeechService.kt
@@ -104,7 +104,10 @@ open class SpeechTextToSpeechService : TextToSpeechService() {
     }
 
     protected open suspend fun resolveModelDir(): String =
-        ModelManager.ensureTtsModels(applicationContext, TtsModel.KOKORO)
+        ModelManager.ensureTtsModels(
+            applicationContext,
+            TtsModel.KOKORO_SHORT_TURN,
+        )
 
     protected open fun createSynthesizer(config: SpeechSynthesizerConfig): SpeechSynthesizer =
         SpeechSynthesizer(config)
@@ -119,8 +122,8 @@ open class SpeechTextToSpeechService : TextToSpeechService() {
             synthesizer ?: createSynthesizer(
                 SpeechSynthesizerConfig(
                     modelDir = modelDir,
-                    useNnapi = true,
-                    ttsModel = TtsModel.KOKORO,
+                    useNnapi = false,
+                    ttsModel = TtsModel.KOKORO_SHORT_TURN,
                 )
             ).also { synthesizer = it }
         }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/DownloadProgressTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/DownloadProgressTest.kt
@@ -26,8 +26,6 @@ class DownloadProgressTest {
     private data class Sized(val name: String, val bytes: Long)
 
     private val MB = 1_000_000L
-    private val totalFiles = 18
-
     /** Default low-memory INT8 manifest order/sizes. */
     private val manifest = listOf(
         Sized("silero-vad.onnx", 2 * MB),                   // #1
@@ -37,18 +35,20 @@ class DownloadProgressTest {
         Sized("vocab.json", 1 * MB),                        // #5
         Sized("config.json", 1 * MB),                       // #6
         Sized("kokoro-e2e.onnx", 3 * MB),                   // #7
-        Sized("kokoro-e2e.onnx.data", 325 * MB),            // #8  <-- the giant
-        Sized("vocab_index.json", 1 * MB),                  // #9
-        Sized("us_gold.json", 2 * MB),                      // #10
-        Sized("us_silver.json", 4 * MB),                    // #11
-        Sized("dict_fr.json", 1 * MB),                      // #12
-        Sized("dict_es.json", 1 * MB),                      // #13
-        Sized("dict_it.json", 1 * MB),                      // #14
-        Sized("dict_pt.json", 1 * MB),                      // #15
-        Sized("dict_hi.json", 1 * MB),                      // #16
-        Sized("voices/af_heart.bin", 1 * MB),               // #17
-        Sized("deepfilter-auxiliary.bin", 2 * MB),          // #18
+        Sized("kokoro-e2e-realtime.onnx", 3 * MB),          // #8
+        Sized("kokoro-e2e.onnx.data", 325 * MB),            // #9  <-- the giant
+        Sized("vocab_index.json", 1 * MB),                  // #10
+        Sized("us_gold.json", 2 * MB),                      // #11
+        Sized("us_silver.json", 4 * MB),                    // #12
+        Sized("dict_fr.json", 1 * MB),                      // #13
+        Sized("dict_es.json", 1 * MB),                      // #14
+        Sized("dict_it.json", 1 * MB),                      // #15
+        Sized("dict_pt.json", 1 * MB),                      // #16
+        Sized("dict_hi.json", 1 * MB),                      // #17
+        Sized("voices/af_heart.bin", 1 * MB),               // #18
+        Sized("deepfilter-auxiliary.bin", 2 * MB),          // #19
     )
+    private val totalFiles = manifest.size
 
     private val CHUNK = 65536L
 
@@ -87,17 +87,17 @@ class DownloadProgressTest {
     @Test
     fun progressPercent_isByteAware_unitValues() {
         // Whole files done plus the fraction of the file in flight.
-        assertEquals(5, ModelDownloadWorker.progressPercent(1, 18, 0, 132 * MB))        // start of EOU encoder
-        assertEquals(8, ModelDownloadWorker.progressPercent(1, 18, 66 * MB, 132 * MB))  // half the EOU encoder
-        assertEquals(38, ModelDownloadWorker.progressPercent(7, 18, 0, 325 * MB))       // start of Kokoro weights
-        assertEquals(100, ModelDownloadWorker.progressPercent(18, 18, 0, 0))            // all files done
+        assertEquals(5, ModelDownloadWorker.progressPercent(1, 19, 0, 132 * MB))        // start of EOU encoder
+        assertEquals(7, ModelDownloadWorker.progressPercent(1, 19, 66 * MB, 132 * MB))  // half the EOU encoder
+        assertEquals(42, ModelDownloadWorker.progressPercent(8, 19, 0, 325 * MB))       // start of Kokoro weights
+        assertEquals(100, ModelDownloadWorker.progressPercent(19, 19, 0, 0))            // all files done
     }
 
     @Test
     fun progressPercent_unknownFileSize_fallsBackToFileCount() {
         // When the server doesn't advertise a length, the in-flight file adds
         // no fraction — degrades to the old whole-file value for that file only.
-        assertEquals(5, ModelDownloadWorker.progressPercent(1, 18, 12345, 0))
+        assertEquals(5, ModelDownloadWorker.progressPercent(1, 19, 12345, 0))
     }
 
     @Test
@@ -116,9 +116,9 @@ class DownloadProgressTest {
             "large file percent should advance through several values, got $distinct",
             distinct.size >= 6,
         )
-        // It spans roughly 38% -> 44% (one file's worth of the 18-file bar).
-        assertEquals("large file starts at ~38%", 38, largeFile.first().percent)
-        assertEquals("large file ends at ~44%", 44, largeFile.last().percent)
+        // It spans roughly 42% -> 47% (one file's worth of the 19-file bar).
+        assertEquals("large file starts at ~42%", 42, largeFile.first().percent)
+        assertEquals("large file ends at ~47%", 47, largeFile.last().percent)
         // ...and is monotonic non-decreasing within the file.
         assertTrue(
             "large file percent must never go backwards",
@@ -133,9 +133,9 @@ class DownloadProgressTest {
         val largeFile = simulate().filter { it.file == "kokoro-e2e.onnx.data" }
         val midpoint = largeFile.first { it.fileBytes >= it.fileTotal / 2 }
         assertTrue(
-            "halfway through the large file the bar should read >= 41 (was frozen at 38), " +
+            "halfway through the large file the bar should read >= 44 (was frozen at 42), " +
                 "was ${midpoint.percent}",
-            midpoint.percent >= 41,
+            midpoint.percent >= 44,
         )
     }
 

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelDownloadWorkerTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelDownloadWorkerTest.kt
@@ -127,6 +127,27 @@ class ModelDownloadWorkerTest {
     }
 
     @Test
+    fun doWork_missingTtsModelInput_defaultsToShortTurnKokoro() = runBlocking {
+        coEvery {
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
+        } returns "/fake"
+
+        val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context).build()
+        worker.doWork()
+
+        coVerify(exactly = 1) {
+            ModelManager.ensureModels(
+                any(),
+                any(),
+                any(),
+                any(),
+                TtsModel.KOKORO_SHORT_TURN,
+                any(),
+            )
+        }
+    }
+
+    @Test
     fun doWork_modelInputs_arePassedToModelManager() = runBlocking {
         coEvery {
             ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
@@ -185,6 +206,16 @@ class ModelDownloadWorkerTest {
         assertEquals(
             androidx.work.NetworkType.NOT_REQUIRED,
             req.workSpec.constraints.requiredNetworkType,
+        )
+    }
+
+    @Test
+    fun request_defaultUsesShortTurnKokoro() {
+        val req = ModelDownloadWorker.request()
+
+        assertEquals(
+            "KOKORO_SHORT_TURN",
+            req.workSpec.input.getString(ModelDownloadWorker.KEY_TTS_MODEL),
         )
     }
 

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
@@ -3,6 +3,7 @@ package audio.soniqo.speech
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -18,6 +19,17 @@ class ModelManagerManifestTest {
     @Test
     fun speechConfigDefault_usesLowMemoryParakeetEou() {
         assertEquals(SttModel.PARAKEET_EOU, SpeechConfig().sttModel)
+        assertEquals(TtsModel.KOKORO_SHORT_TURN, SpeechConfig().ttsModel)
+        assertFalse(SpeechConfig().useNnapi)
+        assertEquals(TtsModel.KOKORO_SHORT_TURN, SpeechSynthesizerConfig().ttsModel)
+        assertFalse(SpeechSynthesizerConfig().useNnapi)
+    }
+
+    @Test
+    fun ttsNativeIds_areStable() {
+        assertEquals(0, TtsModel.KOKORO.nativeId)
+        assertEquals(1, TtsModel.SUPERTONIC.nativeId)
+        assertEquals(2, TtsModel.KOKORO_SHORT_TURN.nativeId)
     }
 
     @Test
@@ -63,6 +75,7 @@ class ModelManagerManifestTest {
         assertEquals(
             listOf(
                 ModelManager.ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "kokoro-e2e-realtime.onnx"),
                 ModelManager.ModelFile("Kokoro-82M-ONNX", "kokoro-e2e.onnx.data"),
                 ModelManager.ModelFile("Kokoro-82M-ONNX", "vocab_index.json"),
                 ModelManager.ModelFile("Kokoro-82M-ONNX", "us_gold.json"),
@@ -78,6 +91,39 @@ class ModelManagerManifestTest {
         )
         assertFalse(files.any { it.repo.contains("Parakeet") || it.repo.contains("Silero") })
         assertFalse(files.any { it.filename.startsWith("deepfilter") })
+        assertEquals(1, files.count { it.filename == "kokoro-e2e.onnx.data" })
+    }
+
+    @Test
+    fun kokoroProfiles_shareAssetsCachesAndWorkerName() {
+        assertEquals(
+            ttsModelFiles(TtsModel.KOKORO),
+            ttsModelFiles(TtsModel.KOKORO_SHORT_TURN),
+        )
+        assertEquals(
+            modelSetKey(ttsModel = TtsModel.KOKORO),
+            modelSetKey(ttsModel = TtsModel.KOKORO_SHORT_TURN),
+        )
+        assertEquals(
+            ttsModelSetKey(TtsModel.KOKORO),
+            ttsModelSetKey(TtsModel.KOKORO_SHORT_TURN),
+        )
+        assertEquals(
+            modelDirName(ttsModel = TtsModel.KOKORO),
+            modelDirName(ttsModel = TtsModel.KOKORO_SHORT_TURN),
+        )
+        assertEquals(
+            ModelDownloadWorker.uniqueName(ttsModel = TtsModel.KOKORO),
+            ModelDownloadWorker.uniqueName(ttsModel = TtsModel.KOKORO_SHORT_TURN),
+        )
+        assertNotEquals(
+            ttsModelSetKey(TtsModel.KOKORO_SHORT_TURN),
+            ttsModelSetKey(TtsModel.SUPERTONIC),
+        )
+        assertTrue(
+            ttsModelFiles(TtsModel.KOKORO_SHORT_TURN)
+                .any { it.filename == "kokoro-e2e-realtime.onnx" },
+        )
     }
 
     @Test

--- a/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechTextToSpeechServiceTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechTextToSpeechServiceTest.kt
@@ -9,6 +9,7 @@ import androidx.test.core.app.ApplicationProvider
 import audio.soniqo.speech.SpeechSynthesisResult
 import audio.soniqo.speech.SpeechSynthesizer
 import audio.soniqo.speech.SpeechSynthesizerConfig
+import audio.soniqo.speech.TtsModel
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -73,6 +74,8 @@ class SpeechTextToSpeechServiceTest {
         service.synthesize(SynthesisRequest("hello", Bundle.EMPTY), callback)
 
         assertEquals("/fake/models_tts", service.createdConfig?.modelDir)
+        assertEquals(false, service.createdConfig?.useNnapi)
+        assertEquals(TtsModel.KOKORO_SHORT_TURN, service.createdConfig?.ttsModel)
         assertEquals("hello", fakeSynthesizer.lastText)
         assertEquals("en", fakeSynthesizer.lastLanguage)
         assertEquals(24_000, callback.sampleRate)


### PR DESCRIPTION
## Summary

- make the published 3.0-second Kokoro short-turn graph the default TTS profile on Android
- retain the full graph as an explicit option with stable native model IDs
- download both small graph protos with one shared roughly 310 MiB external weight file and one shared cache
- default to the measured CPU path and pin speech-core to the merged short-turn implementation from soniqo/speech-core#105
- update all README translations and add regression coverage for defaults, manifests, cache aliases, worker inputs, and framework TTS

## Validation

- ./gradlew :sdk:test :sdk:assembleDebugAndroidTest passed
- physical Galaxy S23 Ultra instrumentation test passed against the published realtime graph
- final merged-core device run measured 0.806 RTF for a 2.3-second short reply
- oversized reply exercised the bounded split/retry path successfully
- no duplicate external Kokoro weights are downloaded