### PR TITLE
Link Android package to canonical documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ On-device speech SDK for Android, powered by [ONNX Runtime](https://onnxruntime.
 
 Low-memory streaming speech recognition (25 languages by default, 114-language TDT optional), text-to-speech, voice activity detection, and noise cancellation — all running locally. No cloud APIs, no data leaves the device.
 
-**[📚 Android Documentation](https://soniqo.audio/getting-started/android)** · **[Kokoro TTS Guide](https://soniqo.audio/guides/kokoro/android)** · **[Parakeet TDT Guide](https://soniqo.audio/guides/parakeet/android)** · **[Silero VAD Guide](https://soniqo.audio/guides/vad/android)** · **[DeepFilterNet3 Guide](https://soniqo.audio/guides/denoise/android)**
+**[📚 Android Documentation](https://soniqo.audio/getting-started/android)**
 
 **[Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Models](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple counterpart) · **[speech-core](https://github.com/soniqo/speech-core)** (pipeline engine + Linux/embedded build)
 
@@ -18,13 +18,13 @@ This repo is the **Android packaging**: Kotlin SDK, JNI bridge, demo app. The C+
 
 | Model | Task | Download | Peak memory | Languages |
 | --- | --- | --- | --- | --- |
-| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | Streaming STT + end-of-utterance (default) | 153 MB | 232 MB | 25 |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Broad-coverage STT (optional) | 891 MB | ~1.1-1.3 GB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Text-to-speech (default) | 330 MB | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Text-to-speech (LiteRT, flow-matching, G2P-free, 44.1 kHz) | ~380 MB | 832 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Voice activity detection | 2 MB | <10 MB | Any |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Noise cancellation | ~8 MB | not loaded by default | Any |
-| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | On-device LLM — structured function / tool calls | 283 MB | app-runtime dependent | EN-tuned |
+| [Parakeet-EOU 120M](https://soniqo.audio/guides/dictate) | Streaming STT + end-of-utterance (default) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
+| [Parakeet TDT v3](https://soniqo.audio/guides/parakeet/android) | Broad-coverage STT (optional) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
+| [Kokoro 82M](https://soniqo.audio/guides/kokoro/android) | Text-to-speech (default) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://soniqo.audio/guides/supertonic) | Text-to-speech (LiteRT, flow-matching, G2P-free, 44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
+| [Silero VAD v5](https://soniqo.audio/guides/vad/android) | Voice activity detection | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | Any |
+| [DeepFilterNet3](https://soniqo.audio/guides/denoise/android) | Noise cancellation | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | not loaded by default | Any |
+| [FunctionGemma 270M](https://soniqo.audio/guides/functiongemma) | On-device LLM — structured function / tool calls | [283 MB](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | app-runtime dependent | EN-tuned |
 
 Models are downloaded automatically on first launch via `ModelManager.ensureModels()`.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ On-device speech SDK for Android, powered by [ONNX Runtime](https://onnxruntime.
 
 Low-memory streaming speech recognition (25 languages by default, 114-language TDT optional), text-to-speech, voice activity detection, and noise cancellation — all running locally. No cloud APIs, no data leaves the device.
 
+**[📚 Android Documentation](https://soniqo.audio/getting-started/android)** · **[Kokoro TTS Guide](https://soniqo.audio/guides/kokoro/android)** · **[Parakeet TDT Guide](https://soniqo.audio/guides/parakeet/android)** · **[Silero VAD Guide](https://soniqo.audio/guides/vad/android)** · **[DeepFilterNet3 Guide](https://soniqo.audio/guides/denoise/android)**
+
 **[Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Models](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple counterpart) · **[speech-core](https://github.com/soniqo/speech-core)** (pipeline engine + Linux/embedded build)
 
 ## Scope

--- a/README_de.md
+++ b/README_de.md
@@ -6,7 +6,7 @@ On-Device Speech-SDK für Android, basierend auf [ONNX Runtime](https://onnxrunt
 
 Speicherarme Streaming-Spracherkennung (standardmäßig 25 Sprachen, optionales TDT mit 114 Sprachen), Text-to-Speech, Sprachaktivitätserkennung und Rauschunterdrückung — alles lokal ausgeführt. Keine Cloud-APIs, keine Daten verlassen das Gerät.
 
-**[📚 Android-Dokumentation](https://soniqo.audio/de/getting-started/android)** · **[Kokoro-TTS-Leitfaden](https://soniqo.audio/de/guides/kokoro/android)** · **[Parakeet-TDT-Leitfaden](https://soniqo.audio/de/guides/parakeet/android)** · **[Silero-VAD-Leitfaden](https://soniqo.audio/de/guides/vad/android)** · **[DeepFilterNet3-Leitfaden](https://soniqo.audio/de/guides/denoise/android)**
+**[📚 Android-Dokumentation](https://soniqo.audio/de/getting-started/android)**
 
 **[Demo-APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modelle](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple-Pendant) · **[speech-core](https://github.com/soniqo/speech-core)** (Pipeline-Engine + Linux/Embedded-Build)
 
@@ -18,13 +18,13 @@ Dieses Repo ist das **Android-Packaging**: Kotlin-SDK, JNI-Bridge, Demo-App. Die
 
 | Modell | Aufgabe | Download | Spitzen-Speicher | Sprachen |
 | --- | --- | --- | --- | --- |
-| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | Streaming-STT + EOU (Standard) | 153 MB | 232 MB | 25 |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | Breite STT-Abdeckung (optional) | 891 MB | ~1,1-1,3 GB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Text-to-Speech (Standard) | 330 MB | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Text-to-Speech (LiteRT, Flow-Matching, G2P-frei, 44,1 kHz) | ~380 MB | 832 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Sprachaktivitätserkennung | 2 MB | <10 MB | Beliebig |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Rauschunterdrückung | ~8 MB | standardmäßig nicht geladen | Beliebig |
-| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | On-Device-LLM — strukturierte Funktions-/Tool-Aufrufe | 283 MB | abhängig vom App-Runtime | EN-getunt |
+| [Parakeet-EOU 120M](https://soniqo.audio/de/guides/dictate) | Streaming-STT + EOU (Standard) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
+| [Parakeet TDT v3](https://soniqo.audio/de/guides/parakeet/android) | Breite STT-Abdeckung (optional) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1,1-1,3 GB | 114 |
+| [Kokoro 82M](https://soniqo.audio/de/guides/kokoro/android) | Text-to-Speech (Standard) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://soniqo.audio/de/guides/supertonic) | Text-to-Speech (LiteRT, Flow-Matching, G2P-frei, 44,1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
+| [Silero VAD v5](https://soniqo.audio/de/guides/vad/android) | Sprachaktivitätserkennung | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | Beliebig |
+| [DeepFilterNet3](https://soniqo.audio/de/guides/denoise/android) | Rauschunterdrückung | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | standardmäßig nicht geladen | Beliebig |
+| [FunctionGemma 270M](https://soniqo.audio/de/guides/functiongemma) | On-Device-LLM — strukturierte Funktions-/Tool-Aufrufe | [283 MB](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | abhängig vom App-Runtime | EN-getunt |
 
 Modelle werden beim ersten Start automatisch über `ModelManager.ensureModels()` heruntergeladen.
 

--- a/README_de.md
+++ b/README_de.md
@@ -6,6 +6,8 @@ On-Device Speech-SDK für Android, basierend auf [ONNX Runtime](https://onnxrunt
 
 Speicherarme Streaming-Spracherkennung (standardmäßig 25 Sprachen, optionales TDT mit 114 Sprachen), Text-to-Speech, Sprachaktivitätserkennung und Rauschunterdrückung — alles lokal ausgeführt. Keine Cloud-APIs, keine Daten verlassen das Gerät.
 
+**[📚 Android-Dokumentation](https://soniqo.audio/de/getting-started/android)** · **[Kokoro-TTS-Leitfaden](https://soniqo.audio/de/guides/kokoro/android)** · **[Parakeet-TDT-Leitfaden](https://soniqo.audio/de/guides/parakeet/android)** · **[Silero-VAD-Leitfaden](https://soniqo.audio/de/guides/vad/android)** · **[DeepFilterNet3-Leitfaden](https://soniqo.audio/de/guides/denoise/android)**
+
 **[Demo-APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modelle](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple-Pendant) · **[speech-core](https://github.com/soniqo/speech-core)** (Pipeline-Engine + Linux/Embedded-Build)
 
 ## Geltungsbereich

--- a/README_es.md
+++ b/README_es.md
@@ -6,7 +6,7 @@ SDK de voz en el dispositivo para Android, impulsado por [ONNX Runtime](https://
 
 Reconocimiento de voz en streaming de baja memoria (25 idiomas por defecto; TDT de 114 idiomas opcional), texto a voz, detección de actividad de voz y cancelación de ruido — todo ejecutándose localmente. Sin APIs en la nube, ningún dato sale del dispositivo.
 
-**[📚 Documentación de Android](https://soniqo.audio/es/getting-started/android)** · **[Guía de Kokoro TTS](https://soniqo.audio/es/guides/kokoro/android)** · **[Guía de Parakeet TDT](https://soniqo.audio/es/guides/parakeet/android)** · **[Guía de Silero VAD](https://soniqo.audio/es/guides/vad/android)** · **[Guía de DeepFilterNet3](https://soniqo.audio/es/guides/denoise/android)**
+**[📚 Documentación de Android](https://soniqo.audio/es/getting-started/android)**
 
 **[APK de demostración](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modelos](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (contraparte Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (motor de pipeline + compilación Linux/embebido)
 
@@ -18,13 +18,13 @@ Este repositorio es el **empaquetado para Android**: SDK de Kotlin, puente JNI, 
 
 | Modelo | Tarea | Descarga | Pico de memoria | Idiomas |
 | --- | --- | --- | --- | --- |
-| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | STT en streaming + EOU (por defecto) | 153 MB | 232 MB | 25 |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | STT de cobertura amplia (opcional) | 891 MB | ~1.1-1.3 GB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Texto a voz (por defecto) | 330 MB | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Texto a voz (LiteRT, flow-matching, G2P-free, 44.1 kHz) | ~380 MB | 832 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Detección de actividad de voz | 2 MB | <10 MB | Cualquiera |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Cancelación de ruido | ~8 MB | no se carga por defecto | Cualquiera |
-| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | LLM en dispositivo — llamadas estructuradas a funciones / herramientas | 283 MB | depende del runtime de la app | Ajustado para EN |
+| [Parakeet-EOU 120M](https://soniqo.audio/es/guides/dictate) | STT en streaming + EOU (por defecto) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
+| [Parakeet TDT v3](https://soniqo.audio/es/guides/parakeet/android) | STT de cobertura amplia (opcional) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
+| [Kokoro 82M](https://soniqo.audio/es/guides/kokoro/android) | Texto a voz (por defecto) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://soniqo.audio/es/guides/supertonic) | Texto a voz (LiteRT, flow-matching, G2P-free, 44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
+| [Silero VAD v5](https://soniqo.audio/es/guides/vad/android) | Detección de actividad de voz | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | Cualquiera |
+| [DeepFilterNet3](https://soniqo.audio/es/guides/denoise/android) | Cancelación de ruido | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | no se carga por defecto | Cualquiera |
+| [FunctionGemma 270M](https://soniqo.audio/es/guides/functiongemma) | LLM en dispositivo — llamadas estructuradas a funciones / herramientas | [283 MB](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | depende del runtime de la app | Ajustado para EN |
 
 Los modelos se descargan automáticamente al primer inicio vía `ModelManager.ensureModels()`.
 

--- a/README_es.md
+++ b/README_es.md
@@ -6,6 +6,8 @@ SDK de voz en el dispositivo para Android, impulsado por [ONNX Runtime](https://
 
 Reconocimiento de voz en streaming de baja memoria (25 idiomas por defecto; TDT de 114 idiomas opcional), texto a voz, detección de actividad de voz y cancelación de ruido — todo ejecutándose localmente. Sin APIs en la nube, ningún dato sale del dispositivo.
 
+**[📚 Documentación de Android](https://soniqo.audio/es/getting-started/android)** · **[Guía de Kokoro TTS](https://soniqo.audio/es/guides/kokoro/android)** · **[Guía de Parakeet TDT](https://soniqo.audio/es/guides/parakeet/android)** · **[Guía de Silero VAD](https://soniqo.audio/es/guides/vad/android)** · **[Guía de DeepFilterNet3](https://soniqo.audio/es/guides/denoise/android)**
+
 **[APK de demostración](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modelos](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (contraparte Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (motor de pipeline + compilación Linux/embebido)
 
 ## Alcance

--- a/README_fr.md
+++ b/README_fr.md
@@ -6,6 +6,8 @@ SDK vocal sur appareil pour Android, propulsé par [ONNX Runtime](https://onnxru
 
 Reconnaissance vocale en streaming à faible mémoire (25 langues par défaut, TDT 114 langues en option), synthèse vocale, détection d'activité vocale et suppression de bruit — tout fonctionne en local. Aucune API cloud, aucune donnée ne quitte l'appareil.
 
+**[📚 Documentation Android](https://soniqo.audio/fr/getting-started/android)** · **[Guide Kokoro TTS](https://soniqo.audio/fr/guides/kokoro/android)** · **[Guide Parakeet TDT](https://soniqo.audio/fr/guides/parakeet/android)** · **[Guide Silero VAD](https://soniqo.audio/fr/guides/vad/android)** · **[Guide DeepFilterNet3](https://soniqo.audio/fr/guides/denoise/android)**
+
 **[APK de démo](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modèles](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (équivalent Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (moteur de pipeline + build Linux/embarqué)
 
 ## Périmètre

--- a/README_fr.md
+++ b/README_fr.md
@@ -6,7 +6,7 @@ SDK vocal sur appareil pour Android, propulsé par [ONNX Runtime](https://onnxru
 
 Reconnaissance vocale en streaming à faible mémoire (25 langues par défaut, TDT 114 langues en option), synthèse vocale, détection d'activité vocale et suppression de bruit — tout fonctionne en local. Aucune API cloud, aucune donnée ne quitte l'appareil.
 
-**[📚 Documentation Android](https://soniqo.audio/fr/getting-started/android)** · **[Guide Kokoro TTS](https://soniqo.audio/fr/guides/kokoro/android)** · **[Guide Parakeet TDT](https://soniqo.audio/fr/guides/parakeet/android)** · **[Guide Silero VAD](https://soniqo.audio/fr/guides/vad/android)** · **[Guide DeepFilterNet3](https://soniqo.audio/fr/guides/denoise/android)**
+**[📚 Documentation Android](https://soniqo.audio/fr/getting-started/android)**
 
 **[APK de démo](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modèles](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (équivalent Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (moteur de pipeline + build Linux/embarqué)
 
@@ -18,13 +18,13 @@ Ce dépôt fournit le **packaging Android** : SDK Kotlin, pont JNI, application 
 
 | Modèle | Tâche | Téléchargement | Mémoire max | Langues |
 | --- | --- | --- | --- | --- |
-| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | STT streaming + EOU (défaut) | 153 Mo | 232 Mo | 25 |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | STT large couverture (optionnel) | 891 Mo | ~1,1-1,3 Go | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Synthèse vocale (défaut) | 330 Mo | 640 Mo | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Synthèse vocale (LiteRT, flow-matching, G2P-free, 44,1 kHz) | ~380 Mo | 832 Mo | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Détection d'activité vocale | 2 Mo | <10 Mo | Toutes |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Suppression de bruit | ~8 Mo | non chargé par défaut | Toutes |
-| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | LLM sur appareil — appels structurés de fonctions / outils | 283 Mo | dépend du runtime de l'app | Ajusté EN |
+| [Parakeet-EOU 120M](https://soniqo.audio/fr/guides/dictate) | STT streaming + EOU (défaut) | [153 Mo](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 Mo | 25 |
+| [Parakeet TDT v3](https://soniqo.audio/fr/guides/parakeet/android) | STT large couverture (optionnel) | [891 Mo](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1,1-1,3 Go | 114 |
+| [Kokoro 82M](https://soniqo.audio/fr/guides/kokoro/android) | Synthèse vocale (défaut) | [330 Mo](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 Mo | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://soniqo.audio/fr/guides/supertonic) | Synthèse vocale (LiteRT, flow-matching, G2P-free, 44,1 kHz) | [~380 Mo](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 Mo | 31 |
+| [Silero VAD v5](https://soniqo.audio/fr/guides/vad/android) | Détection d'activité vocale | [2 Mo](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 Mo | Toutes |
+| [DeepFilterNet3](https://soniqo.audio/fr/guides/denoise/android) | Suppression de bruit | [~8 Mo](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | non chargé par défaut | Toutes |
+| [FunctionGemma 270M](https://soniqo.audio/fr/guides/functiongemma) | LLM sur appareil — appels structurés de fonctions / outils | [283 Mo](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | dépend du runtime de l'app | Ajusté EN |
 
 Les modèles sont téléchargés automatiquement au premier lancement via `ModelManager.ensureModels()`.
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -6,7 +6,7 @@ Android के लिए ऑन-डिवाइस स्पीच SDK, [ONNX Ru
 
 कम-मेमोरी स्ट्रीमिंग स्पीच रिकग्निशन (डिफ़ॉल्ट 25 भाषाएँ, 114-भाषा TDT वैकल्पिक), टेक्स्ट-टू-स्पीच, वॉयस एक्टिविटी डिटेक्शन, और शोर रद्दीकरण — सभी स्थानीय रूप से चलते हैं। कोई क्लाउड API नहीं, कोई डेटा डिवाइस से बाहर नहीं जाता।
 
-**[📚 Android दस्तावेज़](https://soniqo.audio/hi/getting-started/android)** · **[Kokoro TTS गाइड](https://soniqo.audio/hi/guides/kokoro/android)** · **[Parakeet TDT गाइड](https://soniqo.audio/hi/guides/parakeet/android)** · **[Silero VAD गाइड](https://soniqo.audio/hi/guides/vad/android)** · **[DeepFilterNet3 गाइड](https://soniqo.audio/hi/guides/denoise/android)**
+**[📚 Android दस्तावेज़](https://soniqo.audio/hi/getting-started/android)**
 
 **[डेमो APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[मॉडल](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple समकक्ष) · **[speech-core](https://github.com/soniqo/speech-core)** (पाइपलाइन इंजन + Linux/एम्बेडेड बिल्ड)
 
@@ -18,13 +18,13 @@ Android के लिए ऑन-डिवाइस स्पीच SDK, [ONNX Ru
 
 | मॉडल | कार्य | डाउनलोड | पीक मेमोरी | भाषाएँ |
 | --- | --- | --- | --- | --- |
-| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | स्ट्रीमिंग STT + EOU (डिफ़ॉल्ट) | 153 MB | 232 MB | 25 |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | व्यापक STT (वैकल्पिक) | 891 MB | ~1.1-1.3 GB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | टेक्स्ट-टू-स्पीच (डिफ़ॉल्ट) | 330 MB | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | टेक्स्ट-टू-स्पीच (LiteRT, फ़्लो-मैचिंग, G2P-free, 44.1 kHz) | ~380 MB | 832 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | वॉयस एक्टिविटी डिटेक्शन | 2 MB | <10 MB | कोई भी |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | शोर रद्दीकरण | ~8 MB | डिफ़ॉल्ट रूप से लोड नहीं | कोई भी |
-| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | ऑन-डिवाइस LLM — संरचित फ़ंक्शन / टूल कॉल | 283 MB | ऐप runtime पर निर्भर | EN-tuned |
+| [Parakeet-EOU 120M](https://soniqo.audio/hi/guides/dictate) | स्ट्रीमिंग STT + EOU (डिफ़ॉल्ट) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
+| [Parakeet TDT v3](https://soniqo.audio/hi/guides/parakeet/android) | व्यापक STT (वैकल्पिक) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
+| [Kokoro 82M](https://soniqo.audio/hi/guides/kokoro/android) | टेक्स्ट-टू-स्पीच (डिफ़ॉल्ट) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://soniqo.audio/hi/guides/supertonic) | टेक्स्ट-टू-स्पीच (LiteRT, फ़्लो-मैचिंग, G2P-free, 44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
+| [Silero VAD v5](https://soniqo.audio/hi/guides/vad/android) | वॉयस एक्टिविटी डिटेक्शन | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | कोई भी |
+| [DeepFilterNet3](https://soniqo.audio/hi/guides/denoise/android) | शोर रद्दीकरण | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | डिफ़ॉल्ट रूप से लोड नहीं | कोई भी |
+| [FunctionGemma 270M](https://soniqo.audio/hi/guides/functiongemma) | ऑन-डिवाइस LLM — संरचित फ़ंक्शन / टूल कॉल | [283 MB](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | ऐप runtime पर निर्भर | EN-tuned |
 
 मॉडल पहले लॉन्च पर `ModelManager.ensureModels()` के माध्यम से स्वचालित रूप से डाउनलोड होते हैं।
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -6,6 +6,8 @@ Android के लिए ऑन-डिवाइस स्पीच SDK, [ONNX Ru
 
 कम-मेमोरी स्ट्रीमिंग स्पीच रिकग्निशन (डिफ़ॉल्ट 25 भाषाएँ, 114-भाषा TDT वैकल्पिक), टेक्स्ट-टू-स्पीच, वॉयस एक्टिविटी डिटेक्शन, और शोर रद्दीकरण — सभी स्थानीय रूप से चलते हैं। कोई क्लाउड API नहीं, कोई डेटा डिवाइस से बाहर नहीं जाता।
 
+**[📚 Android दस्तावेज़](https://soniqo.audio/hi/getting-started/android)** · **[Kokoro TTS गाइड](https://soniqo.audio/hi/guides/kokoro/android)** · **[Parakeet TDT गाइड](https://soniqo.audio/hi/guides/parakeet/android)** · **[Silero VAD गाइड](https://soniqo.audio/hi/guides/vad/android)** · **[DeepFilterNet3 गाइड](https://soniqo.audio/hi/guides/denoise/android)**
+
 **[डेमो APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[मॉडल](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple समकक्ष) · **[speech-core](https://github.com/soniqo/speech-core)** (पाइपलाइन इंजन + Linux/एम्बेडेड बिल्ड)
 
 ## स्कोप

--- a/README_ja.md
+++ b/README_ja.md
@@ -6,6 +6,8 @@
 
 低メモリのストリーミング音声認識(既定 25 言語、114 言語 TDT は任意)、テキスト読み上げ、音声活動検出、ノイズキャンセリング — すべてローカルで動作。クラウド API 不要、データはデバイスから外に出ません。
 
+**[📚 Android ドキュメント](https://soniqo.audio/ja/getting-started/android)** · **[Kokoro TTS ガイド](https://soniqo.audio/ja/guides/kokoro/android)** · **[Parakeet TDT ガイド](https://soniqo.audio/ja/guides/parakeet/android)** · **[Silero VAD ガイド](https://soniqo.audio/ja/guides/vad/android)** · **[DeepFilterNet3 ガイド](https://soniqo.audio/ja/guides/denoise/android)**
+
 **[デモ APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[モデル](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 版)· **[speech-core](https://github.com/soniqo/speech-core)**(パイプラインエンジン + Linux/組み込みビルド)
 
 ## スコープ

--- a/README_ja.md
+++ b/README_ja.md
@@ -6,7 +6,7 @@
 
 低メモリのストリーミング音声認識(既定 25 言語、114 言語 TDT は任意)、テキスト読み上げ、音声活動検出、ノイズキャンセリング — すべてローカルで動作。クラウド API 不要、データはデバイスから外に出ません。
 
-**[📚 Android ドキュメント](https://soniqo.audio/ja/getting-started/android)** · **[Kokoro TTS ガイド](https://soniqo.audio/ja/guides/kokoro/android)** · **[Parakeet TDT ガイド](https://soniqo.audio/ja/guides/parakeet/android)** · **[Silero VAD ガイド](https://soniqo.audio/ja/guides/vad/android)** · **[DeepFilterNet3 ガイド](https://soniqo.audio/ja/guides/denoise/android)**
+**[📚 Android ドキュメント](https://soniqo.audio/ja/getting-started/android)**
 
 **[デモ APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[モデル](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 版)· **[speech-core](https://github.com/soniqo/speech-core)**(パイプラインエンジン + Linux/組み込みビルド)
 
@@ -18,13 +18,13 @@
 
 | モデル | タスク | ダウンロード | ピークメモリ | 言語 |
 | --- | --- | --- | --- | --- |
-| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | ストリーミング STT + EOU(既定) | 153 MB | 232 MB | 25 |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | 広範囲 STT(任意) | 891 MB | ~1.1-1.3 GB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | テキスト読み上げ(既定) | 330 MB | 640 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | テキスト読み上げ(LiteRT、flow-matching、G2P-free、44.1 kHz) | ~380 MB | 832 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | 音声活動検出 | 2 MB | <10 MB | 任意 |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | ノイズキャンセリング | ~8 MB | 既定では未ロード | 任意 |
-| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | オンデバイス LLM — 構造化関数 / ツール呼び出し | 283 MB | アプリのランタイム次第 | EN チューニング |
+| [Parakeet-EOU 120M](https://soniqo.audio/ja/guides/dictate) | ストリーミング STT + EOU(既定) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
+| [Parakeet TDT v3](https://soniqo.audio/ja/guides/parakeet/android) | 広範囲 STT(任意) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
+| [Kokoro 82M](https://soniqo.audio/ja/guides/kokoro/android) | テキスト読み上げ(既定) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
+| [Supertonic-3](https://soniqo.audio/ja/guides/supertonic) | テキスト読み上げ(LiteRT、flow-matching、G2P-free、44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
+| [Silero VAD v5](https://soniqo.audio/ja/guides/vad/android) | 音声活動検出 | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | 任意 |
+| [DeepFilterNet3](https://soniqo.audio/ja/guides/denoise/android) | ノイズキャンセリング | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 既定では未ロード | 任意 |
+| [FunctionGemma 270M](https://soniqo.audio/ja/guides/functiongemma) | オンデバイス LLM — 構造化関数 / ツール呼び出し | [283 MB](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | アプリのランタイム次第 | EN チューニング |
 
 モデルは初回起動時に `ModelManager.ensureModels()` 経由で自動ダウンロードされます。
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -6,7 +6,7 @@
 
 저메모리 스트리밍 음성 인식(기본 25개 언어, 114개 언어 TDT는 선택), 텍스트 음성 변환, 음성 활동 감지, 노이즈 캔슬링 — 모두 로컬에서 실행됩니다. 클라우드 API도, 디바이스 외부로 전송되는 데이터도 없습니다.
 
-**[📚 Android 문서](https://soniqo.audio/ko/getting-started/android)** · **[Kokoro TTS 가이드](https://soniqo.audio/ko/guides/kokoro/android)** · **[Parakeet TDT 가이드](https://soniqo.audio/ko/guides/parakeet/android)** · **[Silero VAD 가이드](https://soniqo.audio/ko/guides/vad/android)** · **[DeepFilterNet3 가이드](https://soniqo.audio/ko/guides/denoise/android)**
+**[📚 Android 문서](https://soniqo.audio/ko/getting-started/android)**
 
 **[데모 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[모델](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 버전) · **[speech-core](https://github.com/soniqo/speech-core)**(파이프라인 엔진 + Linux/임베디드 빌드)
 
@@ -18,13 +18,13 @@
 
 | 모델 | 작업 | 다운로드 | 피크 메모리 | 언어 |
 | --- | --- | --- | --- | --- |
-| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 스트리밍 STT + EOU(기본) | 153 MB | 232 MB | 25 |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | 광범위 STT(선택) | 891 MB | ~1.1-1.3 GB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 텍스트 음성 변환(기본) | 330 MB | 640 MB | 8(en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 텍스트 음성 변환(LiteRT, flow-matching, G2P-free, 44.1 kHz) | ~380 MB | 832 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | 음성 활동 감지 | 2 MB | <10 MB | 모든 언어 |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 노이즈 캔슬링 | ~8 MB | 기본으로 로드하지 않음 | 모든 언어 |
-| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | 온디바이스 LLM — 구조화 함수 / 도구 호출 | 283 MB | 앱 런타임에 따라 다름 | EN 튜닝 |
+| [Parakeet-EOU 120M](https://soniqo.audio/ko/guides/dictate) | 스트리밍 STT + EOU(기본) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
+| [Parakeet TDT v3](https://soniqo.audio/ko/guides/parakeet/android) | 광범위 STT(선택) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
+| [Kokoro 82M](https://soniqo.audio/ko/guides/kokoro/android) | 텍스트 음성 변환(기본) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8(en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://soniqo.audio/ko/guides/supertonic) | 텍스트 음성 변환(LiteRT, flow-matching, G2P-free, 44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
+| [Silero VAD v5](https://soniqo.audio/ko/guides/vad/android) | 음성 활동 감지 | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | 모든 언어 |
+| [DeepFilterNet3](https://soniqo.audio/ko/guides/denoise/android) | 노이즈 캔슬링 | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 기본으로 로드하지 않음 | 모든 언어 |
+| [FunctionGemma 270M](https://soniqo.audio/ko/guides/functiongemma) | 온디바이스 LLM — 구조화 함수 / 도구 호출 | [283 MB](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | 앱 런타임에 따라 다름 | EN 튜닝 |
 
 모델은 `ModelManager.ensureModels()`를 통해 첫 실행 시 자동으로 다운로드됩니다.
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -6,6 +6,8 @@
 
 저메모리 스트리밍 음성 인식(기본 25개 언어, 114개 언어 TDT는 선택), 텍스트 음성 변환, 음성 활동 감지, 노이즈 캔슬링 — 모두 로컬에서 실행됩니다. 클라우드 API도, 디바이스 외부로 전송되는 데이터도 없습니다.
 
+**[📚 Android 문서](https://soniqo.audio/ko/getting-started/android)** · **[Kokoro TTS 가이드](https://soniqo.audio/ko/guides/kokoro/android)** · **[Parakeet TDT 가이드](https://soniqo.audio/ko/guides/parakeet/android)** · **[Silero VAD 가이드](https://soniqo.audio/ko/guides/vad/android)** · **[DeepFilterNet3 가이드](https://soniqo.audio/ko/guides/denoise/android)**
+
 **[데모 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[모델](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 버전) · **[speech-core](https://github.com/soniqo/speech-core)**(파이프라인 엔진 + Linux/임베디드 빌드)
 
 ## 범위

--- a/README_pt.md
+++ b/README_pt.md
@@ -6,6 +6,8 @@ SDK de voz no dispositivo para Android, baseado em [ONNX Runtime](https://onnxru
 
 Reconhecimento de fala em streaming com baixa memória (25 idiomas por padrão, TDT de 114 idiomas opcional), texto para fala, detecção de atividade vocal e cancelamento de ruído — tudo executado localmente. Sem APIs em nuvem, nenhum dado sai do dispositivo.
 
+**[📚 Documentação Android](https://soniqo.audio/pt/getting-started/android)** · **[Guia do Kokoro TTS](https://soniqo.audio/pt/guides/kokoro/android)** · **[Guia do Parakeet TDT](https://soniqo.audio/pt/guides/parakeet/android)** · **[Guia do Silero VAD](https://soniqo.audio/pt/guides/vad/android)** · **[Guia do DeepFilterNet3](https://soniqo.audio/pt/guides/denoise/android)**
+
 **[APK de demonstração](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modelos](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (contraparte Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (motor de pipeline + build Linux/embarcado)
 
 ## Escopo

--- a/README_pt.md
+++ b/README_pt.md
@@ -6,7 +6,7 @@ SDK de voz no dispositivo para Android, baseado em [ONNX Runtime](https://onnxru
 
 Reconhecimento de fala em streaming com baixa memória (25 idiomas por padrão, TDT de 114 idiomas opcional), texto para fala, detecção de atividade vocal e cancelamento de ruído — tudo executado localmente. Sem APIs em nuvem, nenhum dado sai do dispositivo.
 
-**[📚 Documentação Android](https://soniqo.audio/pt/getting-started/android)** · **[Guia do Kokoro TTS](https://soniqo.audio/pt/guides/kokoro/android)** · **[Guia do Parakeet TDT](https://soniqo.audio/pt/guides/parakeet/android)** · **[Guia do Silero VAD](https://soniqo.audio/pt/guides/vad/android)** · **[Guia do DeepFilterNet3](https://soniqo.audio/pt/guides/denoise/android)**
+**[📚 Documentação Android](https://soniqo.audio/pt/getting-started/android)**
 
 **[APK de demonstração](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modelos](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (contraparte Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (motor de pipeline + build Linux/embarcado)
 
@@ -18,13 +18,13 @@ Este repositório é o **empacotamento Android**: SDK Kotlin, ponte JNI, app de 
 
 | Modelo | Tarefa | Download | Pico de memória | Idiomas |
 | --- | --- | --- | --- | --- |
-| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | STT em streaming + EOU (padrão) | 153 MB | 232 MB | 25 |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | STT de ampla cobertura (opcional) | 891 MB | ~1,1-1,3 GB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Texto para fala (padrão) | 330 MB | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Texto para fala (LiteRT, flow-matching, G2P-free, 44,1 kHz) | ~380 MB | 832 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Detecção de atividade vocal | 2 MB | <10 MB | Qualquer |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Cancelamento de ruído | ~8 MB | não carregado por padrão | Qualquer |
-| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | LLM no dispositivo — chamadas estruturadas de função / ferramenta | 283 MB | depende do runtime do app | Ajustado para EN |
+| [Parakeet-EOU 120M](https://soniqo.audio/pt/guides/dictate) | STT em streaming + EOU (padrão) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
+| [Parakeet TDT v3](https://soniqo.audio/pt/guides/parakeet/android) | STT de ampla cobertura (opcional) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1,1-1,3 GB | 114 |
+| [Kokoro 82M](https://soniqo.audio/pt/guides/kokoro/android) | Texto para fala (padrão) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://soniqo.audio/pt/guides/supertonic) | Texto para fala (LiteRT, flow-matching, G2P-free, 44,1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
+| [Silero VAD v5](https://soniqo.audio/pt/guides/vad/android) | Detecção de atividade vocal | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | Qualquer |
+| [DeepFilterNet3](https://soniqo.audio/pt/guides/denoise/android) | Cancelamento de ruído | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | não carregado por padrão | Qualquer |
+| [FunctionGemma 270M](https://soniqo.audio/pt/guides/functiongemma) | LLM no dispositivo — chamadas estruturadas de função / ferramenta | [283 MB](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | depende do runtime do app | Ajustado para EN |
 
 Os modelos são baixados automaticamente no primeiro lançamento via `ModelManager.ensureModels()`.
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -6,7 +6,7 @@
 
 Потоковое распознавание речи с низким потреблением памяти (25 языков по умолчанию, TDT на 114 языков опционально), синтез речи, определение голосовой активности и шумоподавление — всё работает локально. Никаких облачных API, никакие данные не покидают устройство.
 
-**[📚 Документация Android](https://soniqo.audio/ru/getting-started/android)** · **[Руководство по Kokoro TTS](https://soniqo.audio/ru/guides/kokoro/android)** · **[Руководство по Parakeet TDT](https://soniqo.audio/ru/guides/parakeet/android)** · **[Руководство по Silero VAD](https://soniqo.audio/ru/guides/vad/android)** · **[Руководство по DeepFilterNet3](https://soniqo.audio/ru/guides/denoise/android)**
+**[📚 Документация Android](https://soniqo.audio/ru/getting-started/android)**
 
 **[Демо APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Модели](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (аналог для Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (движок конвейера + сборка для Linux/встраиваемых систем)
 
@@ -18,13 +18,13 @@
 
 | Модель | Задача | Загрузка | Пиковая память | Языки |
 | --- | --- | --- | --- | --- |
-| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | Потоковый STT + EOU (по умолчанию) | 153 МБ | 232 МБ | 25 |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | STT с широким покрытием (опционально) | 891 МБ | ~1,1-1,3 ГБ | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Синтез речи (по умолчанию) | 330 МБ | 640 МБ | 8 (en, fr, es, it, pt, hi, ja, zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | Синтез речи (LiteRT, flow-matching, G2P-free, 44,1 кГц) | ~380 МБ | 832 МБ | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | Определение голосовой активности | 2 МБ | <10 МБ | Любой |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Шумоподавление | ~8 МБ | по умолчанию не загружается | Любой |
-| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | Локальная LLM — структурированные вызовы функций / инструментов | 283 МБ | зависит от runtime приложения | EN-tuned |
+| [Parakeet-EOU 120M](https://soniqo.audio/ru/guides/dictate) | Потоковый STT + EOU (по умолчанию) | [153 МБ](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 МБ | 25 |
+| [Parakeet TDT v3](https://soniqo.audio/ru/guides/parakeet/android) | STT с широким покрытием (опционально) | [891 МБ](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1,1-1,3 ГБ | 114 |
+| [Kokoro 82M](https://soniqo.audio/ru/guides/kokoro/android) | Синтез речи (по умолчанию) | [330 МБ](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 МБ | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Supertonic-3](https://soniqo.audio/ru/guides/supertonic) | Синтез речи (LiteRT, flow-matching, G2P-free, 44,1 кГц) | [~380 МБ](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 МБ | 31 |
+| [Silero VAD v5](https://soniqo.audio/ru/guides/vad/android) | Определение голосовой активности | [2 МБ](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 МБ | Любой |
+| [DeepFilterNet3](https://soniqo.audio/ru/guides/denoise/android) | Шумоподавление | [~8 МБ](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | по умолчанию не загружается | Любой |
+| [FunctionGemma 270M](https://soniqo.audio/ru/guides/functiongemma) | Локальная LLM — структурированные вызовы функций / инструментов | [283 МБ](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | зависит от runtime приложения | EN-tuned |
 
 Модели загружаются автоматически при первом запуске через `ModelManager.ensureModels()`.
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -6,6 +6,8 @@
 
 Потоковое распознавание речи с низким потреблением памяти (25 языков по умолчанию, TDT на 114 языков опционально), синтез речи, определение голосовой активности и шумоподавление — всё работает локально. Никаких облачных API, никакие данные не покидают устройство.
 
+**[📚 Документация Android](https://soniqo.audio/ru/getting-started/android)** · **[Руководство по Kokoro TTS](https://soniqo.audio/ru/guides/kokoro/android)** · **[Руководство по Parakeet TDT](https://soniqo.audio/ru/guides/parakeet/android)** · **[Руководство по Silero VAD](https://soniqo.audio/ru/guides/vad/android)** · **[Руководство по DeepFilterNet3](https://soniqo.audio/ru/guides/denoise/android)**
+
 **[Демо APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Модели](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (аналог для Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (движок конвейера + сборка для Linux/встраиваемых систем)
 
 ## Область применения

--- a/README_zh.md
+++ b/README_zh.md
@@ -6,6 +6,8 @@
 
 低内存流式语音识别(默认 25 种语言,可选 114 语言 TDT)、文本转语音、语音活动检测和噪声消除——全部在本地运行。无需云端 API,数据不会离开设备。
 
+**[📚 Android 文档](https://soniqo.audio/zh/getting-started/android)** · **[Kokoro TTS 指南](https://soniqo.audio/zh/guides/kokoro/android)** · **[Parakeet TDT 指南](https://soniqo.audio/zh/guides/parakeet/android)** · **[Silero VAD 指南](https://soniqo.audio/zh/guides/vad/android)** · **[DeepFilterNet3 指南](https://soniqo.audio/zh/guides/denoise/android)**
+
 **[演示 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[模型](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 对应版本)· **[speech-core](https://github.com/soniqo/speech-core)**(管线引擎 + Linux/嵌入式构建)
 
 ## 范围

--- a/README_zh.md
+++ b/README_zh.md
@@ -6,7 +6,7 @@
 
 低内存流式语音识别(默认 25 种语言,可选 114 语言 TDT)、文本转语音、语音活动检测和噪声消除——全部在本地运行。无需云端 API,数据不会离开设备。
 
-**[📚 Android 文档](https://soniqo.audio/zh/getting-started/android)** · **[Kokoro TTS 指南](https://soniqo.audio/zh/guides/kokoro/android)** · **[Parakeet TDT 指南](https://soniqo.audio/zh/guides/parakeet/android)** · **[Silero VAD 指南](https://soniqo.audio/zh/guides/vad/android)** · **[DeepFilterNet3 指南](https://soniqo.audio/zh/guides/denoise/android)**
+**[📚 Android 文档](https://soniqo.audio/zh/getting-started/android)**
 
 **[演示 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[模型](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 对应版本)· **[speech-core](https://github.com/soniqo/speech-core)**(管线引擎 + Linux/嵌入式构建)
 
@@ -18,13 +18,13 @@
 
 | 模型 | 任务 | 下载大小 | 峰值内存 | 语言 |
 | --- | --- | --- | --- | --- |
-| [Parakeet-EOU 120M](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 流式 STT + 端点检测(默认) | 153 MB | 232 MB | 25 |
-| [Parakeet TDT v3](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | 广覆盖 STT(可选) | 891 MB | ~1.1-1.3 GB | 114 |
-| [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 文本转语音(默认) | 330 MB | 640 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
-| [Supertonic-3](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 文本转语音(LiteRT、流匹配、免 G2P、44.1 kHz) | ~380 MB | 832 MB | 31 |
-| [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | 语音活动检测 | 2 MB | <10 MB | 任意 |
-| [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 噪声消除 | ~8 MB | 默认不加载 | 任意 |
-| [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | 端侧 LLM — 结构化函数 / 工具调用 | 283 MB | 取决于应用运行时 | EN 调优 |
+| [Parakeet-EOU 120M](https://soniqo.audio/zh/guides/dictate) | 流式 STT + 端点检测(默认) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
+| [Parakeet TDT v3](https://soniqo.audio/zh/guides/parakeet/android) | 广覆盖 STT(可选) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
+| [Kokoro 82M](https://soniqo.audio/zh/guides/kokoro/android) | 文本转语音(默认) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
+| [Supertonic-3](https://soniqo.audio/zh/guides/supertonic) | 文本转语音(LiteRT、流匹配、免 G2P、44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
+| [Silero VAD v5](https://soniqo.audio/zh/guides/vad/android) | 语音活动检测 | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | 任意 |
+| [DeepFilterNet3](https://soniqo.audio/zh/guides/denoise/android) | 噪声消除 | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 默认不加载 | 任意 |
+| [FunctionGemma 270M](https://soniqo.audio/zh/guides/functiongemma) | 端侧 LLM — 结构化函数 / 工具调用 | [283 MB](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) | 取决于应用运行时 | EN 调优 |
 
 模型在首次启动时通过 `ModelManager.ensureModels()` 自动下载。
 

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -67,7 +67,7 @@ mavenPublishing {
     pom {
         name.set("speech-android")
         description.set("On-device speech SDK for Android — VAD, STT, TTS, noise cancellation")
-        url.set("https://github.com/soniqo/speech-android")
+        url.set("https://soniqo.audio/getting-started/android")
         inceptionYear.set("2026")
 
         licenses {


### PR DESCRIPTION
## Summary
- link every Android model name to its localized canonical Soniqo guide
- retain direct Hugging Face weight access on each model's download-size link
- add localized Android setup links across all ten READMEs
- update the published Maven POM project URL to the canonical Android documentation
- keep source-control and license metadata on GitHub

## Why
Repository and Maven users should land on the platform-specific documentation. The model table now offers both the relevant implementation guide and the downloadable weights without duplicating a long navigation row.

## Test plan
- `./gradlew :sdk:generatePomFileForMavenPublication :sdk:test`
- verified the generated POM project URL
- verified all 10 READMEs use localized guide destinations and retain Hugging Face weight links
- verified all 70 localized guide targets exist in the site tree
- `git diff --check`
