### PR TITLE
Add full-pipeline Android Control demo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Linux/automotive support moved to [speech-core's `examples/linux/`](https://gith
 - `sdk/src/main/kotlin/audio/soniqo/speech/` — Kotlin public SDK
 - `sdk/src/androidTest/` — instrumented e2e tests
 - `app/` — demo application
+- `control-demo/` — separate full-pipeline voice-command demo (VAD → STT → FunctionGemma → Android tools → TTS)
 - `setup.sh` — downloads ONNX Runtime, initializes the speech-core submodule
 
 ## Build
@@ -25,6 +26,7 @@ Linux/automotive support moved to [speech-core's `examples/linux/`](https://gith
 ```bash
 ./setup.sh
 ./gradlew :app:assembleDebug
+./gradlew :control-demo:assembleDebug
 ./gradlew :sdk:connectedAndroidTest
 ```
 
@@ -34,6 +36,7 @@ Linux/automotive support moved to [speech-core's `examples/linux/`](https://gith
 
 ```bash
 ./gradlew :sdk:test
+./gradlew :control-demo:testDebugUnitTest
 ```
 
 Download retry / resume / timeout / validation / edge cases.
@@ -99,6 +102,12 @@ speech-core PR, then bump the submodule pointer here.
 - Kotlin SDK stays minimal — thin wrapper over JNI.
 - All model tensor names/shapes must match the published ONNX exports under `aufklarer/`.
 - Test on arm64-v8a (Snapdragon) as primary target.
+- Keep `control-demo` routing model-driven: do not add keyword/regex command
+  dispatch, and offer FunctionGemma only tools valid for the current device
+  state.
+- Keep `control-demo`'s `ControlTools` declarations and compact prompt in sync
+  with `speech-models/models/functiongemma/training` whenever the tool surface,
+  argument schema, prompt serialization, or state rules change.
 - **No Claude attribution** in commits, PRs, or model cards. Strip both the `🤖 Generated with [Claude Code]` footer and the `Co-Authored-By: Claude …` trailer from defaults.
 - **Never push directly to main — always use a PR**.
 - **Always ask for confirmation before creating a git commit**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ speech-android — on-device speech SDK for Android (VAD + STT + TTS + noise can
 
 Thin Kotlin SDK + JNI bridge over the [speech-core](https://github.com/soniqo/speech-core)
 C++ engine, which provides the orchestration pipeline AND the ONNX Runtime
-model wrappers (Silero VAD, Parakeet STT, Kokoro TTS, DeepFilterNet3). This
+model wrappers (Silero VAD, Parakeet STT, Kokoro/Pocket TTS, DeepFilterNet3). This
 repo owns only the Android packaging and a single ~250-line JNI bridge.
 
 Linux/automotive support moved to [speech-core's `examples/linux/`](https://github.com/soniqo/speech-core/tree/main/examples/linux).
@@ -70,6 +70,7 @@ org. INT8 quantized by default.
 - `soniqo/Silero-VAD-v5-ONNX` — VAD
 - `soniqo/Parakeet-TDT-v3-ONNX` — STT (114 languages, 8192 BPE vocab)
 - `soniqo/Kokoro-82M-ONNX` — TTS + phonemizer dicts + voice embeddings
+- `soniqo/Pocket-TTS-100M-ONNX-INT8` — streaming English TTS, fixed Alba voice
 - `soniqo/DeepFilterNet3-ONNX` — noise enhancer
 
 `ModelManager.kt` handles download and caching. See speech-core's
@@ -78,7 +79,7 @@ for the full model-file inventory.
 
 ## Key files
 
-- `sdk/src/main/cpp/jni_bridge.cpp` — constructs `speech_core::SileroVad`/`ParakeetStt`/`KokoroTts` and feeds them to `speech_core::VoicePipeline`. No vtable adapters — the model wrappers implement the interfaces directly.
+- `sdk/src/main/cpp/jni_bridge.cpp` — constructs `speech_core::SileroVad`/`ParakeetStt` and the selected Kokoro/Pocket TTS wrapper, then feeds them to `speech_core::VoicePipeline`. No vtable adapters — the model wrappers implement the interfaces directly.
 - `sdk/src/main/cpp/CMakeLists.txt` — pulls speech-core in via `add_subdirectory` with `SPEECH_CORE_WITH_ONNX=ON`; the speech_core_models target provides every model wrapper.
 - `sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt` — main public Kotlin API.
 - `sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt` — JNI surface (must stay in lockstep with `jni_bridge.cpp`).
@@ -105,9 +106,9 @@ speech-core PR, then bump the submodule pointer here.
 - Keep `control-demo` routing model-driven: do not add keyword/regex command
   dispatch, and offer FunctionGemma only tools valid for the current device
   state.
-- Keep `control-demo`'s `ControlTools` declarations and compact prompt in sync
-  with `speech-models/models/functiongemma/training` whenever the tool surface,
-  argument schema, prompt serialization, or state rules change.
+- Keep `control-demo`'s `ControlTools` declarations and compact prompt compatible
+  with the published Control adapter whenever the tool surface, argument schema,
+  prompt serialization, or state rules change.
 - **No Claude attribution** in commits, PRs, or model cards. Strip both the `🤖 Generated with [Claude Code]` footer and the `Co-Authored-By: Claude …` trailer from defaults.
 - **Never push directly to main — always use a PR**.
 - **Always ask for confirmation before creating a git commit**.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Low-memory streaming speech recognition (25 languages by default, 114-language T
 
 ## Scope
 
-This repo is the **Android packaging**: Kotlin SDK, JNI bridge, demo app. The C++ engine and ONNX model wrappers (Silero VAD, Parakeet STT, Kokoro TTS, DeepFilterNet3) live in [speech-core](https://github.com/soniqo/speech-core) and are pulled in via a git submodule. Linux / automotive (Yocto, Qualcomm SA8295P/SA8255P) lives at [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux).
+This repo is the **Android packaging**: Kotlin SDK, JNI bridge, demo app. The C++ engine and ONNX model wrappers (Silero VAD, Parakeet STT, Kokoro/Pocket TTS, DeepFilterNet3) live in [speech-core](https://github.com/soniqo/speech-core) and are pulled in via a git submodule. Linux / automotive (Yocto, Qualcomm SA8295P/SA8255P) lives at [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux).
 
 ## Models
 
@@ -21,6 +21,7 @@ This repo is the **Android packaging**: Kotlin SDK, JNI bridge, demo app. The C+
 | [Parakeet-EOU 120M](https://soniqo.audio/guides/dictate) | Streaming STT + end-of-utterance (default) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/guides/parakeet/android) | Broad-coverage STT (optional) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
 | [Kokoro 82M](https://soniqo.audio/guides/kokoro/android) | Text-to-speech (default) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Streaming text-to-speech (optional, fixed Alba voice) | ~126 MB | not yet measured | English |
 | [Supertonic-3](https://soniqo.audio/guides/supertonic) | Text-to-speech (LiteRT, flow-matching, G2P-free, 44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
 | [Silero VAD v5](https://soniqo.audio/guides/vad/android) | Voice activity detection | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | Any |
 | [DeepFilterNet3](https://soniqo.audio/guides/denoise/android) | Noise cancellation | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | not loaded by default | Any |
@@ -158,7 +159,7 @@ The [`app/`](app/) module is a minimal voice assistant demo with:
 
 The separate [`control-demo/`](control-demo/) app runs the complete agent
 locally: Silero VAD → Parakeet-EOU STT → FunctionGemma 270M tool calls →
-Android device actions → Kokoro TTS. It reports per-stage latency and links
+Android device actions → Pocket TTS. It reports per-stage latency and links
 directly to this checkout's `:sdk`, so local speech optimizations are used.
 
 ```bash
@@ -296,7 +297,8 @@ Barge-in supported: speaking during TTS playback interrupts and starts a new tra
 │  ┌──────────────────────────────────────┐    │
 │  │  speech_core_models (git submodule)  │    │
 │  │   SileroVad / ParakeetStt /          │    │
-│  │   KokoroTts / DeepFilterEnhancer     │    │
+│  │   KokoroTts / OnnxPocketTts /        │    │
+│  │   DeepFilterEnhancer                  │    │
 │  │            │                         │    │
 │  │            ▼                         │    │
 │  │  speech_core  (orchestration:        │    │

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ git clone --recursive https://github.com/soniqo/speech-android.git
 cd speech-android
 ./setup.sh
 ./gradlew :app:assembleDebug
-./gradlew :sdk:connectedAndroidTest   # 34 e2e tests
+./gradlew :sdk:connectedAndroidTest   # 38 e2e tests
 ```
 
 `./setup.sh` initializes the speech-core submodule and downloads ONNX Runtime
@@ -152,6 +152,17 @@ The [`app/`](app/) module is a minimal voice assistant demo with:
 
 ```bash
 ./gradlew :app:installDebug
+```
+
+### Full-pipeline control demo
+
+The separate [`control-demo/`](control-demo/) app runs the complete agent
+locally: Silero VAD → Parakeet-EOU STT → FunctionGemma 270M tool calls →
+Android device actions → Kokoro TTS. It reports per-stage latency and links
+directly to this checkout's `:sdk`, so local speech optimizations are used.
+
+```bash
+./gradlew :control-demo:installDebug
 ```
 
 ## System voice input (`RecognitionService`)

--- a/README_de.md
+++ b/README_de.md
@@ -76,7 +76,7 @@ git clone --recursive https://github.com/soniqo/speech-android.git
 cd speech-android
 ./setup.sh
 ./gradlew :app:assembleDebug
-./gradlew :sdk:connectedAndroidTest   # 34 e2e-Tests
+./gradlew :sdk:connectedAndroidTest   # 38 e2e-Tests
 ```
 
 `./setup.sh` initialisiert das speech-core-Submodul und lädt die ONNX Runtime
@@ -95,6 +95,18 @@ Das Modul [`app/`](app/) ist eine minimale Sprachassistenten-Demo mit:
 
 ```bash
 ./gradlew :app:installDebug
+```
+
+### Vollständige Control-Pipeline-Demo
+
+Die separate App [`control-demo/`](control-demo/) führt den kompletten Agenten
+lokal aus: Silero VAD → Parakeet-EOU STT → FunctionGemma-270M-Tool-Aufrufe →
+Android-Geräteaktionen → Kokoro TTS. Sie zeigt die Latenz jeder Stufe an und
+bindet direkt das `:sdk` dieses Checkouts ein, sodass lokale
+Sprachoptimierungen verwendet werden.
+
+```bash
+./gradlew :control-demo:installDebug
 ```
 
 ## Systemweite Spracheingabe (`RecognitionService`)

--- a/README_de.md
+++ b/README_de.md
@@ -12,7 +12,7 @@ Speicherarme Streaming-Spracherkennung (standardmäßig 25 Sprachen, optionales 
 
 ## Geltungsbereich
 
-Dieses Repo ist das **Android-Packaging**: Kotlin-SDK, JNI-Bridge, Demo-App. Die C++-Engine und die ONNX-Modell-Wrapper (Silero VAD, Parakeet STT, Kokoro TTS, DeepFilterNet3) liegen in [speech-core](https://github.com/soniqo/speech-core) und werden über ein Git-Submodul eingebunden. Linux / Automotive (Yocto, Qualcomm SA8295P/SA8255P) befindet sich unter [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux).
+Dieses Repo ist das **Android-Packaging**: Kotlin-SDK, JNI-Bridge, Demo-App. Die C++-Engine und die ONNX-Modell-Wrapper (Silero VAD, Parakeet STT, Kokoro/Pocket TTS, DeepFilterNet3) liegen in [speech-core](https://github.com/soniqo/speech-core) und werden über ein Git-Submodul eingebunden. Linux / Automotive (Yocto, Qualcomm SA8295P/SA8255P) befindet sich unter [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux).
 
 ## Modelle
 
@@ -21,6 +21,7 @@ Dieses Repo ist das **Android-Packaging**: Kotlin-SDK, JNI-Bridge, Demo-App. Die
 | [Parakeet-EOU 120M](https://soniqo.audio/de/guides/dictate) | Streaming-STT + EOU (Standard) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/de/guides/parakeet/android) | Breite STT-Abdeckung (optional) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1,1-1,3 GB | 114 |
 | [Kokoro 82M](https://soniqo.audio/de/guides/kokoro/android) | Text-to-Speech (Standard) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Streaming-Text-to-Speech (optional, feste Alba-Stimme) | ~126 MB | noch nicht gemessen | Englisch |
 | [Supertonic-3](https://soniqo.audio/de/guides/supertonic) | Text-to-Speech (LiteRT, Flow-Matching, G2P-frei, 44,1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
 | [Silero VAD v5](https://soniqo.audio/de/guides/vad/android) | Sprachaktivitätserkennung | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | Beliebig |
 | [DeepFilterNet3](https://soniqo.audio/de/guides/denoise/android) | Rauschunterdrückung | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | standardmäßig nicht geladen | Beliebig |
@@ -101,7 +102,7 @@ Das Modul [`app/`](app/) ist eine minimale Sprachassistenten-Demo mit:
 
 Die separate App [`control-demo/`](control-demo/) führt den kompletten Agenten
 lokal aus: Silero VAD → Parakeet-EOU STT → FunctionGemma-270M-Tool-Aufrufe →
-Android-Geräteaktionen → Kokoro TTS. Sie zeigt die Latenz jeder Stufe an und
+Android-Geräteaktionen → Pocket TTS. Sie zeigt die Latenz jeder Stufe an und
 bindet direkt das `:sdk` dieses Checkouts ein, sodass lokale
 Sprachoptimierungen verwendet werden.
 
@@ -217,7 +218,8 @@ Barge-In wird unterstützt: Sprechen während der TTS-Wiedergabe unterbricht und
 │  ┌──────────────────────────────────────┐    │
 │  │  speech_core_models (Git-Submodul)   │    │
 │  │   SileroVad / ParakeetStt /          │    │
-│  │   KokoroTts / DeepFilterEnhancer     │    │
+│  │   KokoroTts / OnnxPocketTts /        │    │
+│  │   DeepFilterEnhancer                  │    │
 │  │            │                         │    │
 │  │            ▼                         │    │
 │  │  speech_core  (Orchestrierung:       │    │

--- a/README_es.md
+++ b/README_es.md
@@ -76,7 +76,7 @@ git clone --recursive https://github.com/soniqo/speech-android.git
 cd speech-android
 ./setup.sh
 ./gradlew :app:assembleDebug
-./gradlew :sdk:connectedAndroidTest   # 34 pruebas e2e
+./gradlew :sdk:connectedAndroidTest   # 38 pruebas e2e
 ```
 
 `./setup.sh` inicializa el submódulo speech-core y descarga ONNX Runtime
@@ -95,6 +95,18 @@ El módulo [`app/`](app/) es una demo mínima de asistente de voz con:
 
 ```bash
 ./gradlew :app:installDebug
+```
+
+### Demo de control del pipeline completo
+
+La app independiente [`control-demo/`](control-demo/) ejecuta todo el agente
+localmente: Silero VAD → Parakeet-EOU STT → llamadas a herramientas con
+FunctionGemma 270M → acciones del dispositivo Android → Kokoro TTS. Muestra la
+latencia de cada etapa y enlaza directamente con el `:sdk` de este checkout,
+por lo que usa las optimizaciones de voz locales.
+
+```bash
+./gradlew :control-demo:installDebug
 ```
 
 ## Entrada de voz del sistema (`RecognitionService`)

--- a/README_es.md
+++ b/README_es.md
@@ -12,7 +12,7 @@ Reconocimiento de voz en streaming de baja memoria (25 idiomas por defecto; TDT 
 
 ## Alcance
 
-Este repositorio es el **empaquetado para Android**: SDK de Kotlin, puente JNI, app demo. El motor C++ y los envoltorios de modelos ONNX (Silero VAD, Parakeet STT, Kokoro TTS, DeepFilterNet3) viven en [speech-core](https://github.com/soniqo/speech-core) y se incorporan vía un submódulo git. Linux / automoción (Yocto, Qualcomm SA8295P/SA8255P) vive en [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux).
+Este repositorio es el **empaquetado para Android**: SDK de Kotlin, puente JNI, app demo. El motor C++ y los envoltorios de modelos ONNX (Silero VAD, Parakeet STT, Kokoro/Pocket TTS, DeepFilterNet3) viven en [speech-core](https://github.com/soniqo/speech-core) y se incorporan vía un submódulo git. Linux / automoción (Yocto, Qualcomm SA8295P/SA8255P) vive en [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux).
 
 ## Modelos
 
@@ -21,6 +21,7 @@ Este repositorio es el **empaquetado para Android**: SDK de Kotlin, puente JNI, 
 | [Parakeet-EOU 120M](https://soniqo.audio/es/guides/dictate) | STT en streaming + EOU (por defecto) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/es/guides/parakeet/android) | STT de cobertura amplia (opcional) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
 | [Kokoro 82M](https://soniqo.audio/es/guides/kokoro/android) | Texto a voz (por defecto) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Texto a voz en streaming (opcional, voz Alba fija) | ~126 MB | aún no medido | Inglés |
 | [Supertonic-3](https://soniqo.audio/es/guides/supertonic) | Texto a voz (LiteRT, flow-matching, G2P-free, 44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
 | [Silero VAD v5](https://soniqo.audio/es/guides/vad/android) | Detección de actividad de voz | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | Cualquiera |
 | [DeepFilterNet3](https://soniqo.audio/es/guides/denoise/android) | Cancelación de ruido | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | no se carga por defecto | Cualquiera |
@@ -101,7 +102,7 @@ El módulo [`app/`](app/) es una demo mínima de asistente de voz con:
 
 La app independiente [`control-demo/`](control-demo/) ejecuta todo el agente
 localmente: Silero VAD → Parakeet-EOU STT → llamadas a herramientas con
-FunctionGemma 270M → acciones del dispositivo Android → Kokoro TTS. Muestra la
+FunctionGemma 270M → acciones del dispositivo Android → Pocket TTS. Muestra la
 latencia de cada etapa y enlaza directamente con el `:sdk` de este checkout,
 por lo que usa las optimizaciones de voz locales.
 
@@ -242,7 +243,8 @@ Soporte de barge-in: hablar durante la reproducción TTS interrumpe e inicia una
 │  ┌──────────────────────────────────────┐    │
 │  │  speech_core_models (submódulo git)  │    │
 │  │   SileroVad / ParakeetStt /          │    │
-│  │   KokoroTts / DeepFilterEnhancer     │    │
+│  │   KokoroTts / OnnxPocketTts /        │    │
+│  │   DeepFilterEnhancer                  │    │
 │  │            │                         │    │
 │  │            ▼                         │    │
 │  │  speech_core  (orquestación:         │    │

--- a/README_fr.md
+++ b/README_fr.md
@@ -12,7 +12,7 @@ Reconnaissance vocale en streaming à faible mémoire (25 langues par défaut, T
 
 ## Périmètre
 
-Ce dépôt fournit le **packaging Android** : SDK Kotlin, pont JNI, application de démo. Le moteur C++ et les wrappers de modèles ONNX (Silero VAD, Parakeet STT, Kokoro TTS, DeepFilterNet3) résident dans [speech-core](https://github.com/soniqo/speech-core) et sont intégrés via un sous-module git. Le volet Linux / automobile (Yocto, Qualcomm SA8295P/SA8255P) se trouve dans [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux).
+Ce dépôt fournit le **packaging Android** : SDK Kotlin, pont JNI, application de démo. Le moteur C++ et les wrappers de modèles ONNX (Silero VAD, Parakeet STT, Kokoro/Pocket TTS, DeepFilterNet3) résident dans [speech-core](https://github.com/soniqo/speech-core) et sont intégrés via un sous-module git. Le volet Linux / automobile (Yocto, Qualcomm SA8295P/SA8255P) se trouve dans [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux).
 
 ## Modèles
 
@@ -21,6 +21,7 @@ Ce dépôt fournit le **packaging Android** : SDK Kotlin, pont JNI, application 
 | [Parakeet-EOU 120M](https://soniqo.audio/fr/guides/dictate) | STT streaming + EOU (défaut) | [153 Mo](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 Mo | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/fr/guides/parakeet/android) | STT large couverture (optionnel) | [891 Mo](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1,1-1,3 Go | 114 |
 | [Kokoro 82M](https://soniqo.audio/fr/guides/kokoro/android) | Synthèse vocale (défaut) | [330 Mo](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 Mo | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Synthèse vocale streaming (optionnel, voix Alba fixe) | ~126 Mo | pas encore mesuré | Anglais |
 | [Supertonic-3](https://soniqo.audio/fr/guides/supertonic) | Synthèse vocale (LiteRT, flow-matching, G2P-free, 44,1 kHz) | [~380 Mo](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 Mo | 31 |
 | [Silero VAD v5](https://soniqo.audio/fr/guides/vad/android) | Détection d'activité vocale | [2 Mo](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 Mo | Toutes |
 | [DeepFilterNet3](https://soniqo.audio/fr/guides/denoise/android) | Suppression de bruit | [~8 Mo](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | non chargé par défaut | Toutes |
@@ -101,7 +102,7 @@ Le module [`app/`](app/) est une démo minimale d'assistant vocal avec :
 
 L'app séparée [`control-demo/`](control-demo/) exécute tout l'agent localement :
 Silero VAD → Parakeet-EOU STT → appels d'outils FunctionGemma 270M → actions sur
-l'appareil Android → Kokoro TTS. Elle affiche la latence de chaque étape et se
+l'appareil Android → Pocket TTS. Elle affiche la latence de chaque étape et se
 lie directement au `:sdk` de ce checkout, afin d'utiliser les optimisations
 vocales locales.
 
@@ -217,7 +218,8 @@ Le barge-in est pris en charge : parler pendant la lecture TTS l'interrompt et d
 │  ┌──────────────────────────────────────┐    │
 │  │  speech_core_models (sous-module)    │    │
 │  │   SileroVad / ParakeetStt /          │    │
-│  │   KokoroTts / DeepFilterEnhancer     │    │
+│  │   KokoroTts / OnnxPocketTts /        │    │
+│  │   DeepFilterEnhancer                  │    │
 │  │            │                         │    │
 │  │            ▼                         │    │
 │  │  speech_core  (orchestration :       │    │

--- a/README_fr.md
+++ b/README_fr.md
@@ -76,7 +76,7 @@ git clone --recursive https://github.com/soniqo/speech-android.git
 cd speech-android
 ./setup.sh
 ./gradlew :app:assembleDebug
-./gradlew :sdk:connectedAndroidTest   # 34 tests e2e
+./gradlew :sdk:connectedAndroidTest   # 38 tests e2e
 ```
 
 `./setup.sh` initialise le sous-module speech-core et télécharge ONNX Runtime
@@ -95,6 +95,18 @@ Le module [`app/`](app/) est une démo minimale d'assistant vocal avec :
 
 ```bash
 ./gradlew :app:installDebug
+```
+
+### Démo de contrôle du pipeline complet
+
+L'app séparée [`control-demo/`](control-demo/) exécute tout l'agent localement :
+Silero VAD → Parakeet-EOU STT → appels d'outils FunctionGemma 270M → actions sur
+l'appareil Android → Kokoro TTS. Elle affiche la latence de chaque étape et se
+lie directement au `:sdk` de ce checkout, afin d'utiliser les optimisations
+vocales locales.
+
+```bash
+./gradlew :control-demo:installDebug
 ```
 
 ## Entrée vocale système (`RecognitionService`)

--- a/README_hi.md
+++ b/README_hi.md
@@ -12,7 +12,7 @@ Android के लिए ऑन-डिवाइस स्पीच SDK, [ONNX Ru
 
 ## स्कोप
 
-यह रिपॉज़िटरी **Android पैकेजिंग** है: Kotlin SDK, JNI ब्रिज, डेमो ऐप। C++ इंजन और ONNX मॉडल रैपर (Silero VAD, Parakeet STT, Kokoro TTS, DeepFilterNet3) [speech-core](https://github.com/soniqo/speech-core) में रहते हैं और एक git सबमॉड्यूल के माध्यम से शामिल किए जाते हैं। Linux / ऑटोमोटिव (Yocto, Qualcomm SA8295P/SA8255P) [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux) पर रहता है।
+यह रिपॉज़िटरी **Android पैकेजिंग** है: Kotlin SDK, JNI ब्रिज, डेमो ऐप। C++ इंजन और ONNX मॉडल रैपर (Silero VAD, Parakeet STT, Kokoro/Pocket TTS, DeepFilterNet3) [speech-core](https://github.com/soniqo/speech-core) में रहते हैं और एक git सबमॉड्यूल के माध्यम से शामिल किए जाते हैं। Linux / ऑटोमोटिव (Yocto, Qualcomm SA8295P/SA8255P) [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux) पर रहता है।
 
 ## मॉडल
 
@@ -21,6 +21,7 @@ Android के लिए ऑन-डिवाइस स्पीच SDK, [ONNX Ru
 | [Parakeet-EOU 120M](https://soniqo.audio/hi/guides/dictate) | स्ट्रीमिंग STT + EOU (डिफ़ॉल्ट) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/hi/guides/parakeet/android) | व्यापक STT (वैकल्पिक) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
 | [Kokoro 82M](https://soniqo.audio/hi/guides/kokoro/android) | टेक्स्ट-टू-स्पीच (डिफ़ॉल्ट) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | स्ट्रीमिंग टेक्स्ट-टू-स्पीच (वैकल्पिक, स्थिर Alba आवाज़) | ~126 MB | अभी मापा नहीं गया | अंग्रेज़ी |
 | [Supertonic-3](https://soniqo.audio/hi/guides/supertonic) | टेक्स्ट-टू-स्पीच (LiteRT, फ़्लो-मैचिंग, G2P-free, 44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
 | [Silero VAD v5](https://soniqo.audio/hi/guides/vad/android) | वॉयस एक्टिविटी डिटेक्शन | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | कोई भी |
 | [DeepFilterNet3](https://soniqo.audio/hi/guides/denoise/android) | शोर रद्दीकरण | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | डिफ़ॉल्ट रूप से लोड नहीं | कोई भी |
@@ -101,7 +102,7 @@ cd speech-android
 
 अलग [`control-demo/`](control-demo/) ऐप पूरे एजेंट को स्थानीय रूप से चलाता है:
 Silero VAD → Parakeet-EOU STT → FunctionGemma 270M टूल कॉल → Android डिवाइस
-एक्शन → Kokoro TTS। यह हर चरण की लेटेंसी दिखाता है और इस checkout के `:sdk`
+एक्शन → Pocket TTS। यह हर चरण की लेटेंसी दिखाता है और इस checkout के `:sdk`
 से सीधे लिंक होता है, इसलिए स्थानीय स्पीच ऑप्टिमाइज़ेशन उपयोग होते हैं।
 
 ```bash
@@ -215,7 +216,8 @@ Idle → Listening → Transcribing → Speaking → Idle
 │  ┌──────────────────────────────────────┐    │
 │  │  speech_core_models (git submodule)  │    │
 │  │   SileroVad / ParakeetStt /          │    │
-│  │   KokoroTts / DeepFilterEnhancer     │    │
+│  │   KokoroTts / OnnxPocketTts /        │    │
+│  │   DeepFilterEnhancer                  │    │
 │  │            │                         │    │
 │  │            ▼                         │    │
 │  │  speech_core  (orchestration:        │    │

--- a/README_hi.md
+++ b/README_hi.md
@@ -76,7 +76,7 @@ git clone --recursive https://github.com/soniqo/speech-android.git
 cd speech-android
 ./setup.sh
 ./gradlew :app:assembleDebug
-./gradlew :sdk:connectedAndroidTest   # 34 e2e परीक्षण
+./gradlew :sdk:connectedAndroidTest   # 38 e2e परीक्षण
 ```
 
 `./setup.sh` speech-core सबमॉड्यूल को इनिशियलाइज़ करता है और ONNX Runtime को
@@ -95,6 +95,17 @@ cd speech-android
 
 ```bash
 ./gradlew :app:installDebug
+```
+
+### पूर्ण-पाइपलाइन कंट्रोल डेमो
+
+अलग [`control-demo/`](control-demo/) ऐप पूरे एजेंट को स्थानीय रूप से चलाता है:
+Silero VAD → Parakeet-EOU STT → FunctionGemma 270M टूल कॉल → Android डिवाइस
+एक्शन → Kokoro TTS। यह हर चरण की लेटेंसी दिखाता है और इस checkout के `:sdk`
+से सीधे लिंक होता है, इसलिए स्थानीय स्पीच ऑप्टिमाइज़ेशन उपयोग होते हैं।
+
+```bash
+./gradlew :control-demo:installDebug
 ```
 
 ## सिस्टम वॉयस इनपुट (`RecognitionService`)

--- a/README_ja.md
+++ b/README_ja.md
@@ -76,7 +76,7 @@ git clone --recursive https://github.com/soniqo/speech-android.git
 cd speech-android
 ./setup.sh
 ./gradlew :app:assembleDebug
-./gradlew :sdk:connectedAndroidTest   # 34 個の e2e テスト
+./gradlew :sdk:connectedAndroidTest   # 38 個の e2e テスト
 ```
 
 `./setup.sh` は speech-core サブモジュールを初期化し、ONNX Runtime を
@@ -95,6 +95,18 @@ cd speech-android
 
 ```bash
 ./gradlew :app:installDebug
+```
+
+### フルパイプライン制御デモ
+
+独立した [`control-demo/`](control-demo/) アプリは、Silero VAD →
+Parakeet-EOU STT → FunctionGemma 270M ツール呼び出し → Android
+デバイス操作 → Kokoro TTS というエージェント全体をローカルで実行します。
+各段階のレイテンシを表示し、このチェックアウトの `:sdk` に直接リンクするため、
+ローカルの音声最適化が使われます。
+
+```bash
+./gradlew :control-demo:installDebug
 ```
 
 ## システム音声入力(`RecognitionService`)

--- a/README_ja.md
+++ b/README_ja.md
@@ -12,7 +12,7 @@
 
 ## スコープ
 
-このリポジトリは **Android パッケージング** を担当します:Kotlin SDK、JNI ブリッジ、デモアプリ。C++ エンジンおよび ONNX モデルラッパー(Silero VAD、Parakeet STT、Kokoro TTS、DeepFilterNet3)は [speech-core](https://github.com/soniqo/speech-core) に存在し、git サブモジュールとして取り込まれます。Linux / 自動車向け(Yocto、Qualcomm SA8295P/SA8255P)は [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux) に存在します。
+このリポジトリは **Android パッケージング** を担当します:Kotlin SDK、JNI ブリッジ、デモアプリ。C++ エンジンおよび ONNX モデルラッパー(Silero VAD、Parakeet STT、Kokoro/Pocket TTS、DeepFilterNet3)は [speech-core](https://github.com/soniqo/speech-core) に存在し、git サブモジュールとして取り込まれます。Linux / 自動車向け(Yocto、Qualcomm SA8295P/SA8255P)は [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux) に存在します。
 
 ## モデル
 
@@ -21,6 +21,7 @@
 | [Parakeet-EOU 120M](https://soniqo.audio/ja/guides/dictate) | ストリーミング STT + EOU(既定) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/ja/guides/parakeet/android) | 広範囲 STT(任意) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
 | [Kokoro 82M](https://soniqo.audio/ja/guides/kokoro/android) | テキスト読み上げ(既定) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
+| [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | ストリーミング音声合成(任意、固定 Alba 音声) | ~126 MB | 未計測 | 英語 |
 | [Supertonic-3](https://soniqo.audio/ja/guides/supertonic) | テキスト読み上げ(LiteRT、flow-matching、G2P-free、44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
 | [Silero VAD v5](https://soniqo.audio/ja/guides/vad/android) | 音声活動検出 | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | 任意 |
 | [DeepFilterNet3](https://soniqo.audio/ja/guides/denoise/android) | ノイズキャンセリング | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 既定では未ロード | 任意 |
@@ -101,7 +102,7 @@ cd speech-android
 
 独立した [`control-demo/`](control-demo/) アプリは、Silero VAD →
 Parakeet-EOU STT → FunctionGemma 270M ツール呼び出し → Android
-デバイス操作 → Kokoro TTS というエージェント全体をローカルで実行します。
+デバイス操作 → Pocket TTS というエージェント全体をローカルで実行します。
 各段階のレイテンシを表示し、このチェックアウトの `:sdk` に直接リンクするため、
 ローカルの音声最適化が使われます。
 
@@ -216,7 +217,8 @@ Idle → Listening → Transcribing → Speaking → Idle
 │  ┌──────────────────────────────────────┐    │
 │  │  speech_core_models (git サブモジュール) │    │
 │  │   SileroVad / ParakeetStt /          │    │
-│  │   KokoroTts / DeepFilterEnhancer     │    │
+│  │   KokoroTts / OnnxPocketTts /        │    │
+│  │   DeepFilterEnhancer                  │    │
 │  │            │                         │    │
 │  │            ▼                         │    │
 │  │  speech_core  (オーケストレーション:    │    │

--- a/README_ko.md
+++ b/README_ko.md
@@ -12,7 +12,7 @@
 
 ## 범위
 
-이 저장소는 **Android 패키징**입니다: Kotlin SDK, JNI 브리지, 데모 앱. C++ 엔진과 ONNX 모델 래퍼(Silero VAD, Parakeet STT, Kokoro TTS, DeepFilterNet3)는 [speech-core](https://github.com/soniqo/speech-core)에 있으며 git 서브모듈을 통해 가져옵니다. Linux / 자동차(Yocto, Qualcomm SA8295P/SA8255P)는 [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux)에 있습니다.
+이 저장소는 **Android 패키징**입니다: Kotlin SDK, JNI 브리지, 데모 앱. C++ 엔진과 ONNX 모델 래퍼(Silero VAD, Parakeet STT, Kokoro/Pocket TTS, DeepFilterNet3)는 [speech-core](https://github.com/soniqo/speech-core)에 있으며 git 서브모듈을 통해 가져옵니다. Linux / 자동차(Yocto, Qualcomm SA8295P/SA8255P)는 [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux)에 있습니다.
 
 ## 모델
 
@@ -21,6 +21,7 @@
 | [Parakeet-EOU 120M](https://soniqo.audio/ko/guides/dictate) | 스트리밍 STT + EOU(기본) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/ko/guides/parakeet/android) | 광범위 STT(선택) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
 | [Kokoro 82M](https://soniqo.audio/ko/guides/kokoro/android) | 텍스트 음성 변환(기본) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8(en, fr, es, it, pt, hi, ja, zh) |
+| [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | 스트리밍 음성 합성(선택, 고정 Alba 음성) | ~126 MB | 미측정 | 영어 |
 | [Supertonic-3](https://soniqo.audio/ko/guides/supertonic) | 텍스트 음성 변환(LiteRT, flow-matching, G2P-free, 44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
 | [Silero VAD v5](https://soniqo.audio/ko/guides/vad/android) | 음성 활동 감지 | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | 모든 언어 |
 | [DeepFilterNet3](https://soniqo.audio/ko/guides/denoise/android) | 노이즈 캔슬링 | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 기본으로 로드하지 않음 | 모든 언어 |
@@ -101,7 +102,7 @@ cd speech-android
 
 별도의 [`control-demo/`](control-demo/) 앱은 Silero VAD →
 Parakeet-EOU STT → FunctionGemma 270M 도구 호출 → Android 기기 동작 →
-Kokoro TTS로 이어지는 전체 에이전트를 로컬에서 실행합니다. 단계별 지연 시간을
+Pocket TTS로 이어지는 전체 에이전트를 로컬에서 실행합니다. 단계별 지연 시간을
 표시하고 이 체크아웃의 `:sdk`에 직접 연결하므로 로컬 음성 최적화를 사용합니다.
 
 ```bash
@@ -215,7 +216,8 @@ Idle → Listening → Transcribing → Speaking → Idle
 │  ┌──────────────────────────────────────┐    │
 │  │  speech_core_models (git submodule)  │    │
 │  │   SileroVad / ParakeetStt /          │    │
-│  │   KokoroTts / DeepFilterEnhancer     │    │
+│  │   KokoroTts / OnnxPocketTts /        │    │
+│  │   DeepFilterEnhancer                  │    │
 │  │            │                         │    │
 │  │            ▼                         │    │
 │  │  speech_core  (orchestration:        │    │

--- a/README_ko.md
+++ b/README_ko.md
@@ -76,7 +76,7 @@ git clone --recursive https://github.com/soniqo/speech-android.git
 cd speech-android
 ./setup.sh
 ./gradlew :app:assembleDebug
-./gradlew :sdk:connectedAndroidTest   # 34개 e2e 테스트
+./gradlew :sdk:connectedAndroidTest   # 38개 e2e 테스트
 ```
 
 `./setup.sh`는 speech-core 서브모듈을 초기화하고 ONNX Runtime을
@@ -95,6 +95,17 @@ cd speech-android
 
 ```bash
 ./gradlew :app:installDebug
+```
+
+### 전체 파이프라인 제어 데모
+
+별도의 [`control-demo/`](control-demo/) 앱은 Silero VAD →
+Parakeet-EOU STT → FunctionGemma 270M 도구 호출 → Android 기기 동작 →
+Kokoro TTS로 이어지는 전체 에이전트를 로컬에서 실행합니다. 단계별 지연 시간을
+표시하고 이 체크아웃의 `:sdk`에 직접 연결하므로 로컬 음성 최적화를 사용합니다.
+
+```bash
+./gradlew :control-demo:installDebug
 ```
 
 ## 시스템 음성 입력(`RecognitionService`)

--- a/README_pt.md
+++ b/README_pt.md
@@ -12,7 +12,7 @@ Reconhecimento de fala em streaming com baixa memória (25 idiomas por padrão, 
 
 ## Escopo
 
-Este repositório é o **empacotamento Android**: SDK Kotlin, ponte JNI, app de demonstração. O motor C++ e os wrappers de modelo ONNX (Silero VAD, Parakeet STT, Kokoro TTS, DeepFilterNet3) ficam em [speech-core](https://github.com/soniqo/speech-core) e são incorporados via submódulo git. Linux / automotivo (Yocto, Qualcomm SA8295P/SA8255P) está em [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux).
+Este repositório é o **empacotamento Android**: SDK Kotlin, ponte JNI, app de demonstração. O motor C++ e os wrappers de modelo ONNX (Silero VAD, Parakeet STT, Kokoro/Pocket TTS, DeepFilterNet3) ficam em [speech-core](https://github.com/soniqo/speech-core) e são incorporados via submódulo git. Linux / automotivo (Yocto, Qualcomm SA8295P/SA8255P) está em [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux).
 
 ## Modelos
 
@@ -21,6 +21,7 @@ Este repositório é o **empacotamento Android**: SDK Kotlin, ponte JNI, app de 
 | [Parakeet-EOU 120M](https://soniqo.audio/pt/guides/dictate) | STT em streaming + EOU (padrão) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/pt/guides/parakeet/android) | STT de ampla cobertura (opcional) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1,1-1,3 GB | 114 |
 | [Kokoro 82M](https://soniqo.audio/pt/guides/kokoro/android) | Texto para fala (padrão) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Texto para fala em streaming (opcional, voz Alba fixa) | ~126 MB | ainda não medido | Inglês |
 | [Supertonic-3](https://soniqo.audio/pt/guides/supertonic) | Texto para fala (LiteRT, flow-matching, G2P-free, 44,1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
 | [Silero VAD v5](https://soniqo.audio/pt/guides/vad/android) | Detecção de atividade vocal | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | Qualquer |
 | [DeepFilterNet3](https://soniqo.audio/pt/guides/denoise/android) | Cancelamento de ruído | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | não carregado por padrão | Qualquer |
@@ -101,7 +102,7 @@ O módulo [`app/`](app/) é uma demo mínima de assistente de voz com:
 
 O app separado [`control-demo/`](control-demo/) executa todo o agente
 localmente: Silero VAD → Parakeet-EOU STT → chamadas de ferramentas do
-FunctionGemma 270M → ações do dispositivo Android → Kokoro TTS. Ele mostra a
+FunctionGemma 270M → ações do dispositivo Android → Pocket TTS. Ele mostra a
 latência de cada etapa e vincula diretamente o `:sdk` deste checkout, usando
 assim as otimizações locais de voz.
 
@@ -240,7 +241,8 @@ Suporte a barge-in: falar durante a reprodução TTS interrompe e inicia uma nov
 │  ┌──────────────────────────────────────┐    │
 │  │  speech_core_models (submódulo git)  │    │
 │  │   SileroVad / ParakeetStt /          │    │
-│  │   KokoroTts / DeepFilterEnhancer     │    │
+│  │   KokoroTts / OnnxPocketTts /        │    │
+│  │   DeepFilterEnhancer                  │    │
 │  │            │                         │    │
 │  │            ▼                         │    │
 │  │  speech_core  (orquestração:         │    │

--- a/README_pt.md
+++ b/README_pt.md
@@ -76,7 +76,7 @@ git clone --recursive https://github.com/soniqo/speech-android.git
 cd speech-android
 ./setup.sh
 ./gradlew :app:assembleDebug
-./gradlew :sdk:connectedAndroidTest   # 34 testes e2e
+./gradlew :sdk:connectedAndroidTest   # 38 testes e2e
 ```
 
 `./setup.sh` inicializa o submódulo speech-core e baixa o ONNX Runtime
@@ -95,6 +95,18 @@ O módulo [`app/`](app/) é uma demo mínima de assistente de voz com:
 
 ```bash
 ./gradlew :app:installDebug
+```
+
+### Demo de controle do pipeline completo
+
+O app separado [`control-demo/`](control-demo/) executa todo o agente
+localmente: Silero VAD → Parakeet-EOU STT → chamadas de ferramentas do
+FunctionGemma 270M → ações do dispositivo Android → Kokoro TTS. Ele mostra a
+latência de cada etapa e vincula diretamente o `:sdk` deste checkout, usando
+assim as otimizações locais de voz.
+
+```bash
+./gradlew :control-demo:installDebug
 ```
 
 ## Entrada de voz do sistema (`RecognitionService`)

--- a/README_ru.md
+++ b/README_ru.md
@@ -76,7 +76,7 @@ git clone --recursive https://github.com/soniqo/speech-android.git
 cd speech-android
 ./setup.sh
 ./gradlew :app:assembleDebug
-./gradlew :sdk:connectedAndroidTest   # 34 e2e-теста
+./gradlew :sdk:connectedAndroidTest   # 38 e2e-тестов
 ```
 
 `./setup.sh` инициализирует submodule speech-core и загружает ONNX Runtime
@@ -95,6 +95,18 @@ cd speech-android
 
 ```bash
 ./gradlew :app:installDebug
+```
+
+### Демо полного конвейера управления
+
+Отдельное приложение [`control-demo/`](control-demo/) локально запускает
+полного агента: Silero VAD → Parakeet-EOU STT → вызовы инструментов
+FunctionGemma 270M → действия Android-устройства → Kokoro TTS. Оно показывает
+задержку каждого этапа и напрямую подключает `:sdk` из этой рабочей копии,
+поэтому использует локальные оптимизации речи.
+
+```bash
+./gradlew :control-demo:installDebug
 ```
 
 ## Системный голосовой ввод (`RecognitionService`)

--- a/README_ru.md
+++ b/README_ru.md
@@ -12,7 +12,7 @@
 
 ## Область применения
 
-Этот репозиторий — **Android-обёртка**: Kotlin SDK, JNI-мост, демо-приложение. C++-движок и обёртки ONNX-моделей (Silero VAD, Parakeet STT, Kokoro TTS, DeepFilterNet3) находятся в [speech-core](https://github.com/soniqo/speech-core) и подключаются через git-submodule. Linux / автомобильные системы (Yocto, Qualcomm SA8295P/SA8255P) — в [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux).
+Этот репозиторий — **Android-обёртка**: Kotlin SDK, JNI-мост, демо-приложение. C++-движок и обёртки ONNX-моделей (Silero VAD, Parakeet STT, Kokoro/Pocket TTS, DeepFilterNet3) находятся в [speech-core](https://github.com/soniqo/speech-core) и подключаются через git-submodule. Linux / автомобильные системы (Yocto, Qualcomm SA8295P/SA8255P) — в [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux).
 
 ## Модели
 
@@ -21,6 +21,7 @@
 | [Parakeet-EOU 120M](https://soniqo.audio/ru/guides/dictate) | Потоковый STT + EOU (по умолчанию) | [153 МБ](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 МБ | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/ru/guides/parakeet/android) | STT с широким покрытием (опционально) | [891 МБ](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1,1-1,3 ГБ | 114 |
 | [Kokoro 82M](https://soniqo.audio/ru/guides/kokoro/android) | Синтез речи (по умолчанию) | [330 МБ](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 МБ | 8 (en, fr, es, it, pt, hi, ja, zh) |
+| [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Потоковый синтез речи (опционально, фиксированный голос Alba) | ~126 МБ | ещё не измерено | Английский |
 | [Supertonic-3](https://soniqo.audio/ru/guides/supertonic) | Синтез речи (LiteRT, flow-matching, G2P-free, 44,1 кГц) | [~380 МБ](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 МБ | 31 |
 | [Silero VAD v5](https://soniqo.audio/ru/guides/vad/android) | Определение голосовой активности | [2 МБ](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 МБ | Любой |
 | [DeepFilterNet3](https://soniqo.audio/ru/guides/denoise/android) | Шумоподавление | [~8 МБ](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | по умолчанию не загружается | Любой |
@@ -101,7 +102,7 @@ cd speech-android
 
 Отдельное приложение [`control-demo/`](control-demo/) локально запускает
 полного агента: Silero VAD → Parakeet-EOU STT → вызовы инструментов
-FunctionGemma 270M → действия Android-устройства → Kokoro TTS. Оно показывает
+FunctionGemma 270M → действия Android-устройства → Pocket TTS. Оно показывает
 задержку каждого этапа и напрямую подключает `:sdk` из этой рабочей копии,
 поэтому использует локальные оптимизации речи.
 
@@ -217,7 +218,8 @@ Idle → Listening → Transcribing → Speaking → Idle
 │  ┌──────────────────────────────────────┐    │
 │  │  speech_core_models (git submodule)  │    │
 │  │   SileroVad / ParakeetStt /          │    │
-│  │   KokoroTts / DeepFilterEnhancer     │    │
+│  │   KokoroTts / OnnxPocketTts /        │    │
+│  │   DeepFilterEnhancer                  │    │
 │  │            │                         │    │
 │  │            ▼                         │    │
 │  │  speech_core  (оркестрация:          │    │

--- a/README_zh.md
+++ b/README_zh.md
@@ -12,7 +12,7 @@
 
 ## 范围
 
-本仓库是 **Android 打包**:Kotlin SDK、JNI 桥接、演示应用。C++ 引擎和 ONNX 模型封装(Silero VAD、Parakeet STT、Kokoro TTS、DeepFilterNet3)位于 [speech-core](https://github.com/soniqo/speech-core),通过 git 子模块引入。Linux / 汽车(Yocto、Qualcomm SA8295P/SA8255P)位于 [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux)。
+本仓库是 **Android 打包**:Kotlin SDK、JNI 桥接、演示应用。C++ 引擎和 ONNX 模型封装(Silero VAD、Parakeet STT、Kokoro/Pocket TTS、DeepFilterNet3)位于 [speech-core](https://github.com/soniqo/speech-core),通过 git 子模块引入。Linux / 汽车(Yocto、Qualcomm SA8295P/SA8255P)位于 [speech-core/examples/linux](https://github.com/soniqo/speech-core/tree/main/examples/linux)。
 
 ## 模型
 
@@ -21,6 +21,7 @@
 | [Parakeet-EOU 120M](https://soniqo.audio/zh/guides/dictate) | 流式 STT + 端点检测(默认) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/zh/guides/parakeet/android) | 广覆盖 STT(可选) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
 | [Kokoro 82M](https://soniqo.audio/zh/guides/kokoro/android) | 文本转语音(默认) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
+| [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | 流式文本转语音(可选,固定 Alba 音色) | ~126 MB | 尚未测量 | 英语 |
 | [Supertonic-3](https://soniqo.audio/zh/guides/supertonic) | 文本转语音(LiteRT、流匹配、免 G2P、44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |
 | [Silero VAD v5](https://soniqo.audio/zh/guides/vad/android) | 语音活动检测 | [2 MB](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) | <10 MB | 任意 |
 | [DeepFilterNet3](https://soniqo.audio/zh/guides/denoise/android) | 噪声消除 | [~8 MB](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | 默认不加载 | 任意 |
@@ -100,7 +101,7 @@ cd speech-android
 
 独立的 [`control-demo/`](control-demo/) 应用在本地运行完整智能体:
 Silero VAD → Parakeet-EOU STT → FunctionGemma 270M 工具调用 →
-Android 设备操作 → Kokoro TTS。它显示各阶段延迟,并直接链接此检出的
+Android 设备操作 → Pocket TTS。它显示各阶段延迟,并直接链接此检出的
 `:sdk`,因此会使用本地语音优化。
 
 ```bash
@@ -214,7 +215,8 @@ Idle → Listening → Transcribing → Speaking → Idle
 │  ┌──────────────────────────────────────┐    │
 │  │  speech_core_models(git 子模块)      │    │
 │  │   SileroVad / ParakeetStt /          │    │
-│  │   KokoroTts / DeepFilterEnhancer     │    │
+│  │   KokoroTts / OnnxPocketTts /        │    │
+│  │   DeepFilterEnhancer                  │    │
 │  │            │                         │    │
 │  │            ▼                         │    │
 │  │  speech_core(编排:                  │    │

--- a/README_zh.md
+++ b/README_zh.md
@@ -76,7 +76,7 @@ git clone --recursive https://github.com/soniqo/speech-android.git
 cd speech-android
 ./setup.sh
 ./gradlew :app:assembleDebug
-./gradlew :sdk:connectedAndroidTest   # 34 个端到端测试
+./gradlew :sdk:connectedAndroidTest   # 38 个端到端测试
 ```
 
 `./setup.sh` 会初始化 speech-core 子模块并将 ONNX Runtime 下载到 `./ort/`。
@@ -94,6 +94,17 @@ cd speech-android
 
 ```bash
 ./gradlew :app:installDebug
+```
+
+### 完整管线控制演示
+
+独立的 [`control-demo/`](control-demo/) 应用在本地运行完整智能体:
+Silero VAD → Parakeet-EOU STT → FunctionGemma 270M 工具调用 →
+Android 设备操作 → Kokoro TTS。它显示各阶段延迟,并直接链接此检出的
+`:sdk`,因此会使用本地语音优化。
+
+```bash
+./gradlew :control-demo:installDebug
 ```
 
 ## 系统语音输入(`RecognitionService`)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("com.android.application") version "8.7.0" apply false
-    id("com.android.library") version "8.7.0" apply false
+    id("com.android.application") version "8.13.2" apply false
+    id("com.android.library") version "8.13.2" apply false
     // LiteRT-LM 0.14.0 publishes Kotlin 2.3 metadata, which requires the
     // Kotlin 2.2 compiler used by the full-pipeline Compose demo.
     id("org.jetbrains.kotlin.android") version "2.2.21" apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
     id("com.android.application") version "8.7.0" apply false
     id("com.android.library") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    // LiteRT-LM 0.14.0 publishes Kotlin 2.3 metadata, which requires the
+    // Kotlin 2.2 compiler used by the full-pipeline Compose demo.
+    id("org.jetbrains.kotlin.android") version "2.2.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.21" apply false
     id("com.vanniktech.maven.publish") version "0.30.0" apply false
 }

--- a/control-demo/README.md
+++ b/control-demo/README.md
@@ -2,19 +2,16 @@
 
 This separate application runs a complete on-device voice agent:
 
-`Silero VAD → Parakeet-EOU STT → FunctionGemma 270M → Android action → Kokoro TTS`
+`Silero VAD → Parakeet-EOU STT → FunctionGemma 270M → Android action → Pocket TTS`
 
-It links directly to this checkout's `:sdk` module, so SDK and Kokoro changes
+It links directly to this checkout's `:sdk` module, so SDK and Pocket changes
 are exercised without publishing an intermediate artifact. On first launch it
 downloads the public speech models plus two separate FunctionGemma artifacts:
 the reusable 327.4 MB Android LoRA base and the 9.5 MB Control adapter. It then
 operates without a network connection.
 
-The Control-specific FunctionGemma datasets, LoRA runner, evaluator, and
-experiment notes live in
-[`speech-models/models/functiongemma/training`](https://github.com/soniqo/speech-models/tree/main/models/functiongemma/training).
-The app always pairs the adapter with the compact prompt serialization used for
-training. The exact base and adapter files are published under
+The app always pairs the adapter with its compact prompt serialization. The
+exact base and adapter files are published under
 [`soniqo/FunctionGemma-270M-LiteRT-LM`](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM).
 
 ## Run
@@ -30,7 +27,7 @@ Grant microphone access in the app, tap the orb, and try commands such as
 "set volume to three" or "what can you do?" Contact and media commands also
 need their corresponding Android permissions.
 
-The footer shows STT, LLM, Kokoro first-audio, round-trip, and memory metrics.
+The footer shows STT, LLM, Pocket first-audio, round-trip, and memory metrics.
 The same data is available for device benchmarks with:
 
 ```bash

--- a/control-demo/README.md
+++ b/control-demo/README.md
@@ -45,10 +45,10 @@ adb logcat -s SpeechControl | grep 'TURN'
 ./gradlew :control-demo:assembleDebug
 ```
 
-The adapter instrumentation suite expects the published base and adapter plus
-the compact held-out JSONL under the test app's internal `files/` directory;
-see `LiteRtLmLoraTest` for the exact filenames. It reports route accuracy,
-argument accuracy, engine load, mean, p50, p95, and maximum generation latency.
+The adapter instrumentation suite reuses the base and adapter downloaded by
+the demo. Push only the compact held-out JSONL to `files/compact-test.jsonl`;
+see `LiteRtLmLoraTest` for details. It reports route accuracy, argument
+accuracy, engine load, mean, p50, p95, and maximum generation latency.
 
 For representative latency, benchmark a release build on the target phone.
 Emulator CPU timings are useful for functional checks but do not represent a

--- a/control-demo/README.md
+++ b/control-demo/README.md
@@ -1,0 +1,68 @@
+# Full-pipeline control demo
+
+This separate application runs a complete on-device voice agent:
+
+`Silero VAD → Parakeet-EOU STT → FunctionGemma 270M → Android action → Kokoro TTS`
+
+It links directly to this checkout's `:sdk` module, so SDK and Kokoro changes
+are exercised without publishing an intermediate artifact. On first launch it
+downloads the public speech models plus two separate FunctionGemma artifacts:
+the reusable 327.4 MB Android LoRA base and the 9.5 MB Control adapter. It then
+operates without a network connection.
+
+The Control-specific FunctionGemma datasets, LoRA runner, evaluator, and
+experiment notes live in
+[`speech-models/models/functiongemma/training`](https://github.com/soniqo/speech-models/tree/main/models/functiongemma/training).
+The app always pairs the adapter with the compact prompt serialization used for
+training. The exact base and adapter files are published under
+[`soniqo/FunctionGemma-270M-LiteRT-LM`](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM).
+
+## Run
+
+Use an arm64 Android device with at least 4 GB RAM:
+
+```bash
+./setup.sh
+./gradlew :control-demo:installDebug
+```
+
+Grant microphone access in the app, tap the orb, and try commands such as
+"set volume to three" or "what can you do?" Contact and media commands also
+need their corresponding Android permissions.
+
+The footer shows STT, LLM, Kokoro first-audio, round-trip, and memory metrics.
+The same data is available for device benchmarks with:
+
+```bash
+adb logcat -s SpeechControl | grep 'TURN'
+```
+
+## Validate
+
+```bash
+./gradlew :control-demo:testDebugUnitTest
+./gradlew :control-demo:lintDebug
+./gradlew :control-demo:assembleDebug
+```
+
+The adapter instrumentation suite expects the published base and adapter plus
+the compact held-out JSONL under the test app's internal `files/` directory;
+see `LiteRtLmLoraTest` for the exact filenames. It reports route accuracy,
+argument accuracy, engine load, mean, p50, p95, and maximum generation latency.
+
+For representative latency, benchmark a release build on the target phone.
+Emulator CPU timings are useful for functional checks but do not represent a
+Snapdragon device or its accelerators.
+
+### Apple Silicon emulator workaround
+
+If an arm64 emulator crashes in `liblitertlm_jni.so` on `RDSVL`, add the
+following line to that AVD's `config.ini` and cold-boot it:
+
+```ini
+kernel.parameters=arm64.nosme arm64.nosve
+```
+
+Some Apple Silicon/Android emulator combinations advertise SME/SVE to the
+guest even when those instructions are not available through virtualization.
+The kernel flags keep LiteRT-LM's XNNPack backend on supported NEON kernels.

--- a/control-demo/build.gradle.kts
+++ b/control-demo/build.gradle.kts
@@ -1,0 +1,65 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
+}
+
+android {
+    namespace = "audio.soniqo.speech.control"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "audio.soniqo.speech.control"
+        minSdk = 26
+        targetSdk = 35
+        versionCode = (findProperty("VERSION_CODE")?.toString()?.toIntOrNull() ?: 1)
+        versionName = (findProperty("VERSION_NAME")?.toString() ?: "dev")
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    // Use this checkout directly so speech, including Kokoro optimizations,
+    // is always exercised through the local SDK under development.
+    implementation(project(":sdk"))
+
+    // FunctionGemma runs in the app rather than the SDK, keeping LiteRT-LM
+    // out of the published speech artifact.
+    implementation("com.google.ai.edge.litertlm:litertlm-android:0.14.0")
+    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.activity:activity-ktx:1.9.0")
+    implementation("androidx.work:work-runtime-ktx:2.11.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
+
+    implementation(platform("androidx.compose:compose-bom:2024.12.01"))
+    implementation("androidx.activity:activity-compose:1.9.3")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.animation:animation")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test:runner:1.6.2")
+}

--- a/control-demo/build.gradle.kts
+++ b/control-demo/build.gradle.kts
@@ -39,7 +39,7 @@ android {
 }
 
 dependencies {
-    // Use this checkout directly so speech, including Kokoro optimizations,
+    // Use this checkout directly so speech, including Pocket streaming,
     // is always exercised through the local SDK under development.
     implementation(project(":sdk"))
 

--- a/control-demo/src/androidTest/kotlin/audio/soniqo/speech/control/KokoroLatencyTest.kt
+++ b/control-demo/src/androidTest/kotlin/audio/soniqo/speech/control/KokoroLatencyTest.kt
@@ -1,0 +1,186 @@
+package audio.soniqo.speech.control
+
+import android.os.SystemClock
+import android.system.Os
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import audio.soniqo.speech.ModelManager
+import audio.soniqo.speech.PipelineMode
+import audio.soniqo.speech.SpeechConfig
+import audio.soniqo.speech.SpeechPipeline
+import audio.soniqo.speech.SpeechSynthesizer
+import audio.soniqo.speech.SpeechSynthesizerConfig
+import audio.soniqo.speech.TtsModel
+import java.io.File
+import kotlin.math.ceil
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Opt-in physical-device benchmark for the first control-agent speech chunk.
+ *
+ * Run with `-e runKokoroLatency true`; `-e useNnapi true` selects NNAPI.
+ * The demo must have completed its first-run model download beforehand.
+ */
+@RunWith(AndroidJUnit4::class)
+class KokoroLatencyTest {
+
+    @Test
+    fun reportsFirstChunkLatency() {
+        val args = InstrumentationRegistry.getArguments()
+        assumeTrue(
+            "set -e runKokoroLatency true to run the Kokoro latency benchmark",
+            args.getString("runKokoroLatency") == "true",
+        )
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val modelDir = File(ModelManager.modelDir(context))
+        require(File(modelDir, "kokoro-e2e-realtime.onnx").isFile) {
+            "Launch the demo to download ${modelDir.absolutePath}"
+        }
+        require(File(modelDir, "kokoro-e2e.onnx.data").isFile)
+
+        val useNnapi = args.getString("useNnapi")?.toBoolean() == true
+        val threads = args.getString("kokoroThreads")
+            ?.toIntOrNull()
+            ?.takeIf { it > 0 }
+        threads?.let {
+            Os.setenv("SPEECH_CORE_KOKORO_ORT_THREADS", it.toString(), true)
+        }
+        val loadStart = SystemClock.elapsedRealtimeNanos()
+        SpeechSynthesizer(
+            SpeechSynthesizerConfig(
+                modelDir = modelDir.absolutePath,
+                useNnapi = useNnapi,
+                ttsModel = TtsModel.KOKORO_SHORT_TURN,
+            ),
+        ).use { synthesizer ->
+            val loadMs = elapsedMs(loadStart)
+            // Exclude first-run allocator/page-fault effects from the warm figures.
+            val warmup = synthesizer.synthesize("Ready when you are.", "en")
+            assertTrue(warmup.pcm16.isNotEmpty())
+
+            val latencies = buildList {
+                repeat(10) {
+                    val start = SystemClock.elapsedRealtimeNanos()
+                    val result = synthesizer.synthesize("I can call your contacts,", "en")
+                    add(elapsedMs(start))
+                    assertTrue(result.pcm16.isNotEmpty())
+                }
+            }.sorted()
+
+            val mean = latencies.average()
+            val p50 = percentile(latencies, 0.50)
+            val p95 = percentile(latencies, 0.95)
+            println(
+                "KOKORO_LATENCY backend=${if (useNnapi) "nnapi" else "cpu"} " +
+                    "threads=${threads ?: "default"} " +
+                    "load_ms=$loadMs samples=${latencies.size} mean_ms=$mean " +
+                    "p50_ms=$p50 p95_ms=$p95 max_ms=${latencies.last()}",
+            )
+        }
+    }
+
+    @Test
+    fun nativeStreamingDeliversBeforeTheWholeReply() {
+        val args = InstrumentationRegistry.getArguments()
+        assumeTrue(
+            "set -e runKokoroStreaming true to run the JNI streaming check",
+            args.getString("runKokoroStreaming") == "true",
+        )
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val modelDir = File(ModelManager.modelDir(context))
+        require(File(modelDir, "kokoro-e2e-realtime.onnx").isFile)
+        val useNnapi = args.getString("useNnapi")?.toBoolean() == true
+        SpeechPipeline(
+            SpeechConfig(
+                modelDir = modelDir.absolutePath,
+                useNnapi = useNnapi,
+                pipelineMode = PipelineMode.TRANSCRIBE_ONLY,
+                language = "en",
+            ),
+        ).use { pipeline ->
+            val start = SystemClock.elapsedRealtimeNanos()
+            var firstChunkMs = 0L
+            var chunks = 0
+            var pcmBytes = 0L
+            var sawFinal = false
+            pipeline.synthesizeStreaming(
+                "I can call your contacts, dial numbers, look up phone numbers, " +
+                    "play or stop music,",
+                "en",
+            ) { chunk, isFinal ->
+                if (firstChunkMs == 0L) firstChunkMs = elapsedMs(start)
+                chunks++
+                pcmBytes += chunk.pcm16.size
+                sawFinal = isFinal
+            }
+            val totalMs = elapsedMs(start)
+            println(
+                "KOKORO_STREAMING backend=${if (useNnapi) "nnapi" else "cpu"} " +
+                    "first_chunk_ms=$firstChunkMs total_ms=$totalMs " +
+                    "chunks=$chunks pcm_bytes=$pcmBytes",
+            )
+            assertTrue("expected retry output to contain multiple chunks", chunks >= 2)
+            assertTrue("first chunk must precede buffered completion", firstChunkMs < totalMs)
+            assertTrue("final callback missing", sawFinal)
+            assertTrue("streamed PCM must not be empty", pcmBytes > 0)
+        }
+    }
+
+    @Test
+    fun optimizedControlReplyAvoidsNativeRetry() {
+        val args = InstrumentationRegistry.getArguments()
+        assumeTrue(
+            "set -e runOptimizedReply true to run the control-reply check",
+            args.getString("runOptimizedReply") == "true",
+        )
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val modelDir = File(ModelManager.modelDir(context))
+        require(File(modelDir, "kokoro-e2e-realtime.onnx").isFile)
+        val useNnapi = args.getString("useNnapi")?.toBoolean() == true
+        SpeechPipeline(
+            SpeechConfig(
+                modelDir = modelDir.absolutePath,
+                useNnapi = useNnapi,
+                pipelineMode = PipelineMode.TRANSCRIBE_ONLY,
+                language = "en",
+            ),
+        ).use { pipeline ->
+            val pieces = SpeechChunks.split(ControlTools.CAPABILITIES_SUMMARY)
+            val start = SystemClock.elapsedRealtimeNanos()
+            var firstChunkMs = 0L
+            var nativeChunks = 0
+            var pcmBytes = 0L
+            for (piece in pieces) {
+                pipeline.synthesizeStreaming(piece, "en") { chunk, _ ->
+                    if (firstChunkMs == 0L) firstChunkMs = elapsedMs(start)
+                    nativeChunks++
+                    pcmBytes += chunk.pcm16.size
+                }
+            }
+            val totalMs = elapsedMs(start)
+            val audioSeconds = pcmBytes / 2.0 / pipeline.ttsSampleRate
+            println(
+                "KOKORO_OPTIMIZED backend=${if (useNnapi) "nnapi" else "cpu"} " +
+                    "first_chunk_ms=$firstChunkMs total_ms=$totalMs " +
+                    "app_pieces=${pieces.size} native_chunks=$nativeChunks " +
+                    "audio_s=$audioSeconds synth_rtf=${totalMs / 1_000.0 / audioSeconds}",
+            )
+            assertTrue("every app piece should need one native run", nativeChunks == pieces.size)
+            assertTrue("optimized PCM must not be empty", pcmBytes > 0)
+        }
+    }
+
+    private fun elapsedMs(startNanos: Long): Long =
+        (SystemClock.elapsedRealtimeNanos() - startNanos) / 1_000_000
+
+    private fun percentile(sorted: List<Long>, quantile: Double): Long {
+        val index = (ceil(sorted.size * quantile).toInt() - 1).coerceIn(sorted.indices)
+        return sorted[index]
+    }
+}

--- a/control-demo/src/androidTest/kotlin/audio/soniqo/speech/control/LiteRtLmLoraTest.kt
+++ b/control-demo/src/androidTest/kotlin/audio/soniqo/speech/control/LiteRtLmLoraTest.kt
@@ -1,0 +1,188 @@
+package audio.soniqo.speech.control
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import audio.soniqo.speech.llm.ArgumentValue
+import audio.soniqo.speech.llm.FunctionGemma
+import java.io.File
+import kotlin.math.ceil
+import kotlin.system.measureTimeMillis
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.json.JSONObject
+
+@RunWith(AndroidJUnit4::class)
+class LiteRtLmLoraTest {
+
+    @Test
+    fun compactHeldOutReportsQualityAndLatency() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val model = File(context.filesDir, "model-lora16-android.litertlm")
+        val adapter = File(context.filesDir, "control-r4-rank16.tflite")
+        val dataset = File(context.filesDir, "compact-test.jsonl")
+        require(model.isFile) { "Push the LoRA-enabled model to ${model.absolutePath}" }
+        require(adapter.isFile) { "Push the Control adapter to ${adapter.absolutePath}" }
+        require(dataset.isFile) { "Push compact/test.jsonl to ${dataset.absolutePath}" }
+
+        val runtime = LiteRtLmRuntime(model.absolutePath, adapter.absolutePath)
+        val loadMs = measureTimeMillis { runtime.initialize() }
+        val parser = FunctionGemma(runtime, maxNewTokens = 128)
+        val latencies = mutableListOf<Long>()
+        var cases = 0
+        var routeCorrect = 0
+        var actionCases = 0
+        var actionArgumentsExact = 0
+        var failuresLogged = 0
+
+        try {
+            dataset.forEachLine { line ->
+                if (line.isBlank()) return@forEachLine
+                val row = JSONObject(line)
+                val messages = row.getJSONArray("messages")
+                val developer = messages.getJSONObject(0).getString("content")
+                val user = messages.getJSONObject(1).getString("content")
+                val metadata = row.getJSONObject("metadata")
+                val expectedTool = if (metadata.isNull("expected_tool")) {
+                    null
+                } else {
+                    metadata.getString("expected_tool")
+                }
+                val expectedArguments = metadata.optJSONObject("expected_arguments")
+                val prompt =
+                    "<start_of_turn>developer\n$developer<end_of_turn>\n" +
+                        "<start_of_turn>user\n$user<end_of_turn>\n" +
+                        "<start_of_turn>model\n"
+
+                lateinit var raw: String
+                val elapsed = measureTimeMillis {
+                    raw = runtime.generate(prompt, maxNewTokens = 128)
+                }
+                latencies += elapsed
+                cases++
+
+                val call = parser.parseToolCalls(raw).singleOrNull()
+                val routeMatches = call?.name == expectedTool ||
+                    (call == null && expectedTool == null)
+                if (routeMatches) routeCorrect++
+
+                var argumentsMatch = true
+                if (expectedTool != null) {
+                    actionCases++
+                    if (call == null || !routeMatches) {
+                        argumentsMatch = false
+                    } else if (expectedArguments != null) {
+                        val keys = expectedArguments.keys()
+                        while (keys.hasNext()) {
+                            val key = keys.next()
+                            if (key == "say") continue
+                            val expected = expectedArguments.get(key).toString().trim().lowercase()
+                            val actual = argumentText(call.arguments[key])
+                            if (actual != expected) argumentsMatch = false
+                        }
+                    }
+                    if (argumentsMatch) actionArgumentsExact++
+                }
+
+                if ((!routeMatches || !argumentsMatch) && failuresLogged < 20) {
+                    println(
+                        "LORA_EVAL_FAILURE command='${user.replace("'", "\\'")}' " +
+                            "expected=$expectedTool actual=${call?.name} " +
+                            "raw='${raw.replace("\n", " ").take(300)}'",
+                    )
+                    failuresLogged++
+                }
+            }
+
+            val sorted = latencies.sorted()
+            val mean = sorted.average()
+            val p50 = percentile(sorted, 0.50)
+            val p95 = percentile(sorted, 0.95)
+            val routeAccuracy = routeCorrect * 100.0 / cases
+            val argumentAccuracy = actionArgumentsExact * 100.0 / actionCases
+            println(
+                "LORA_EVAL cases=$cases engine_load_ms=$loadMs " +
+                    "route_correct=$routeCorrect route_accuracy=$routeAccuracy " +
+                    "action_arguments_exact=$actionArgumentsExact/$actionCases " +
+                    "action_argument_accuracy=$argumentAccuracy " +
+                    "mean_ms=$mean p50_ms=$p50 p95_ms=$p95 max_ms=${sorted.last()}",
+            )
+            assertEquals("Unexpected held-out dataset size", 136, cases)
+            assertTrue("Held-out route accuracy was $routeAccuracy%", routeAccuracy >= 85.0)
+        } finally {
+            runtime.close()
+        }
+    }
+
+    @Test
+    fun compactControlAdapterGeneratesExpectedCalls() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val model = File(context.filesDir, "model-lora16-android.litertlm")
+        val adapter = File(context.filesDir, "control-r4-rank16.tflite")
+        require(model.isFile) { "Push the LoRA-enabled model to ${model.absolutePath}" }
+        require(adapter.isFile) { "Push the Control adapter to ${adapter.absolutePath}" }
+
+        val runtime = LiteRtLmRuntime(model.absolutePath, adapter.absolutePath)
+        val loadMs = measureTimeMillis { runtime.initialize() }
+        val parser = FunctionGemma(runtime, maxNewTokens = 128)
+        val tools = ControlTools.availableTools(musicPlaying = false)
+
+        try {
+            val cases = listOf(
+                Case("set volume to five", "set_volume", "level", "5"),
+                Case("call anna", "call_contact", "name", "anna"),
+                Case(
+                    "is there any Nina Simone on this phone",
+                    "find_music",
+                    "query",
+                    "nina simone",
+                ),
+            )
+            println("LORA_METRIC engine_load_ms=$loadMs")
+            for (case in cases) {
+                lateinit var raw: String
+                val generateMs = measureTimeMillis {
+                    raw = runtime.generate(
+                        CompactPrompt.format(tools, musicPlaying = false, case.command),
+                        maxNewTokens = 128,
+                    )
+                }
+                val call = ControlTools.selectSingleCall(parser.parseToolCalls(raw))
+                println(
+                    "LORA_METRIC command='${case.command}' generate_ms=$generateMs " +
+                        "raw='${raw.replace("\n", " ")}'",
+                )
+                assertNotNull("No single tool call for ${case.command}: $raw", call)
+                assertEquals(case.tool, call!!.name)
+                val actual = when (val value = call.arguments[case.argument]) {
+                    is ArgumentValue.Int -> value.value.toString()
+                    is ArgumentValue.Double -> value.value.toString().removeSuffix(".0")
+                    is ArgumentValue.Str -> value.value.trim().lowercase()
+                    else -> value.toString().trim().lowercase()
+                }
+                assertEquals(case.value, actual)
+            }
+        } finally {
+            runtime.close()
+        }
+    }
+
+    private data class Case(
+        val command: String,
+        val tool: String,
+        val argument: String,
+        val value: String,
+    )
+
+    private fun percentile(sorted: List<Long>, fraction: Double): Long =
+        sorted[(ceil(sorted.size * fraction).toInt() - 1).coerceIn(sorted.indices)]
+
+    private fun argumentText(value: ArgumentValue?): String = when (value) {
+        is ArgumentValue.Int -> value.value.toString()
+        is ArgumentValue.Double -> value.value.toString().removeSuffix(".0")
+        is ArgumentValue.Str -> value.value.trim().lowercase()
+        else -> value.toString().trim().lowercase()
+    }
+}

--- a/control-demo/src/androidTest/kotlin/audio/soniqo/speech/control/LiteRtLmLoraTest.kt
+++ b/control-demo/src/androidTest/kotlin/audio/soniqo/speech/control/LiteRtLmLoraTest.kt
@@ -2,6 +2,8 @@ package audio.soniqo.speech.control
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import audio.soniqo.speech.LlmModel
+import audio.soniqo.speech.ModelManager
 import audio.soniqo.speech.llm.ArgumentValue
 import audio.soniqo.speech.llm.FunctionGemma
 import java.io.File
@@ -20,11 +22,12 @@ class LiteRtLmLoraTest {
     @Test
     fun compactHeldOutReportsQualityAndLatency() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val model = File(context.filesDir, "model-lora16-android.litertlm")
-        val adapter = File(context.filesDir, "control-r4-rank16.tflite")
+        val profile = LlmModel.FUNCTIONGEMMA_CONTROL_LORA
+        val model = File(ModelManager.llmModelFile(context, profile))
+        val adapter = File(requireNotNull(ModelManager.llmAdapterFile(context, profile)))
         val dataset = File(context.filesDir, "compact-test.jsonl")
-        require(model.isFile) { "Push the LoRA-enabled model to ${model.absolutePath}" }
-        require(adapter.isFile) { "Push the Control adapter to ${adapter.absolutePath}" }
+        require(model.isFile) { "Launch the demo to download ${model.absolutePath}" }
+        require(adapter.isFile) { "Launch the demo to download ${adapter.absolutePath}" }
         require(dataset.isFile) { "Push compact/test.jsonl to ${dataset.absolutePath}" }
 
         val runtime = LiteRtLmRuntime(model.absolutePath, adapter.absolutePath)
@@ -119,10 +122,11 @@ class LiteRtLmLoraTest {
     @Test
     fun compactControlAdapterGeneratesExpectedCalls() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val model = File(context.filesDir, "model-lora16-android.litertlm")
-        val adapter = File(context.filesDir, "control-r4-rank16.tflite")
-        require(model.isFile) { "Push the LoRA-enabled model to ${model.absolutePath}" }
-        require(adapter.isFile) { "Push the Control adapter to ${adapter.absolutePath}" }
+        val profile = LlmModel.FUNCTIONGEMMA_CONTROL_LORA
+        val model = File(ModelManager.llmModelFile(context, profile))
+        val adapter = File(requireNotNull(ModelManager.llmAdapterFile(context, profile)))
+        require(model.isFile) { "Launch the demo to download ${model.absolutePath}" }
+        require(adapter.isFile) { "Launch the demo to download ${adapter.absolutePath}" }
 
         val runtime = LiteRtLmRuntime(model.absolutePath, adapter.absolutePath)
         val loadMs = measureTimeMillis { runtime.initialize() }

--- a/control-demo/src/androidTest/kotlin/audio/soniqo/speech/control/PocketTtsLatencyTest.kt
+++ b/control-demo/src/androidTest/kotlin/audio/soniqo/speech/control/PocketTtsLatencyTest.kt
@@ -1,0 +1,220 @@
+package audio.soniqo.speech.control
+
+import android.os.SystemClock
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import audio.soniqo.speech.ModelManager
+import audio.soniqo.speech.PipelineMode
+import audio.soniqo.speech.SpeechConfig
+import audio.soniqo.speech.SpeechPipeline
+import audio.soniqo.speech.TtsModel
+import java.io.File
+import kotlin.math.ceil
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Opt-in physical-device gate for Pocket's real 80 ms streaming callbacks. */
+@RunWith(AndroidJUnit4::class)
+class PocketTtsLatencyTest {
+
+    @Test
+    fun streamsFramesBelowInteractiveLatencyGate() {
+        val args = InstrumentationRegistry.getArguments()
+        assumeTrue(
+            "set -e runPocketLatency true to run the Pocket latency benchmark",
+            args.getString("runPocketLatency") == "true",
+        )
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val modelDir = File(ModelManager.modelDir(context, ttsModel = TtsModel.POCKET))
+        val pocketDir = File(modelDir, "pocket_tts")
+        for (name in REQUIRED_FILES) {
+            require(File(pocketDir, name).isFile) {
+                "Launch the Pocket control demo to download ${pocketDir.absolutePath}/$name"
+            }
+        }
+
+        val loadStart = SystemClock.elapsedRealtimeNanos()
+        SpeechPipeline(
+            SpeechConfig(
+                modelDir = modelDir.absolutePath,
+                useNnapi = false,
+                ttsModel = TtsModel.POCKET,
+                pipelineMode = PipelineMode.TRANSCRIBE_ONLY,
+                language = "en",
+            ),
+        ).use { pipeline ->
+            val loadMs = elapsedMs(loadStart)
+            assertEquals(24_000, pipeline.ttsSampleRate)
+
+            // Exclude session/page-fault warm-up from the warm interaction gate.
+            synthesizeAndMeasure(pipeline, "Ready when you are.")
+
+            val results = buildList {
+                repeat(10) {
+                    add(synthesizeAndMeasure(pipeline, "I can call your contacts,"))
+                }
+            }
+            val firstAudio = results.map { it.firstAudioMs }.sorted()
+            val totals = results.map { it.totalMs }.sorted()
+            val mean = firstAudio.average()
+            val p50 = percentile(firstAudio, 0.50)
+            val p95 = percentile(firstAudio, 0.95)
+            val max = firstAudio.last()
+            val medianRtf = results.map { it.rtf }.sorted()[results.size / 2]
+
+            println(
+                "POCKET_LATENCY backend=cpu threads=2 flow_steps=4 " +
+                    "load_ms=$loadMs samples=${results.size} mean_ms=$mean " +
+                    "p50_ms=$p50 p95_ms=$p95 max_ms=$max " +
+                    "total_p50_ms=${percentile(totals, 0.50)} " +
+                    "total_p95_ms=${percentile(totals, 0.95)} " +
+                    "median_rtf=$medianRtf",
+            )
+            assertTrue("Pocket warm TTFA p95 must stay below 300 ms, was $p95 ms", p95 < 300)
+        }
+    }
+
+    @Test
+    fun playsFramesThroughOneContinuousAudioTrack() = runBlocking {
+        val args = InstrumentationRegistry.getArguments()
+        assumeTrue(
+            "set -e runPocketPlayback true to run audible Pocket playback",
+            args.getString("runPocketPlayback") == "true",
+        )
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val modelDir = File(ModelManager.modelDir(context, ttsModel = TtsModel.POCKET))
+        require(File(modelDir, "pocket_tts/lm_main.int8.onnx").isFile)
+        SpeechPipeline(
+            SpeechConfig(
+                modelDir = modelDir.absolutePath,
+                useNnapi = false,
+                ttsModel = TtsModel.POCKET,
+                pipelineMode = PipelineMode.TRANSCRIBE_ONLY,
+                language = "en",
+            ),
+        ).use { pipeline ->
+            synthesizeAndMeasure(pipeline, "Ready when you are.")
+
+            val prepareStarted = SystemClock.elapsedRealtimeNanos()
+            val player = StreamingPcmPlayer(pipeline.ttsSampleRate)
+            val prepareMs = elapsedMs(prepareStarted)
+            try {
+                repeat(2) { turnIndex ->
+                    val started = SystemClock.elapsedRealtimeNanos()
+                    var callbackMs = 0L
+                    var playbackStartMs = 0L
+                    var nativeFrames = 0
+                    var pcmBytes = 0L
+                    pipeline.synthesizeStreaming(
+                        if (turnIndex == 0) {
+                            "Pocket TTS is now running on your phone."
+                        } else {
+                            "The warm audio path is ready for another turn."
+                        },
+                        "en",
+                    ) { chunk, _ ->
+                        if (chunk.pcm16.isEmpty()) return@synthesizeStreaming
+                        if (callbackMs == 0L) callbackMs = elapsedMs(started)
+                        nativeFrames++
+                        pcmBytes += chunk.pcm16.size
+                        if (playbackStartMs == 0L) {
+                            assertEquals(player.sampleRate, chunk.sampleRate)
+                            player.start(chunk.pcm16)
+                            playbackStartMs = elapsedMs(started)
+                        } else {
+                            player.write(chunk.pcm16)
+                        }
+                    }
+                    val firstPresentationNanos = player.awaitFirstPresentationNanos()
+                    player.awaitDrained()
+                    val presentationMs = firstPresentationNanos?.let {
+                        ((it - started) / 1_000_000).coerceAtLeast(playbackStartMs)
+                    }
+                    val perf = if (
+                        player.performanceMode == android.media.AudioTrack.PERFORMANCE_MODE_LOW_LATENCY
+                    ) "low-latency" else "normal"
+                    val audioSeconds = pcmBytes / 2.0 / pipeline.ttsSampleRate
+                    println(
+                        "POCKET_PLAYBACK turn=${turnIndex + 1} prepare_ms=$prepareMs " +
+                            "callback_ms=$callbackMs playback_start_ms=$playbackStartMs " +
+                            "first_presentation_ms=${presentationMs ?: "unavailable"} " +
+                            "frames=$nativeFrames audio_s=$audioSeconds " +
+                            "output=$perf buffer_bytes=${player.bufferSizeBytes} " +
+                            "underruns=${player.underrunCount}",
+                    )
+                    assertTrue("Pocket callback exceeded 300 ms: $callbackMs", callbackMs < 300)
+                    assertTrue(
+                        "AudioTrack start exceeded 350 ms: $playbackStartMs",
+                        playbackStartMs < 350,
+                    )
+                    assertTrue(
+                        "Audio presentation timestamp unavailable or too slow: $presentationMs",
+                        presentationMs != null && presentationMs < 450,
+                    )
+                    assertEquals("continuous playback must not underrun", 0, player.underrunCount)
+                    player.resetForNextUtterance()
+                }
+            } finally {
+                player.close()
+            }
+        }
+    }
+
+    private fun synthesizeAndMeasure(pipeline: SpeechPipeline, text: String): Result {
+        val start = SystemClock.elapsedRealtimeNanos()
+        var firstAudioMs = 0L
+        var frames = 0
+        var pcmBytes = 0L
+        var sawFinal = false
+        pipeline.synthesizeStreaming(text, "en") { chunk, isFinal ->
+            if (chunk.pcm16.isNotEmpty()) {
+                if (firstAudioMs == 0L) firstAudioMs = elapsedMs(start)
+                assertEquals("Pocket frames must contain 80 ms at 24 kHz", 3_840, chunk.pcm16.size)
+                frames++
+                pcmBytes += chunk.pcm16.size
+            }
+            if (isFinal) sawFinal = true
+        }
+        val totalMs = elapsedMs(start)
+        assertTrue("Pocket emitted no audio", frames > 0)
+        assertTrue("Pocket final callback missing", sawFinal)
+        val audioSeconds = pcmBytes / 2.0 / pipeline.ttsSampleRate
+        return Result(
+            firstAudioMs = firstAudioMs,
+            totalMs = totalMs,
+            rtf = totalMs / 1_000.0 / audioSeconds,
+        )
+    }
+
+    private fun elapsedMs(startNanos: Long): Long =
+        (SystemClock.elapsedRealtimeNanos() - startNanos) / 1_000_000
+
+    private fun percentile(sorted: List<Long>, quantile: Double): Long {
+        val index = (ceil(sorted.size * quantile).toInt() - 1).coerceIn(sorted.indices)
+        return sorted[index]
+    }
+
+    private data class Result(
+        val firstAudioMs: Long,
+        val totalMs: Long,
+        val rtf: Double,
+    )
+
+    private companion object {
+        val REQUIRED_FILES = listOf(
+            "decoder.int8.onnx",
+            "encoder.onnx",
+            "lm_flow.int8.onnx",
+            "lm_main.int8.onnx",
+            "text_conditioner.onnx",
+            "token_scores.json",
+            "vocab.json",
+        )
+    }
+}

--- a/control-demo/src/main/AndroidManifest.xml
+++ b/control-demo/src/main/AndroidManifest.xml
@@ -1,0 +1,41 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <!-- API 33+: required to show the model-download progress notification. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Voice commands operate on real device data: contact lookup for
+         call_contact / find_contact, local audio for play_music. Calls go
+         through ACTION_DIAL, which needs no permission. -->
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+
+    <application
+        android:allowBackup="false"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.SoniqoControl">
+
+        <!-- configChanges: handle rotation in-place instead of recreating the
+             Activity, which would build a second SpeechPipeline + LLM engine
+             (heavy native models) and leak the old ones. -->
+        <!-- singleTop: a debug-harness `am start` re-delivers to the running
+             instance via onNewIntent instead of stacking a second activity
+             (and a second copy of the models). Harness extras are ignored in
+             non-debuggable builds. -->
+        <activity
+            android:name=".ControlAgentActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:configChanges="orientation|screenSize|smallestScreenSize|keyboardHidden|uiMode">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/CompactPrompt.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/CompactPrompt.kt
@@ -1,0 +1,41 @@
+package audio.soniqo.speech.control
+
+import audio.soniqo.speech.llm.FunctionDeclaration
+
+/**
+ * Compact FunctionGemma prompt for adapters fine-tuned on the compact style
+ * (`speech-models/models/functiongemma/training/data/compact`): the developer
+ * turn carries the FunctionGemma trigger, the state-filtered function names,
+ * and the music state — no full schema declarations. The schemas are trained
+ * into the weights, so this prompt must stay byte-identical to the training
+ * serialization in `generate_dataset.py` (`compact_developer_turn`), rendered
+ * through the same Gemma turn structure the SDK uses for the canonical path.
+ *
+ * This demo always pairs the compact prompt with the published Control LoRA.
+ */
+object CompactPrompt {
+
+    private const val TRIGGER =
+        "You are a model that can do function calling with the following functions"
+
+    /** Developer-turn body: trigger + available function names + music state. */
+    fun developerTurn(tools: List<FunctionDeclaration>, musicPlaying: Boolean): String {
+        val names = tools.joinToString(", ") { it.name }
+        val state = if (musicPlaying) "playing" else "idle"
+        return "$TRIGGER\nAvailable functions: $names.\nMusic state: $state."
+    }
+
+    /**
+     * Full prompt for a runtime that does not apply the chat template itself
+     * (LiteRtLmRuntime.appliesChatTemplate == false), mirroring
+     * FunctionGemmaPrompt.formatPrompt's turn structure.
+     */
+    fun format(
+        tools: List<FunctionDeclaration>,
+        musicPlaying: Boolean,
+        userText: String,
+    ): String =
+        "<start_of_turn>developer\n${developerTurn(tools, musicPlaying)}<end_of_turn>\n" +
+            "<start_of_turn>user\n$userText<end_of_turn>\n" +
+            "<start_of_turn>model\n"
+}

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/CompactPrompt.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/CompactPrompt.kt
@@ -3,13 +3,12 @@ package audio.soniqo.speech.control
 import audio.soniqo.speech.llm.FunctionDeclaration
 
 /**
- * Compact FunctionGemma prompt for adapters fine-tuned on the compact style
- * (`speech-models/models/functiongemma/training/data/compact`): the developer
- * turn carries the FunctionGemma trigger, the state-filtered function names,
- * and the music state — no full schema declarations. The schemas are trained
- * into the weights, so this prompt must stay byte-identical to the training
- * serialization in `generate_dataset.py` (`compact_developer_turn`), rendered
- * through the same Gemma turn structure the SDK uses for the canonical path.
+ * Compact FunctionGemma prompt for the published Control adapter: the
+ * developer turn carries the FunctionGemma trigger, the state-filtered
+ * function names, and the music state — no full schema declarations. The
+ * schemas are trained into the weights, so this prompt must stay compatible
+ * with the adapter's compact training serialization and use the same Gemma
+ * turn structure as the SDK's canonical path.
  *
  * This demo always pairs the compact prompt with the published Control LoRA.
  */

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlAgentActivity.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlAgentActivity.kt
@@ -1,0 +1,1014 @@
+package audio.soniqo.speech.control
+
+import android.Manifest
+import android.content.ContentUris
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioRecord
+import android.media.AudioTrack
+import android.media.MediaPlayer
+import android.media.MediaRecorder
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.provider.ContactsContract
+import android.provider.MediaStore
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.getValue
+import androidx.core.app.ActivityCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import audio.soniqo.speech.ModelDownloadWorker
+import audio.soniqo.speech.ModelManager
+import audio.soniqo.speech.LlmModel
+import audio.soniqo.speech.ModelPrecision
+import audio.soniqo.speech.PipelineMode
+import audio.soniqo.speech.SpeechConfig
+import audio.soniqo.speech.SpeechEvent
+import audio.soniqo.speech.SpeechPipeline
+import audio.soniqo.speech.SttModel
+import audio.soniqo.speech.control.ui.ControlActions
+import audio.soniqo.speech.control.ui.ControlScreen
+import audio.soniqo.speech.control.ui.SoniqoControlTheme
+import audio.soniqo.speech.llm.FunctionGemma
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Soniqo Control — voice command recognition for basic phone functionality,
+ * running the full on-device pipeline from the soniqo blog post "Running a
+ * voice agent on-device: one pipeline, three memory budgets":
+ *
+ *   Silero VAD → Parakeet-EOU 120M (TRANSCRIBE_ONLY) → FunctionGemma 270M
+ *   (LiteRT-LM) → device tool (dial / contacts / music / volume) → Kokoro
+ *   speaks the model-authored `say` argument.
+ *
+ * The UI is Jetpack Compose ([ControlScreen]) subscribing to a single
+ * [ControlStore] state flow; this Activity owns the pipeline and pushes
+ * state into the store. Debug-build scripted driving: long-press "hold to
+ * type" or `adb shell am start -n .../.ControlAgentActivity --es command
+ * "call anna"`. Intent harness extras are ignored in non-debuggable builds.
+ */
+class ControlAgentActivity : ComponentActivity() {
+
+    private var pipeline: SpeechPipeline? = null
+    private var llmRuntime: LiteRtLmRuntime? = null
+    private var functionGemma: FunctionGemma? = null
+    private var audioRecord: AudioRecord? = null
+    private var audioTrack: AudioTrack? = null
+    private var mediaPlayer: MediaPlayer? = null
+
+    @Volatile private var recording = false
+    @Volatile private var micPaused = false
+    // Debug mic tap: launch with `--ez record_mic true` to dump everything the
+    // microphone session captures (including audio consumed while the agent
+    // speaks) as 16 kHz mono PCM16 under files/mic_debug/, pullable via
+    // run-as. Off by default — nothing is ever recorded without the flag.
+    @Volatile private var micDebugEnabled = false
+    @Volatile private var micDebugStream: java.io.FileOutputStream? = null
+    // Software input gain (see MicGain). `--ez mic_gain false` disables it,
+    // e.g. to replay recordings at their original level for benchmarks.
+    @Volatile private var micGainEnabled = true
+    private val replayInFlight = AtomicBoolean(false)
+    private val micGain = MicGain()
+    private val turnInFlight = AtomicBoolean(false)
+    @Volatile private var ready = false
+    private var pendingCommand: String? = null
+    private var pendingReplay: String? = null
+
+    private val store = ControlStore()
+    private val device = AndroidDeviceActions()
+    private val memory = MemoryMonitor()
+
+    private var pipelineStarted = false
+    private var observingDownload = false
+    // STT model override for on-device A/B: `--es stt_model PARAKEET` selects
+    // the 0.6B TDT v3; unset keeps DEMO_STT. Read before models load.
+    private var sttOverride: String? = null
+
+    private val acceptsDebugIntents: Boolean
+        get() = applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
+
+    private fun activeStt(): SttModel =
+        sttOverride?.let { runCatching { SttModel.valueOf(it) }.getOrNull() } ?: DEMO_STT
+    // Drives the Kokoro voice (and Nemotron's prompt slot if ever selected).
+    // Parakeet STT autodetects regardless — like every other Parakeet
+    // runtime, there is no language forcing, so accented speech can
+    // occasionally decode into a non-Latin script on the multilingual TDT.
+    private fun activeLanguage(): String = "en"
+
+    // Contextual-biasing phrases for the STT beam search: the fixed command
+    // grammar and the brand, plus the track titles/artists currently on the
+    // device. The command core is always present; without media permission
+    // listMusic() returns empty and only the fixed phrases apply.
+    private fun buildContextPhrases(): List<String> {
+        val phrases = mutableListOf(
+            "Soniqo",
+            "set volume", "volume up", "volume down", "mute", "unmute",
+            "play music", "play", "stop", "stop playing", "pause", "resume",
+            "next track", "previous track",
+            "call", "dial", "dial number", "redial",
+            "find music", "search music", "list music",
+            "what can you do",
+        )
+        runCatching {
+            device.listMusic(null).forEach { t ->
+                if (t.title.isNotBlank()) phrases.add(t.title)
+                t.artist?.let { if (it.isNotBlank()) phrases.add(it) }
+            }
+        }
+        return phrases.map { it.trim() }.filter { it.isNotEmpty() }.distinct()
+    }
+
+    private var speechStartMs = 0L
+    private var speechEndMs = 0L
+
+    companion object {
+        private const val TAG = "SpeechControl"
+
+        // STT model for the demo. PARAKEET_EOU is the low-memory default
+        // (25 languages, ~232 MB) — fast, ~2 s round trip, ~1.3 GB total.
+        // PARAKEET is Parakeet-TDT v3 (114 languages, auto-detect) but
+        // ~891 MB download and ~2 GB total, which is ~5× slower under
+        // emulation and needs a real device with an NPU to feel good.
+        private val DEMO_STT = SttModel.PARAKEET_EOU
+
+        // Parakeet-EOU RNN-T decode width. > 1 enables beam search, which
+        // contextual biasing (buildContextPhrases) rides on. Truncation seen in
+        // the replay bench traced to the fixture cadence, not the decoder
+        // (beam == greedy on the host); testing live on-device.
+        private const val EOU_BEAM_SIZE = 4
+
+        private val isEmulator = Build.FINGERPRINT.contains("generic")
+                || Build.MODEL.contains("Emulator")
+                || Build.MODEL.contains("sdk")
+                || Build.HARDWARE.contains("ranchu")
+
+        private val mediaPermission =
+            if (Build.VERSION.SDK_INT >= 33) Manifest.permission.READ_MEDIA_AUDIO
+            else Manifest.permission.READ_EXTERNAL_STORAGE
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (acceptsDebugIntents) {
+            pendingCommand = intent?.getStringExtra("command")
+            pendingReplay = if (pendingCommand == null) {
+                intent?.getStringExtra("replay_pcm")
+            } else {
+                null
+            }
+            micDebugEnabled = intent?.getBooleanExtra("record_mic", false) == true
+            micGainEnabled = intent?.getBooleanExtra("mic_gain", true) != false
+            intent?.getStringExtra("stt_model")?.let { sttOverride = it }
+        }
+        setContent {
+            SoniqoControlTheme {
+                val state by store.state.collectAsStateWithLifecycle()
+                ControlScreen(
+                    state = state,
+                    actions = ControlActions(
+                        onMicTap = ::toggleMicrophone,
+                        onOpenType = { store.setTypeDialog(true) },
+                        onSubmitTyped = { cmd ->
+                            store.setTypeDialog(false)
+                            handleCommand(cmd, sttMs = 0f, voiceAnchored = false)
+                        },
+                        onDismissType = { store.setTypeDialog(false) },
+                        onOpenInfo = { store.setInfoDialog(true) },
+                        onDismissInfo = { store.setInfoDialog(false) },
+                    ),
+                )
+            }
+        }
+        bench("baseline")
+        loadModels()
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        if (!acceptsDebugIntents) return
+        micGainEnabled = intent.getBooleanExtra("mic_gain", micGainEnabled)
+        val command = intent.getStringExtra("command")
+        val replay = intent.getStringExtra("replay_pcm")
+        when {
+            command != null -> {
+                pendingReplay = null
+                if (ready) handleCommand(command, sttMs = 0f, voiceAnchored = false)
+                else pendingCommand = command
+            }
+            replay != null -> {
+                pendingCommand = null
+                if (ready) runReplay(replay) else pendingReplay = replay
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Store helpers
+    // -----------------------------------------------------------------------
+
+    private fun bench(stage: String) {
+        val mb = memory.sample()
+        Log.i(TAG, "[bench] $stage: $mb MB")
+        store.setMemory(memory.currentMb(), memory.peakMb)
+    }
+
+    /** Friendly stage name for a model file, so the status reads "downloading
+     *  transcription model" instead of "downloading parakeet-eou-encoder.onnx". */
+    private fun modelLabel(file: String): String = when {
+        file.startsWith("silero") -> "voice detection"
+        file.startsWith("parakeet") || file == "vocab.json" || file == "config.json" ||
+            file == "encoder.onnx" || file == "decoder.onnx" || file == "joint.onnx" ||
+            file.startsWith("nemotron") -> "transcription model"
+        file == "model.litertlm" || file.startsWith("model-lora") ||
+            file.startsWith("control-r4-") -> "language model"
+        file.startsWith("kokoro") || file.startsWith("dict") || file.startsWith("us_") ||
+            file.startsWith("voices") || file.startsWith("voice_styles") ||
+            file == "vocab_index.json" || file.endsWith(".tflite") -> "speech synthesis"
+        file.startsWith("deepfilter") -> "noise filter"
+        else -> "models"
+    }
+
+    /** Rest state after a turn: keep listening if the mic is live, else idle. */
+    private fun returnToRest() {
+        store.setMic(if (recording) MicState.LISTENING else MicState.IDLE)
+        store.setStatus(if (recording) "listening" else "tap to talk")
+    }
+
+    // -----------------------------------------------------------------------
+    // Model download + init
+    // -----------------------------------------------------------------------
+
+    private fun loadModels() {
+        store.setStatus("downloading models")
+        store.setDownload(0)
+        // includeLlm = true: the FunctionGemma bundle downloads in this same
+        // foreground worker, so the whole ~800 MB setup survives the screen
+        // dozing / Wi-Fi power-save (an in-app download dies on "unable to
+        // resolve huggingface.co" the moment the phone sleeps).
+        ModelDownloadWorker.enqueue(
+            applicationContext,
+            ModelPrecision.INT8,
+            sttModel = activeStt(),
+            includeLlm = true,
+            llmModel = LlmModel.FUNCTIONGEMMA_CONTROL_LORA,
+        )
+        if (observingDownload) return
+        observingDownload = true
+        WorkManager.getInstance(applicationContext)
+            .getWorkInfosForUniqueWorkLiveData(
+                ModelDownloadWorker.uniqueName(
+                    sttModel = activeStt(),
+                    includeLlm = true,
+                    llmModel = LlmModel.FUNCTIONGEMMA_CONTROL_LORA,
+                ))
+            .observe(this) { infos ->
+                val info = infos.firstOrNull { !it.state.isFinished }
+                    ?: infos.lastOrNull() ?: return@observe
+                when (info.state) {
+                    WorkInfo.State.ENQUEUED,
+                    WorkInfo.State.BLOCKED,
+                    WorkInfo.State.RUNNING -> {
+                        val total = info.progress.getInt(ModelDownloadWorker.KEY_TOTAL, 0)
+                        if (total > 0) {
+                            val file = info.progress.getString(ModelDownloadWorker.KEY_FILE) ?: ""
+                            val label = modelLabel(file)
+                            store.setStatus("downloading $label")
+                            store.setDownloadStage(label)
+                            store.setDownload(info.progress.getInt(ModelDownloadWorker.KEY_PERCENT, 0))
+                        }
+                    }
+                    WorkInfo.State.SUCCEEDED -> {
+                        val modelDir = info.outputData.getString(ModelDownloadWorker.KEY_MODEL_DIR)
+                        if (modelDir == null) { store.setStatus("error — no model dir"); return@observe }
+                        if (!pipelineStarted) { pipelineStarted = true; initEverything(modelDir) }
+                    }
+                    WorkInfo.State.FAILED -> {
+                        val err = info.outputData.getString(ModelDownloadWorker.KEY_ERROR) ?: "unknown"
+                        store.addNote("download failed: $err")
+                        store.setStatus("download failed")
+                    }
+                    WorkInfo.State.CANCELLED -> store.setStatus("download cancelled")
+                }
+            }
+    }
+
+    private fun initEverything(modelDir: String) {
+        lifecycleScope.launch(Dispatchers.Default) {
+            try {
+                store.setStatus("loading pipeline")
+                store.setDownloadStage(null)
+                val p = SpeechPipeline(SpeechConfig(
+                    modelDir = modelDir,
+                    useNnapi = !isEmulator,
+                    sttModel = activeStt(),
+                    pipelineMode = PipelineMode.TRANSCRIBE_ONLY,
+                    emitPartialTranscriptions = true,
+                    language = activeLanguage(),
+                    // 0.5 s default cut people off mid-command on-device —
+                    // dictated digits and thinking pauses exceed it easily.
+                    endOfSpeechSilenceSec = 0.8f,
+                    // Greedy by default (EOU_BEAM_SIZE); beam under-emits
+                    // on-device. Ignored by other STT models.
+                    beamSize = EOU_BEAM_SIZE,
+                ))
+                pipeline = p
+                bench("pipeline loaded")
+
+                launch { p.events.collect { onSpeechEvent(it) } }
+                p.start()
+                // Bias recognition toward the command grammar, the brand, and
+                // whatever music is on this device right now. No-op in greedy
+                // mode; only meaningful once EOU_BEAM_SIZE > 1.
+                if (EOU_BEAM_SIZE > 1) p.setContextPhrases(buildContextPhrases())
+
+                store.setStatus("downloading language model")
+                store.setDownloadStage("language model")
+                val llmProfile = LlmModel.FUNCTIONGEMMA_CONTROL_LORA
+                val llmPath = ModelManager.ensureLlmModels(
+                    applicationContext,
+                    llmModel = llmProfile,
+                ) { prog ->
+                    if (prog.fileTotalBytes > 0) {
+                        store.setDownload((prog.bytesDownloaded * 100 / prog.fileTotalBytes).toInt())
+                    }
+                    store.setStatus("downloading language model · " +
+                        "${prog.bytesDownloaded / 1_000_000}/${prog.fileTotalBytes / 1_000_000} MB")
+                }
+                val adapterPath = requireNotNull(
+                    ModelManager.llmAdapterFile(applicationContext, llmProfile),
+                ) { "Control LLM profile is missing its adapter" }
+                store.setStatus("loading LLM engine")
+                val runtime = LiteRtLmRuntime(llmPath, adapterPath)
+                runtime.initialize()
+                llmRuntime = runtime
+                functionGemma = FunctionGemma(runtime, maxNewTokens = 128)
+                bench("llm loaded")
+
+                memory.start()
+                launch {
+                    while (true) { store.setMemory(memory.currentMb(), memory.peakMb); delay(1000) }
+                }
+
+                ready = true
+                store.setDownload(null)
+                store.setMic(MicState.IDLE)
+                store.setStatus("ready · on-device")
+                p.nnapiFallbackReason?.let { Log.w(TAG, "NNAPI unavailable, using CPU: $it") }
+                pendingCommand?.let { cmd ->
+                    pendingCommand = null
+                    handleCommand(cmd, sttMs = 0f, voiceAnchored = false)
+                }
+                pendingReplay?.let { name ->
+                    pendingReplay = null
+                    runReplay(name)
+                }
+            } catch (e: Throwable) {
+                Log.e(TAG, "init failed", e)
+                store.addNote("init error: ${e.message}")
+                store.setStatus("error")
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Pipeline events → agent turn
+    // -----------------------------------------------------------------------
+
+    private fun onSpeechEvent(event: SpeechEvent) {
+        // The pipeline keeps running while idle, so VAD/STT can fire on stray
+        // room audio (notably the emulator's host mic). Only let speech events
+        // drive the UI while the user actually has a mic session open —
+        // otherwise the orb could get stuck "listening" with no turn behind it.
+        if (!recording && !replayInFlight.get() && event !is SpeechEvent.Error) return
+        when (event) {
+            is SpeechEvent.SpeechStarted -> {
+                speechStartMs = System.currentTimeMillis()
+                store.setMic(MicState.LISTENING)
+                store.setStatus("listening")
+            }
+            is SpeechEvent.SpeechEnded -> {
+                speechEndMs = System.currentTimeMillis()
+                store.setStatus("transcribing")
+            }
+            is SpeechEvent.PartialTranscription -> store.setStatus("hearing: ${event.text}")
+            is SpeechEvent.TranscriptionCompleted -> {
+                val text = event.text.trim()
+                if (text.isNotEmpty()) handleCommand(text, event.sttMs, voiceAnchored = true)
+                else returnToRest()  // empty utterance — don't strand "transcribing"
+            }
+            is SpeechEvent.Error -> {
+                store.addNote("error: ${event.message}")
+                store.setStatus("error")
+            }
+            else -> {}
+        }
+    }
+
+    private fun handleCommand(text: String, sttMs: Float, voiceAnchored: Boolean) {
+        if (!turnInFlight.compareAndSet(false, true)) {
+            store.addNote("dropped (turn in flight): $text")
+            return
+        }
+        val turnId = store.beginTurn(text)
+        lifecycleScope.launch(Dispatchers.Default) {
+            try { runAgentTurn(turnId, text, sttMs, voiceAnchored) }
+            finally { turnInFlight.set(false) }
+        }
+    }
+
+    // FunctionGemma was trained on lowercase, unpunctuated utterances (the
+    // EOU model's output style). TDT emits cased, punctuated text; fold it
+    // back to the training distribution before routing. The UI transcript
+    // keeps the raw text.
+    private val llmPunct = Regex("[.,!?;:-]+")
+    private val llmSpaces = Regex("\\s+")
+    private fun normalizeForLlm(text: String): String =
+        text.lowercase().replace(llmPunct, " ").replace(llmSpaces, " ").trim()
+
+    /** STT/typed command → FunctionGemma tool call → device action → speak. */
+    private suspend fun runAgentTurn(turnId: Long, text: String, sttMs: Float, voiceAnchored: Boolean) {
+        val llm = functionGemma
+        val p = pipeline
+        if (llm == null || p == null) { store.addNote("LLM not ready yet"); return }
+        val speechSec = if (voiceAnchored && speechEndMs > speechStartMs)
+            (speechEndMs - speechStartMs) / 1000f else 0f
+
+        store.setMic(MicState.THINKING)
+        store.setStatus("thinking")
+        val llmStart = System.currentTimeMillis()
+        val turnAnchorMs = if (voiceAnchored && speechEndMs > 0) speechEndMs else llmStart
+
+        // Every command is routed by FunctionGemma. The tool list is filtered
+        // to the current device state (e.g. stop_music only while music plays),
+        // so the model can only choose valid actions.
+        var llmMs = 0L
+        var rawLength = 0
+        val musicPlaying = device.isMusicPlaying
+        val tools = ControlTools.availableTools(musicPlaying = musicPlaying)
+        val prompt = normalizeForLlm(text)
+        val raw = try {
+            // The Control adapter was trained on this compact serialization:
+            // schemas live in its weights, while the prompt carries the
+            // state-filtered function names and current music state.
+            val runtime = llmRuntime ?: error("LLM runtime not ready")
+            runtime.generate(CompactPrompt.format(tools, musicPlaying, prompt), 128)
+        } catch (e: Exception) {
+            Log.e(TAG, "LLM generation failed", e)
+            store.updateTurn(turnId) { it.copy(toolLabel = "llm error: ${e.message}", failed = true) }
+            returnToRest(); return
+        }
+        llmMs = System.currentTimeMillis() - llmStart
+        rawLength = raw.length
+        val calls = llm.parseToolCalls(raw)
+        val selectedCall = ControlTools.selectSingleCall(calls)
+        // Routing telemetry for analysis: input, what the model emitted, and
+        // which tool (of the state-filtered set) it chose.
+        Log.i(TAG, "ROUTE in='$prompt' musicPlaying=$musicPlaying " +
+            "compact=true " +
+            "tools=[${tools.joinToString(",") { it.name }}] " +
+            "calls=${calls.size} chose=${selectedCall?.name ?: "NONE"} " +
+            "raw='${raw.replace("\n", " ").take(160)}'")
+        val outcome = selectedCall?.let { call ->
+            try { ControlTools.execute(call, device) }
+            catch (e: Exception) { Log.e(TAG, "tool execution failed", e); null }
+        } ?: run {
+            val label = when {
+                calls.isEmpty() -> "no tool call"
+                calls.size > 1 -> "ambiguous: ${calls.size} tool calls"
+                else -> "unhandled: ${calls.single().name}"
+            }
+            store.updateTurn(turnId) { it.copy(toolLabel = label, failed = true) }
+            Log.i(TAG, "unparsed LLM output: ${raw.take(200)}")
+            null
+        }
+        val actionMs = System.currentTimeMillis() - turnAnchorMs
+
+        val spoken = outcome?.spoken ?: ControlTools.NO_TOOL_RESPONSE
+        outcome?.let { o -> store.updateTurn(turnId) { it.copy(toolLabel = o.label) } }
+        store.updateTurn(turnId) { it.copy(spoken = spoken) }
+
+        store.setMic(MicState.SPEAKING)
+        store.setStatus("speaking")
+        micPaused = true
+        // Pipelined speech: play piece N while synthesizing piece N+1, so
+        // the first sound lands after one short synthesis instead of after
+        // the whole reply. ttsMs reports time to first audio; ttsAudioSec
+        // totals every piece.
+        val pieces = SpeechChunks.split(spoken)
+        val ttsStart = System.currentTimeMillis()
+        var firstSoundMs = 0L
+        var audioSecTotal = 0f
+        try {
+            kotlinx.coroutines.coroutineScope {
+                var current = p.synthesize(pieces.first(), "en")
+                for (index in pieces.indices) {
+                    val following = if (index + 1 < pieces.size) {
+                        val nextText = pieces[index + 1]
+                        async(Dispatchers.Default) { p.synthesize(nextText, "en") }
+                    } else null
+
+                    if (firstSoundMs == 0L) {
+                        firstSoundMs = System.currentTimeMillis() - ttsStart
+                        val roundMs = System.currentTimeMillis() - turnAnchorMs
+                        val metrics = TurnMetrics(
+                            sttMs = sttMs, speechSec = speechSec,
+                            llmMs = llmMs, llmChars = rawLength,
+                            ttsMs = firstSoundMs, ttsAudioSec = 0f,
+                            actionMs = actionMs, roundMs = roundMs,
+                            memMb = memory.currentMb(),
+                        )
+                        store.updateTurn(turnId) { it.copy(metrics = metrics) }
+                        store.setLastMetrics(metrics)
+                        store.setMemory(memory.currentMb(), memory.peakMb)
+                        Log.i(TAG, "TURN ${metrics.format()}")
+                    }
+                    val sec = current.pcm16.size / 2f / current.sampleRate
+                    audioSecTotal += sec
+                    playPcm(current.pcm16, current.sampleRate)
+                    delay((sec * 1000).toLong() + 150)
+                    stopPlayback()
+                    current = following?.await() ?: break
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "TTS failed", e)
+            store.addNote("tts error: ${e.message}")
+            micPaused = false; returnToRest(); return
+        }
+        Log.i(TAG, "tts first-sound ${firstSoundMs}ms · pieces=${pieces.size} " +
+            "· audio ${"%.1f".format(audioSecTotal)}s · " +
+            "round ${System.currentTimeMillis() - turnAnchorMs}ms total")
+        micPaused = false
+        returnToRest()
+    }
+
+    // -----------------------------------------------------------------------
+    // Device actions — the real Android bindings behind the tools
+    // -----------------------------------------------------------------------
+
+    private inner class AndroidDeviceActions : DeviceActions {
+        @Volatile var nowPlaying: String? = null
+        @Volatile var lastCall: String? = null
+        @Volatile var lastContact: String? = null
+        private var audioFocus: AudioFocusRequest? = null
+
+        override val isMusicPlaying: Boolean
+            get() = try { mediaPlayer?.isPlaying == true } catch (_: Exception) { false }
+        val volumeLevel: Int
+            get() {
+                val am = getSystemService(AUDIO_SERVICE) as AudioManager
+                val max = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+                return if (max > 0)
+                    (am.getStreamVolume(AudioManager.STREAM_MUSIC) * 10f / max).roundToInt()
+                else 0
+            }
+
+        override fun lookupContact(name: String): Contact? {
+            if (checkSelfPermission(Manifest.permission.READ_CONTACTS)
+                != PackageManager.PERMISSION_GRANTED) {
+                store.addNote("contacts permission not granted"); return null
+            }
+            return try {
+                contentResolver.query(
+                    ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
+                    arrayOf(
+                        ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME,
+                        ContactsContract.CommonDataKinds.Phone.NUMBER,
+                    ),
+                    "${ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME} LIKE ?",
+                    arrayOf("%$name%"),
+                    ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME,
+                )?.use { cursor ->
+                    if (cursor.moveToFirst())
+                        Contact(cursor.getString(0), cursor.getString(1))
+                            .also { lastContact = "${it.name} · ${it.number}" }
+                    else null
+                }
+            } catch (e: SecurityException) { Log.w(TAG, "contact lookup denied", e); null }
+        }
+
+        override fun dial(number: String) {
+            lastCall = number
+            startActivity(Intent(Intent.ACTION_DIAL, Uri.fromParts("tel", number, null))
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        }
+
+        override fun playMusic(query: String?): Track? {
+            if (checkSelfPermission(mediaPermission) != PackageManager.PERMISSION_GRANTED) {
+                store.addNote("media permission not granted"); return null
+            }
+            val selection = query?.let {
+                "(${MediaStore.Audio.Media.TITLE} LIKE ? OR ${MediaStore.Audio.Media.ARTIST} LIKE ?)"
+            }
+            val args = query?.let { arrayOf("%$it%", "%$it%") }
+            return try {
+                contentResolver.query(
+                    MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                    arrayOf(MediaStore.Audio.Media._ID, MediaStore.Audio.Media.TITLE,
+                        MediaStore.Audio.Media.ARTIST),
+                    selection, args, MediaStore.Audio.Media.TITLE,
+                )?.use { cursor ->
+                    if (!cursor.moveToFirst()) return null
+                    val uri = ContentUris.withAppendedId(
+                        MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, cursor.getLong(0))
+                    val title = cursor.getString(1) ?: "track"
+                    val artist = cursor.getString(2)
+                        ?.takeUnless { it.isBlank() || it == MediaStore.UNKNOWN_STRING }
+                    stopMusic()
+
+                    val attrs = AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_MEDIA)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC).build()
+                    val am = getSystemService(AUDIO_SERVICE) as AudioManager
+                    // Without focus, Samsung routes media playback nowhere while
+                    // the assistant's TTS stream is active — the track "plays"
+                    // silently. Take focus so it reaches the speaker.
+                    val focus = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                        .setAudioAttributes(attrs).build()
+                    am.requestAudioFocus(focus)
+                    audioFocus = focus
+
+                    // "Play music" with the media stream at 0 just produces
+                    // silence (playback is muted, not stopped). Nudge it to
+                    // audible so the command actually does something; if the
+                    // user already set a level, leave it.
+                    val maxVol = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+                    if (am.getStreamVolume(AudioManager.STREAM_MUSIC) == 0) {
+                        am.setStreamVolume(AudioManager.STREAM_MUSIC, (maxVol * 0.6f).toInt(), 0)
+                    }
+
+                    mediaPlayer = MediaPlayer().apply {
+                        setAudioAttributes(attrs)
+                        setOnErrorListener { _, what, extra ->
+                            Log.e(TAG, "MediaPlayer error what=$what extra=$extra"); false
+                        }
+                        // Clean up when the track ends so isMusicPlaying (which
+                        // gates the stop_music tool) reflects reality.
+                        setOnCompletionListener { stopMusic() }
+                        setDataSource(this@ControlAgentActivity, uri)
+                        prepare()
+                        start()
+                    }
+                    Log.i(TAG, "music start: '$title' playing=${mediaPlayer?.isPlaying} " +
+                        "vol=${am.getStreamVolume(AudioManager.STREAM_MUSIC)}/$maxVol")
+
+                    Track(title, artist).also {
+                        nowPlaying = if (artist != null) "$title · $artist" else title
+                    }
+                }
+            } catch (e: Exception) { Log.w(TAG, "playMusic failed", e); null }
+        }
+
+        override fun listMusic(query: String?): List<Track> {
+            if (checkSelfPermission(mediaPermission) != PackageManager.PERMISSION_GRANTED) {
+                store.addNote("media permission not granted"); return emptyList()
+            }
+            val selection = query?.let {
+                "(${MediaStore.Audio.Media.TITLE} LIKE ? OR ${MediaStore.Audio.Media.ARTIST} LIKE ?)"
+            }
+            val args = query?.let { arrayOf("%$it%", "%$it%") }
+            return try {
+                contentResolver.query(
+                    MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                    arrayOf(MediaStore.Audio.Media.TITLE, MediaStore.Audio.Media.ARTIST),
+                    selection, args, MediaStore.Audio.Media.TITLE,
+                )?.use { cursor ->
+                    val tracks = mutableListOf<Track>()
+                    while (cursor.moveToNext() && tracks.size < 25) {
+                        val title = cursor.getString(0) ?: continue
+                        val artist = cursor.getString(1)
+                            ?.takeUnless { it.isBlank() || it == MediaStore.UNKNOWN_STRING }
+                        tracks.add(Track(title, artist))
+                    }
+                    tracks
+                } ?: emptyList()
+            } catch (e: Exception) {
+                Log.w(TAG, "listMusic failed", e); emptyList()
+            }
+        }
+
+        override fun stopMusic() {
+            mediaPlayer?.let { mp ->
+                mediaPlayer = null
+                try { mp.stop() } catch (_: Exception) {}
+                mp.release()
+            }
+            audioFocus?.let {
+                audioFocus = null
+                (getSystemService(AUDIO_SERVICE) as AudioManager).abandonAudioFocusRequest(it)
+            }
+            nowPlaying = null
+        }
+
+        override fun setVolume(level: Int) {
+            val am = getSystemService(AUDIO_SERVICE) as AudioManager
+            val max = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+            am.setStreamVolume(AudioManager.STREAM_MUSIC,
+                (level * max / 10f).roundToInt().coerceIn(0, max), 0)
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Audio out (agent speech)
+    // -----------------------------------------------------------------------
+
+    private fun playPcm(pcm: ByteArray, sampleRate: Int) {
+        stopPlayback()
+        val lead = sampleRate * 80 / 1000
+        val fadeIn = sampleRate * 5 / 1000
+        val fadeOut = sampleRate * 10 / 1000
+        val samples = pcm.size / 2
+        val out = ByteArray((lead + samples) * 2)
+        val src = java.nio.ByteBuffer.wrap(pcm).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        val dst = java.nio.ByteBuffer.wrap(out).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        dst.position(lead * 2)
+        val fadeOutStart = (samples - fadeOut).coerceAtLeast(0)
+        for (i in 0 until samples) {
+            val s = src.short.toInt()
+            val gain = when {
+                i < fadeIn -> i.toFloat() / fadeIn
+                i >= fadeOutStart -> (samples - i).toFloat() / fadeOut
+                else -> 1f
+            }
+            dst.putShort((s * gain).toInt().toShort())
+        }
+        val track = AudioTrack.Builder()
+            .setAudioAttributes(AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_ASSISTANT)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH).build())
+            .setAudioFormat(AudioFormat.Builder()
+                .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                .setSampleRate(sampleRate)
+                .setChannelMask(AudioFormat.CHANNEL_OUT_MONO).build())
+            .setTransferMode(AudioTrack.MODE_STATIC)
+            .setBufferSizeInBytes(out.size).build()
+        track.write(out, 0, out.size)
+        track.play()
+        audioTrack = track
+    }
+
+    private fun stopPlayback() {
+        audioTrack?.let { track ->
+            audioTrack = null
+            try { track.stop() } catch (_: Exception) {}
+            track.release()
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Microphone
+    // -----------------------------------------------------------------------
+
+    private fun toggleMicrophone() {
+        if (recording) {
+            stopMicrophone()
+            store.setMic(MicState.IDLE)
+            store.setStatus("tap to talk")
+        } else {
+            val wanted = arrayOf(Manifest.permission.RECORD_AUDIO,
+                Manifest.permission.READ_CONTACTS, mediaPermission)
+            val missing = wanted.filter {
+                checkSelfPermission(it) != PackageManager.PERMISSION_GRANTED
+            }
+            if (missing.isNotEmpty()) {
+                ActivityCompat.requestPermissions(this, missing.toTypedArray(), 1); return
+            }
+            startMicrophone()
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int, permissions: Array<String>, results: IntArray,
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, results)
+        if (requestCode == 1 &&
+            checkSelfPermission(Manifest.permission.RECORD_AUDIO)
+                == PackageManager.PERMISSION_GRANTED) {
+            startMicrophone()
+        }
+    }
+
+    /** Bench hook: stream a recorded mic_debug PCM file through the live
+     *  pipeline (bit-identical input across model/quant configs). ~4x
+     *  realtime; VAD timing derives from chunk count, not wallclock. */
+    private fun runReplay(name: String) {
+        val p = pipeline ?: return
+        val safeName = name.length in 1..128 && name.endsWith(".pcm") &&
+            name.all { it.isLetterOrDigit() || it == '.' || it == '_' || it == '-' }
+        if (!safeName) {
+            store.addNote("replay: invalid file name")
+            return
+        }
+        if (!replayInFlight.compareAndSet(false, true)) {
+            store.addNote("replay: already running")
+            return
+        }
+        lifecycleScope.launch(Dispatchers.IO) {
+            try {
+                val file = java.io.File(java.io.File(filesDir, "mic_debug"), name)
+                if (!file.exists()) {
+                    store.addNote("replay: $name not found")
+                    return@launch
+                }
+                micGain.reset()
+                store.addNote("replay: $name gain=$micGainEnabled stt=${activeStt()}")
+                Log.i(TAG, "REPLAY start $name gain=$micGainEnabled stt=${activeStt()}")
+                val bytes = file.readBytes()
+                val total = bytes.size / 2
+                val buf = FloatArray(512)
+                var index = 0
+                while (index < total && replayInFlight.get()) {
+                    val n = minOf(512, total - index)
+                    for (j in 0 until n) {
+                        val lo = bytes[2 * (index + j)].toInt() and 0xFF
+                        val hi = bytes[2 * (index + j) + 1].toInt()
+                        buf[j] = ((hi shl 8) or lo) / 32768f
+                    }
+                    if (n < 512) java.util.Arrays.fill(buf, n, 512, 0f)
+                    if (micGainEnabled) micGain.process(buf, n)
+                    p.pushAudio(buf)
+                    index += n
+                    // 512 samples = 32 ms of audio → push at ~1x real time so
+                    // heavier decoders (EOU beam search) get their real-time
+                    // budget. Pushing faster (was 8 ms = 4x) backs the beam up
+                    // and the pipeline truncates finals — a fixture artifact,
+                    // not a decoder bug.
+                    delay(32)
+                }
+                java.util.Arrays.fill(buf, 0f)
+                repeat(40) { p.pushAudio(buf); delay(32) }
+                Log.i(TAG, "REPLAY done $name")
+            } finally {
+                replayInFlight.set(false)
+            }
+        }
+    }
+
+    private fun startMicrophone() {
+        val p = pipeline ?: return
+        // Permissions are revocable while the app is running. Guard again at
+        // the point of use instead of relying only on toggleMicrophone().
+        if (checkSelfPermission(Manifest.permission.RECORD_AUDIO)
+            != PackageManager.PERMISSION_GRANTED) {
+            store.addNote("microphone permission not granted")
+            store.setMic(MicState.IDLE)
+            store.setStatus("tap to talk")
+            return
+        }
+        val sampleRate = 16000
+        val bufferSize = AudioRecord.getMinBufferSize(
+            sampleRate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_FLOAT)
+        if (bufferSize <= 0) { store.addNote("mic unavailable (code $bufferSize)"); return }
+        val record = try {
+            AudioRecord(MediaRecorder.AudioSource.VOICE_RECOGNITION, sampleRate,
+                AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_FLOAT, bufferSize)
+        } catch (e: SecurityException) {
+            Log.w(TAG, "microphone permission revoked", e)
+            store.addNote("microphone permission not granted")
+            return
+        }
+        if (record.state != AudioRecord.STATE_INITIALIZED) {
+            record.release(); store.addNote("mic init failed"); return
+        }
+        audioRecord = record
+        recording = true
+        micGain.reset()
+        // Duck our own playback while listening: full-volume music over the
+        // mic is the main SNR killer for speak-over-music commands.
+        try { mediaPlayer?.setVolume(0.25f, 0.25f) } catch (_: Exception) {}
+        try {
+            record.startRecording()
+        } catch (e: SecurityException) {
+            Log.w(TAG, "microphone permission revoked before recording", e)
+            recording = false
+            audioRecord = null
+            record.release()
+            store.addNote("microphone permission not granted")
+            return
+        }
+        store.setMic(MicState.LISTENING)
+        store.setStatus("listening")
+        if (micDebugEnabled) {
+            try {
+                val dir = java.io.File(filesDir, "mic_debug").apply { mkdirs() }
+                dir.listFiles()?.sortedBy { it.name }?.dropLast(4)?.forEach { it.delete() }
+                val file = java.io.File(dir, "mic_${System.currentTimeMillis()}.pcm")
+                micDebugStream = java.io.FileOutputStream(file)
+                store.addNote("mic debug: recording to ${file.name} (16 kHz mono s16le)")
+            } catch (e: Exception) {
+                Log.w(TAG, "mic debug open failed", e)
+            }
+        }
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            val buffer = FloatArray(512)
+            val debugBytes = ByteArray(buffer.size * 2)
+            var deadReads = 0
+            while (recording) {
+                val read = try {
+                    audioRecord?.read(buffer, 0, buffer.size, AudioRecord.READ_BLOCKING) ?: 0
+                } catch (_: IllegalStateException) { break }
+                if (read > 0) micDebugStream?.let { stream ->
+                    // Full-session tap: every captured sample, even while the
+                    // agent is speaking (micPaused), so end-of-utterance and
+                    // echo behavior can be analyzed offline.
+                    try {
+                        var b = 0
+                        for (i in 0 until read) {
+                            val s = (buffer[i].coerceIn(-1f, 1f) * 32767f).toInt()
+                            debugBytes[b++] = (s and 0xFF).toByte()
+                            debugBytes[b++] = ((s shr 8) and 0xFF).toByte()
+                        }
+                        stream.write(debugBytes, 0, read * 2)
+                    } catch (e: Exception) {
+                        Log.w(TAG, "mic debug write failed", e)
+                        if (micDebugStream === stream) micDebugStream = null
+                        runCatching { stream.close() }
+                    }
+                }
+                if (read > 0 && !micPaused) {
+                    deadReads = 0
+                    if (micGainEnabled) micGain.process(buffer, read)
+                    p.pushAudio(buffer)
+                    var peak = 0f
+                    for (i in 0 until read) { val a = abs(buffer[i]); if (a > peak) peak = a }
+                    store.setMicLevel(peak)
+                } else if (micPaused) {
+                    store.setMicLevel(0f)
+                } else if (read <= 0 && ++deadReads > 40) {
+                    // Blocking reads returning nothing: the input device died
+                    // underneath us (seen with QEMU audio after playback).
+                    Log.w(TAG, "mic delivering no audio — ending session")
+                    break
+                }
+            }
+            // If the loop ended while the session was still supposed to be
+            // live, resync state so the UI never shows a dead "listening".
+            if (recording) {
+                recording = false
+                runCatching { audioRecord?.release() }
+                audioRecord = null
+                store.setMicLevel(0f)
+                store.setMic(MicState.IDLE)
+                store.setStatus("mic ended — tap to talk")
+                store.addNote("mic session ended unexpectedly — tap the orb to restart")
+            }
+        }
+    }
+
+    private fun stopMicrophone() {
+        recording = false
+        try { mediaPlayer?.setVolume(1f, 1f) } catch (_: Exception) {}
+        audioRecord?.stop()
+        audioRecord?.release()
+        audioRecord = null
+        store.setMicLevel(0f)
+        micDebugStream?.let { stream ->
+            micDebugStream = null
+            try { stream.close() } catch (_: Exception) {}
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Lifecycle
+    // -----------------------------------------------------------------------
+
+    override fun onStop() {
+        super.onStop()
+        if (recording) {
+            stopMicrophone()
+            store.setMic(MicState.IDLE)
+            store.setStatus("tap to talk")
+        }
+        micPaused = false
+        stopPlayback()
+    }
+
+    override fun onDestroy() {
+        stopMicrophone()
+        stopPlayback()
+        device.stopMusic()
+        memory.stop()
+        pipeline?.stop()
+        pipeline?.close()
+        llmRuntime?.close()
+        super.onDestroy()
+    }
+}

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlAgentActivity.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlAgentActivity.kt
@@ -10,12 +10,12 @@ import android.media.AudioFocusRequest
 import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioRecord
-import android.media.AudioTrack
 import android.media.MediaPlayer
 import android.media.MediaRecorder
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.SystemClock
 import android.provider.ContactsContract
 import android.provider.MediaStore
 import android.util.Log
@@ -33,7 +33,9 @@ import audio.soniqo.speech.PipelineMode
 import audio.soniqo.speech.SpeechConfig
 import audio.soniqo.speech.SpeechEvent
 import audio.soniqo.speech.SpeechPipeline
+import audio.soniqo.speech.SpeechSynthesisResult
 import audio.soniqo.speech.SttModel
+import audio.soniqo.speech.TtsModel
 import audio.soniqo.speech.control.ui.ControlActions
 import audio.soniqo.speech.control.ui.ControlScreen
 import audio.soniqo.speech.control.ui.SoniqoControlTheme
@@ -41,10 +43,11 @@ import audio.soniqo.speech.llm.FunctionGemma
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -55,8 +58,8 @@ import kotlinx.coroutines.withContext
  * voice agent on-device: one pipeline, three memory budgets":
  *
  *   Silero VAD → Parakeet-EOU 120M (TRANSCRIBE_ONLY) → FunctionGemma 270M
- *   (LiteRT-LM) → device tool (dial / contacts / music / volume) → Kokoro
- *   speaks the model-authored `say` argument.
+ *   (LiteRT-LM) → device tool (dial / contacts / music / volume) → Pocket
+ *   TTS streams the model-authored `say` argument.
  *
  * The UI is Jetpack Compose ([ControlScreen]) subscribing to a single
  * [ControlStore] state flow; this Activity owns the pipeline and pushes
@@ -70,7 +73,8 @@ class ControlAgentActivity : ComponentActivity() {
     private var llmRuntime: LiteRtLmRuntime? = null
     private var functionGemma: FunctionGemma? = null
     private var audioRecord: AudioRecord? = null
-    private var audioTrack: AudioTrack? = null
+    private val speechPlayerLock = Any()
+    @Volatile private var speechPlayer: StreamingPcmPlayer? = null
     private var mediaPlayer: MediaPlayer? = null
 
     @Volatile private var recording = false
@@ -106,7 +110,7 @@ class ControlAgentActivity : ComponentActivity() {
 
     private fun activeStt(): SttModel =
         sttOverride?.let { runCatching { SttModel.valueOf(it) }.getOrNull() } ?: DEMO_STT
-    // Drives the Kokoro voice (and Nemotron's prompt slot if ever selected).
+    // Drives the TTS language (and Nemotron's prompt slot if ever selected).
     // Parakeet STT autodetects regardless — like every other Parakeet
     // runtime, there is no language forcing, so accented speech can
     // occasionally decode into a non-Latin script on the multilingual TDT.
@@ -147,6 +151,9 @@ class ControlAgentActivity : ComponentActivity() {
         // ~891 MB download and ~2 GB total, which is ~5× slower under
         // emulation and needs a real device with an NPU to feel good.
         private val DEMO_STT = SttModel.PARAKEET_EOU
+        // Pocket is a recurrent ONNX model that emits real 80 ms frames. Keep
+        // Kokoro available through the SDK for multilingual/voice selection.
+        private val DEMO_TTS = TtsModel.POCKET
 
         // Parakeet-EOU RNN-T decode width. > 1 enables beam search, which
         // contextual biasing (buildContextPhrases) rides on. Truncation seen in
@@ -232,6 +239,7 @@ class ControlAgentActivity : ComponentActivity() {
     /** Friendly stage name for a model file, so the status reads "downloading
      *  transcription model" instead of "downloading parakeet-eou-encoder.onnx". */
     private fun modelLabel(file: String): String = when {
+        file.startsWith("pocket_tts/") -> "speech synthesis"
         file.startsWith("silero") -> "voice detection"
         file.startsWith("parakeet") || file == "vocab.json" || file == "config.json" ||
             file == "encoder.onnx" || file == "decoder.onnx" || file == "joint.onnx" ||
@@ -266,6 +274,7 @@ class ControlAgentActivity : ComponentActivity() {
             applicationContext,
             ModelPrecision.INT8,
             sttModel = activeStt(),
+            ttsModel = DEMO_TTS,
             includeLlm = true,
             llmModel = LlmModel.FUNCTIONGEMMA_CONTROL_LORA,
         )
@@ -275,6 +284,7 @@ class ControlAgentActivity : ComponentActivity() {
             .getWorkInfosForUniqueWorkLiveData(
                 ModelDownloadWorker.uniqueName(
                     sttModel = activeStt(),
+                    ttsModel = DEMO_TTS,
                     includeLlm = true,
                     llmModel = LlmModel.FUNCTIONGEMMA_CONTROL_LORA,
                 ))
@@ -318,6 +328,7 @@ class ControlAgentActivity : ComponentActivity() {
                     modelDir = modelDir,
                     useNnapi = !isEmulator,
                     sttModel = activeStt(),
+                    ttsModel = DEMO_TTS,
                     pipelineMode = PipelineMode.TRANSCRIBE_ONLY,
                     emitPartialTranscriptions = true,
                     language = activeLanguage(),
@@ -330,6 +341,14 @@ class ControlAgentActivity : ComponentActivity() {
                 ))
                 pipeline = p
                 bench("pipeline loaded")
+
+                // Samsung takes roughly 225 ms to allocate its AudioTrack.
+                // Pay that once while models are loading, then retain the
+                // stream across turns so it is never on the TTFA path.
+                if (DEMO_TTS == TtsModel.POCKET) {
+                    acquireSpeechPlayer(p.ttsSampleRate)
+                    bench("speech output ready")
+                }
 
                 launch { p.events.collect { onSpeechEvent(it) } }
                 p.start()
@@ -507,44 +526,113 @@ class ControlAgentActivity : ComponentActivity() {
         store.setMic(MicState.SPEAKING)
         store.setStatus("speaking")
         micPaused = true
-        // Pipelined speech: play piece N while synthesizing piece N+1, so
-        // the first sound lands after one short synthesis instead of after
-        // the whole reply. ttsMs reports time to first audio; ttsAudioSec
-        // totals every piece.
-        val pieces = SpeechChunks.split(spoken)
-        val ttsStart = System.currentTimeMillis()
-        var firstSoundMs = 0L
+        // Pocket is genuinely recurrent, so send it the whole response and
+        // play its 80 ms callbacks through one continuous AudioTrack. Kokoro
+        // retains bounded app-side splitting for its fixed output graph.
+        val pieces = if (DEMO_TTS == TtsModel.POCKET) listOf(spoken) else SpeechChunks.split(spoken)
+        val ttsStartWallMs = System.currentTimeMillis()
+        val ttsStartNanos = SystemClock.elapsedRealtimeNanos()
+        val firstChunkMs = AtomicLong(0)
+        val firstPresentationMs = AtomicLong(0)
+        var playbackStartMs = 0L
         var audioSecTotal = 0f
+        var nativeChunks = 0
+        var playbackUnderruns = 0
+        var playbackPerformanceMode = -1
+        var playbackBufferBytes = 0
+
+        fun publishFirstAudioMetrics(ttsMs: Long) {
+            val roundMs = (ttsStartWallMs - turnAnchorMs + ttsMs).coerceAtLeast(ttsMs)
+            val metrics = TurnMetrics(
+                sttMs = sttMs, speechSec = speechSec,
+                llmMs = llmMs, llmChars = rawLength,
+                ttsMs = ttsMs, ttsAudioSec = 0f,
+                actionMs = actionMs, roundMs = roundMs,
+                memMb = memory.currentMb(),
+            )
+            store.updateTurn(turnId) { it.copy(metrics = metrics) }
+            store.setLastMetrics(metrics)
+            store.setMemory(memory.currentMb(), memory.peakMb)
+            Log.i(TAG, "TURN ${metrics.format()}")
+        }
+
         try {
             kotlinx.coroutines.coroutineScope {
-                var current = p.synthesize(pieces.first(), "en")
-                for (index in pieces.indices) {
-                    val following = if (index + 1 < pieces.size) {
-                        val nextText = pieces[index + 1]
-                        async(Dispatchers.Default) { p.synthesize(nextText, "en") }
-                    } else null
-
-                    if (firstSoundMs == 0L) {
-                        firstSoundMs = System.currentTimeMillis() - ttsStart
-                        val roundMs = System.currentTimeMillis() - turnAnchorMs
-                        val metrics = TurnMetrics(
-                            sttMs = sttMs, speechSec = speechSec,
-                            llmMs = llmMs, llmChars = rawLength,
-                            ttsMs = firstSoundMs, ttsAudioSec = 0f,
-                            actionMs = actionMs, roundMs = roundMs,
-                            memMb = memory.currentMb(),
-                        )
-                        store.updateTurn(turnId) { it.copy(metrics = metrics) }
-                        store.setLastMetrics(metrics)
-                        store.setMemory(memory.currentMb(), memory.peakMb)
-                        Log.i(TAG, "TURN ${metrics.format()}")
+                val audio = Channel<SpeechSynthesisResult>(Channel.UNLIMITED)
+                val producer = launch(Dispatchers.Default) {
+                    try {
+                        for (piece in pieces) {
+                            p.synthesizeStreaming(piece, "en") { chunk, _ ->
+                                // Pocket terminates with an empty final callback;
+                                // it is control flow, not an audio frame.
+                                if (chunk.pcm16.isNotEmpty()) {
+                                    firstChunkMs.compareAndSet(
+                                        0,
+                                        (SystemClock.elapsedRealtimeNanos() - ttsStartNanos) /
+                                            1_000_000,
+                                    )
+                                    check(audio.trySend(chunk).isSuccess) {
+                                        "TTS playback channel closed"
+                                    }
+                                }
+                            }
+                        }
+                    } catch (e: Throwable) {
+                        audio.close(e)
+                        throw e
+                    } finally {
+                        audio.close()
                     }
-                    val sec = current.pcm16.size / 2f / current.sampleRate
-                    audioSecTotal += sec
-                    playPcm(current.pcm16, current.sampleRate)
-                    delay((sec * 1000).toLong() + 150)
-                    stopPlayback()
-                    current = following?.await() ?: break
+                }
+                var playbackCompleted = false
+                try {
+                    var player: StreamingPcmPlayer? = null
+                    var presentationWatcher: kotlinx.coroutines.Job? = null
+                    for (current in audio) {
+                        nativeChunks++
+                        val sec = current.pcm16.size / 2f / current.sampleRate
+                        audioSecTotal += sec
+                        val active = player
+                        if (active == null) {
+                            val created = acquireSpeechPlayer(current.sampleRate)
+                            player = created
+                            created.start(current.pcm16)
+                            playbackStartMs =
+                                (SystemClock.elapsedRealtimeNanos() - ttsStartNanos) / 1_000_000
+                            playbackPerformanceMode = created.performanceMode
+                            playbackBufferBytes = created.bufferSizeBytes
+                            publishFirstAudioMetrics(playbackStartMs)
+                            presentationWatcher = launch(Dispatchers.Default) {
+                                created.awaitFirstPresentationNanos()?.let { presentedNanos ->
+                                    val presentedMs = ((presentedNanos - ttsStartNanos) / 1_000_000)
+                                        .coerceAtLeast(playbackStartMs)
+                                    firstPresentationMs.set(presentedMs)
+                                    publishFirstAudioMetrics(presentedMs)
+                                    Log.i(
+                                        TAG,
+                                        "tts first-presentation ${presentedMs}ms " +
+                                            "(model callback ${firstChunkMs.get()}ms)",
+                                    )
+                                }
+                            }
+                        } else {
+                            check(active.sampleRate == current.sampleRate) {
+                                "TTS sample rate changed mid-turn: " +
+                                    "${active.sampleRate} -> ${current.sampleRate}"
+                            }
+                            active.write(current.pcm16)
+                        }
+                    }
+                    producer.join()
+                    val active = player ?: error("TTS completed without audio")
+                    active.awaitDrained()
+                    presentationWatcher?.join()
+                    playbackUnderruns = active.underrunCount
+                    active.resetForNextUtterance()
+                    playbackCompleted = true
+                } finally {
+                    if (producer.isActive) p.cancelSynthesis()
+                    if (!playbackCompleted) stopPlayback()
                 }
             }
         } catch (e: Exception) {
@@ -552,8 +640,16 @@ class ControlAgentActivity : ComponentActivity() {
             store.addNote("tts error: ${e.message}")
             micPaused = false; returnToRest(); return
         }
-        Log.i(TAG, "tts first-sound ${firstSoundMs}ms · pieces=${pieces.size} " +
-            "· audio ${"%.1f".format(audioSecTotal)}s · " +
+        val presentedMs = firstPresentationMs.get().takeIf { it > 0 } ?: playbackStartMs
+        val perf = if (playbackPerformanceMode == android.media.AudioTrack.PERFORMANCE_MODE_LOW_LATENCY) {
+            "low-latency"
+        } else {
+            "normal"
+        }
+        Log.i(TAG, "tts model-callback ${firstChunkMs.get()}ms · playback-start ${playbackStartMs}ms " +
+            "· first-presentation ${presentedMs}ms · app-pieces=${pieces.size} " +
+            "· native-frames=$nativeChunks · audio ${"%.1f".format(audioSecTotal)}s " +
+            "· output=$perf buffer=$playbackBufferBytes underruns=$playbackUnderruns · " +
             "round ${System.currentTimeMillis() - turnAnchorMs}ms total")
         micPaused = false
         returnToRest()
@@ -729,47 +825,20 @@ class ControlAgentActivity : ComponentActivity() {
     // Audio out (agent speech)
     // -----------------------------------------------------------------------
 
-    private fun playPcm(pcm: ByteArray, sampleRate: Int) {
-        stopPlayback()
-        val lead = sampleRate * 80 / 1000
-        val fadeIn = sampleRate * 5 / 1000
-        val fadeOut = sampleRate * 10 / 1000
-        val samples = pcm.size / 2
-        val out = ByteArray((lead + samples) * 2)
-        val src = java.nio.ByteBuffer.wrap(pcm).order(java.nio.ByteOrder.LITTLE_ENDIAN)
-        val dst = java.nio.ByteBuffer.wrap(out).order(java.nio.ByteOrder.LITTLE_ENDIAN)
-        dst.position(lead * 2)
-        val fadeOutStart = (samples - fadeOut).coerceAtLeast(0)
-        for (i in 0 until samples) {
-            val s = src.short.toInt()
-            val gain = when {
-                i < fadeIn -> i.toFloat() / fadeIn
-                i >= fadeOutStart -> (samples - i).toFloat() / fadeOut
-                else -> 1f
-            }
-            dst.putShort((s * gain).toInt().toShort())
+    private fun acquireSpeechPlayer(sampleRate: Int): StreamingPcmPlayer =
+        synchronized(speechPlayerLock) {
+            speechPlayer?.also {
+                check(it.sampleRate == sampleRate) {
+                    "TTS sample rate changed: ${it.sampleRate} -> $sampleRate"
+                }
+            } ?: StreamingPcmPlayer(sampleRate).also { speechPlayer = it }
         }
-        val track = AudioTrack.Builder()
-            .setAudioAttributes(AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_ASSISTANT)
-                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH).build())
-            .setAudioFormat(AudioFormat.Builder()
-                .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-                .setSampleRate(sampleRate)
-                .setChannelMask(AudioFormat.CHANNEL_OUT_MONO).build())
-            .setTransferMode(AudioTrack.MODE_STATIC)
-            .setBufferSizeInBytes(out.size).build()
-        track.write(out, 0, out.size)
-        track.play()
-        audioTrack = track
-    }
 
     private fun stopPlayback() {
-        audioTrack?.let { track ->
-            audioTrack = null
-            try { track.stop() } catch (_: Exception) {}
-            track.release()
-        }
+        val player = synchronized(speechPlayerLock) {
+            speechPlayer.also { speechPlayer = null }
+        } ?: return
+        player.close()
     }
 
     // -----------------------------------------------------------------------

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlStore.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlStore.kt
@@ -1,0 +1,89 @@
+package audio.soniqo.speech.control
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+
+/** Push-to-talk visual state. */
+enum class MicState { OFFLINE, IDLE, LISTENING, THINKING, SPEAKING }
+
+sealed interface FeedItem { val id: Long }
+
+/** Instrumentation note (bench lines, hints, errors). */
+data class SystemNote(override val id: Long, val text: String) : FeedItem
+
+/** One voice/typed command, filled in as the turn progresses. */
+data class Turn(
+    override val id: Long,
+    val utterance: String,
+    val toolLabel: String? = null,
+    val spoken: String? = null,
+    val metrics: TurnMetrics? = null,
+    val failed: Boolean = false,
+) : FeedItem
+
+data class ControlUiState(
+    val status: String = "initializing",
+    val micState: MicState = MicState.OFFLINE,
+    val micLevel: Float = 0f,
+    /** null = no download in flight. */
+    val downloadPercent: Int? = null,
+    /** Friendly label of the model currently downloading (for the setup panel). */
+    val downloadStage: String? = null,
+    val memNowMb: Int = 0,
+    val memPeakMb: Int = 0,
+    /** Latencies of the most recent completed turn, for the status line. */
+    val lastMetrics: TurnMetrics? = null,
+    val feed: List<FeedItem> = emptyList(),
+    val showTypeDialog: Boolean = false,
+    val showInfoDialog: Boolean = false,
+)
+
+/**
+ * Single source of truth for the screen — the zustand analog: one state
+ * flow, small named mutations, UI subscribes and recomposes. All methods are
+ * safe to call from any thread.
+ */
+class ControlStore {
+
+    private val _state = MutableStateFlow(ControlUiState())
+    val state: StateFlow<ControlUiState> = _state
+
+    private var nextId = 1L
+    private fun id(): Long = synchronized(this) { nextId++ }
+
+    fun setStatus(text: String) = _state.update { it.copy(status = text) }
+
+    fun setMic(mic: MicState) = _state.update { it.copy(micState = mic) }
+
+    fun setMicLevel(level: Float) = _state.update { it.copy(micLevel = level) }
+
+    fun setDownload(percent: Int?) = _state.update { it.copy(downloadPercent = percent) }
+
+    fun setDownloadStage(stage: String?) = _state.update { it.copy(downloadStage = stage) }
+
+    fun setMemory(nowMb: Int, peakMb: Int) =
+        _state.update { it.copy(memNowMb = nowMb, memPeakMb = peakMb) }
+
+    fun setLastMetrics(metrics: TurnMetrics) =
+        _state.update { it.copy(lastMetrics = metrics) }
+
+    fun setTypeDialog(visible: Boolean) = _state.update { it.copy(showTypeDialog = visible) }
+
+    fun setInfoDialog(visible: Boolean) = _state.update { it.copy(showInfoDialog = visible) }
+
+    fun addNote(text: String) = _state.update {
+        it.copy(feed = it.feed + SystemNote(id(), text))
+    }
+
+    /** Start a turn card; returns its id for the follow-up updates. */
+    fun beginTurn(utterance: String): Long {
+        val turnId = id()
+        _state.update { it.copy(feed = it.feed + Turn(turnId, utterance)) }
+        return turnId
+    }
+
+    fun updateTurn(turnId: Long, transform: (Turn) -> Turn) = _state.update { s ->
+        s.copy(feed = s.feed.map { if (it is Turn && it.id == turnId) transform(it) else it })
+    }
+}

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlTools.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlTools.kt
@@ -140,10 +140,8 @@ object ControlTools {
 
     /** Spoken by list_capabilities — the executor states the real surface,
      *  the model's `say` is ignored (it tends to under- or over-promise). */
-    // Longer than the Kokoro export's single-call 5 s output budget on
-    // purpose: speech-core synthesizes long text in sentence chunks
-    // (speech-core#104), and this string exercises that path on every
-    // "what can you do".
+    // Deliberately long enough to exercise multi-frame streaming on every
+    // "what can you do" response.
     const val CAPABILITIES_SUMMARY =
         "I can call your contacts, dial numbers, look up phone numbers, " +
         "play or stop music, and set the volume — all offline, on this device."

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlTools.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlTools.kt
@@ -1,0 +1,288 @@
+package audio.soniqo.speech.control
+
+import audio.soniqo.speech.llm.ArgumentValue
+import audio.soniqo.speech.llm.FunctionCall
+import audio.soniqo.speech.llm.FunctionDeclaration
+
+/**
+ * Phone-control tool surface for FunctionGemma.
+ *
+ * Every tool takes a `say` string parameter — a short confirmation the model
+ * writes for the driver/user, so one LLM pass authors both the action and
+ * the sentence TTS speaks. `say` is honored on action tools whose outcome
+ * the model can predict (dial, volume, stop). Lookup tools (find_contact,
+ * call_contact, play_music) speak the actual device result instead — the
+ * model cannot know what the address book or media store will return, so
+ * the "function response" turn is collapsed into a result template.
+ */
+object ControlTools {
+
+    private val SAY_PARAM = mapOf(
+        "type" to "STRING",
+        "description" to "Short spoken confirmation for the user, one sentence",
+    )
+
+    val declarations: List<FunctionDeclaration> = listOf(
+        FunctionDeclaration(
+            name = "call_contact",
+            description = "Call a person from the address book by name",
+            parameters = mapOf(
+                "type" to "OBJECT",
+                "properties" to mapOf(
+                    "name" to mapOf(
+                        "type" to "STRING",
+                        "description" to "Contact name to call, e.g. Anna",
+                    ),
+                    "say" to SAY_PARAM,
+                ),
+                "required" to listOf("name", "say"),
+            ),
+        ),
+        FunctionDeclaration(
+            name = "dial_number",
+            description = "Dial a phone number the user spoke digit by digit",
+            parameters = mapOf(
+                "type" to "OBJECT",
+                "properties" to mapOf(
+                    "number" to mapOf(
+                        "type" to "STRING",
+                        // No example number here: the 270M model copies
+                        // literal examples into its arguments verbatim.
+                        "description" to "The phone number to dial",
+                    ),
+                    "say" to SAY_PARAM,
+                ),
+                "required" to listOf("number", "say"),
+            ),
+        ),
+        FunctionDeclaration(
+            name = "find_contact",
+            // Keep this description short and plain: longer variants (e.g.
+            // "... without calling them") measurably degrade the 270M
+            // model's call syntax on adjacent queries.
+            description = "Look up a person's phone number in the address book",
+            parameters = mapOf(
+                "type" to "OBJECT",
+                "properties" to mapOf(
+                    "name" to mapOf(
+                        "type" to "STRING",
+                        "description" to "Contact name to search for",
+                    ),
+                    "say" to SAY_PARAM,
+                ),
+                "required" to listOf("name", "say"),
+            ),
+        ),
+        FunctionDeclaration(
+            name = "find_music",
+            description = "List or search songs and artists in the music library without playing",
+            parameters = mapOf(
+                "type" to "OBJECT",
+                "properties" to mapOf(
+                    "query" to mapOf(
+                        "type" to "STRING",
+                        "description" to "Song title or artist to search for; omit to list available music",
+                    ),
+                    "say" to SAY_PARAM,
+                ),
+                "required" to listOf("say"),
+            ),
+        ),
+        FunctionDeclaration(
+            name = "play_music",
+            description = "Play music from the device library, optionally matching a song or artist",
+            parameters = mapOf(
+                "type" to "OBJECT",
+                "properties" to mapOf(
+                    "query" to mapOf(
+                        "type" to "STRING",
+                        "description" to "Song title or artist to play; omit for any music",
+                    ),
+                    "say" to SAY_PARAM,
+                ),
+                "required" to listOf("say"),
+            ),
+        ),
+        FunctionDeclaration(
+            name = "stop_music",
+            description = "Stop music playback",
+            parameters = mapOf(
+                "type" to "OBJECT",
+                "properties" to mapOf("say" to SAY_PARAM),
+                "required" to listOf("say"),
+            ),
+        ),
+        FunctionDeclaration(
+            name = "set_volume",
+            description = "Set the media volume",
+            parameters = mapOf(
+                "type" to "OBJECT",
+                "properties" to mapOf(
+                    "level" to mapOf(
+                        "type" to "INTEGER",
+                        "description" to "Volume 0 (mute) to 10 (max)",
+                    ),
+                    "say" to SAY_PARAM,
+                ),
+                "required" to listOf("level", "say"),
+            ),
+        ),
+        FunctionDeclaration(
+            name = "list_capabilities",
+            description = "Tell the user what you can do and which commands are available",
+            parameters = mapOf(
+                "type" to "OBJECT",
+                "properties" to mapOf("say" to SAY_PARAM),
+                "required" to listOf("say"),
+            ),
+        ),
+    )
+
+    /** Spoken by list_capabilities — the executor states the real surface,
+     *  the model's `say` is ignored (it tends to under- or over-promise). */
+    // Longer than the Kokoro export's single-call 5 s output budget on
+    // purpose: speech-core synthesizes long text in sentence chunks
+    // (speech-core#104), and this string exercises that path on every
+    // "what can you do".
+    const val CAPABILITIES_SUMMARY =
+        "I can call your contacts, dial numbers, look up phone numbers, " +
+        "play or stop music, and set the volume — all offline, on this device."
+
+    val VOLUME_RANGE = 0..10
+
+    /** Spoken fallback when the model produced no parseable tool call. */
+    const val NO_TOOL_RESPONSE = "Sorry, I can't do that. Ask me what I can do."
+
+    /**
+     * The tools offered to FunctionGemma for the current device state. Only
+     * valid actions are presented, so the model can't pick something that
+     * makes no sense: stop_music appears only while music is playing (you
+     * can't stop what isn't playing). Calling, lookups, volume, and play are
+     * always available. Everything is routed by the model — no hardcoded
+     * command matching.
+     */
+    fun availableTools(musicPlaying: Boolean): List<FunctionDeclaration> =
+        declarations.filter { it.name != "stop_music" || musicPlaying }
+
+    /**
+     * A spoken command represents one device action. Reject malformed model
+     * output containing zero or multiple calls instead of guessing which
+     * action the user intended.
+     */
+    internal fun selectSingleCall(calls: List<FunctionCall>): FunctionCall? =
+        calls.singleOrNull()
+
+    /**
+     * Execute [call] against [device]. Returns null for an unknown tool or
+     * missing required argument. Pure orchestration — all Android work is
+     * behind [DeviceActions] — so the mapping is unit-testable.
+     */
+    fun execute(call: FunctionCall, device: DeviceActions): ToolOutcome? {
+        val say = call.string("say")
+        return when (call.name) {
+            "call_contact" -> {
+                val name = call.string("name") ?: return null
+                val contact = device.lookupContact(name)
+                if (contact == null) {
+                    // Never speak the model's success line for a failed lookup.
+                    ToolOutcome(
+                        "I couldn't find $name in your contacts.",
+                        label(call.name, "name" to name),
+                    )
+                } else {
+                    device.stopMusic()  // a call takes over audio; stop the music
+                    device.dial(contact.number)
+                    ToolOutcome(
+                        say ?: "Calling ${contact.name}.",
+                        label(call.name, "name" to name),
+                    )
+                }
+            }
+            "dial_number" -> {
+                val number = call.string("number") ?: return null
+                device.stopMusic()  // a call takes over audio; stop the music
+                device.dial(number)
+                ToolOutcome(say ?: "Calling $number.", label(call.name, "number" to number))
+            }
+            "find_contact" -> {
+                val name = call.string("name") ?: return null
+                val contact = device.lookupContact(name)
+                ToolOutcome(
+                    contact?.let { "${it.name}'s number is ${it.number}." }
+                        ?: "No contact named $name.",
+                    label(call.name, "name" to name),
+                )
+            }
+            "find_music" -> {
+                val query = call.string("query")
+                val tracks = device.listMusic(query)
+                ToolOutcome(
+                    when {
+                        tracks.isEmpty() && query == null ->
+                            "There is no music on this device."
+                        tracks.isEmpty() -> "No music matching $query."
+                        else -> {
+                            val sample = tracks.take(3).joinToString(", ") {
+                                if (it.artist != null) "${it.title} by ${it.artist}"
+                                else it.title
+                            }
+                            if (tracks.size > 3)
+                                "You have ${tracks.size} tracks, including $sample."
+                            else "You have: $sample."
+                        }
+                    },
+                    label(call.name, "query" to (query ?: "*")),
+                )
+            }
+            "play_music" -> {
+                val query = call.string("query")
+                // The 270M model sometimes invents a query for a generic
+                // "play some music" — when the requested match misses, fall
+                // back to any track rather than refusing to play.
+                val track = device.playMusic(query) ?: device.playMusic(null)
+                ToolOutcome(
+                    when {
+                        track == null -> "No music found on this device."
+                        track.artist != null -> "Playing ${track.title} by ${track.artist}."
+                        else -> "Playing ${track.title}."
+                    },
+                    label(call.name, "query" to (query ?: "*")),
+                )
+            }
+            "stop_music" -> {
+                device.stopMusic()
+                ToolOutcome(say ?: "Music stopped.", label(call.name))
+            }
+            "set_volume" -> {
+                val level = (call.int("level") ?: return null).coerceIn(VOLUME_RANGE)
+                device.setVolume(level)
+                ToolOutcome(say ?: "Volume $level.", label(call.name, "level" to level))
+            }
+            "list_capabilities" -> ToolOutcome(CAPABILITIES_SUMMARY, label(call.name))
+            else -> null
+        }
+    }
+
+    private fun label(name: String, vararg args: Pair<String, Any?>): String =
+        "$name {${args.joinToString(", ") { "${it.first}: ${it.second}" }}}"
+}
+
+// ---------------------------------------------------------------------------
+// Typed accessors over parsed FunctionGemma arguments. The 270M model
+// occasionally emits an int where a string is declared (or vice versa), so
+// each accessor coerces the near-miss encodings instead of failing the turn.
+// ---------------------------------------------------------------------------
+
+internal fun FunctionCall.string(key: String): String? = when (val v = arguments[key]) {
+    is ArgumentValue.Str -> v.value.trim().ifEmpty { null }
+    is ArgumentValue.Int -> v.value.toString()
+    is ArgumentValue.Double -> v.value.toString()
+    else -> null
+}
+
+internal fun FunctionCall.int(key: String): Int? = when (val v = arguments[key]) {
+    is ArgumentValue.Int -> v.value.toInt()
+    is ArgumentValue.Double -> v.value.toInt()
+    is ArgumentValue.Str -> v.value.trim().toDoubleOrNull()?.toInt()
+    else -> null
+}

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/DeviceActions.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/DeviceActions.kt
@@ -1,0 +1,42 @@
+package audio.soniqo.speech.control
+
+/** A contact hit from the address book. */
+data class Contact(val name: String, val number: String)
+
+/** A playable local audio track. */
+data class Track(val title: String, val artist: String?)
+
+/** Result of executing one tool call. */
+data class ToolOutcome(
+    /** What the agent says — model-authored `say` or a result template. */
+    val spoken: String,
+    /** Compact log label, e.g. `call_contact {name: anna}`. */
+    val label: String,
+)
+
+/**
+ * Device operations the voice tools bind to. The activity implements these
+ * with real Android APIs (ContactsContract, MediaStore/MediaPlayer,
+ * AudioManager, ACTION_DIAL); unit tests substitute a fake.
+ */
+interface DeviceActions {
+    /** True while a track is actively playing — gates the stop_music tool. */
+    val isMusicPlaying: Boolean
+
+    /** Best fuzzy match from the address book, or null. */
+    fun lookupContact(name: String): Contact?
+
+    /** Open the dialer with [number] (ACTION_DIAL — user confirms the call). */
+    fun dial(number: String)
+
+    /** Start playing a local track matching [query] (null = any). */
+    fun playMusic(query: String?): Track?
+
+    /** Tracks matching [query] (null = list the library), without playing. */
+    fun listMusic(query: String?): List<Track>
+
+    fun stopMusic()
+
+    /** Media volume, 0..10. */
+    fun setVolume(level: Int)
+}

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/LiteRtLmRuntime.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/LiteRtLmRuntime.kt
@@ -1,0 +1,63 @@
+package audio.soniqo.speech.control
+
+import audio.soniqo.speech.llm.FunctionGemma
+import com.google.ai.edge.litertlm.Backend
+import com.google.ai.edge.litertlm.ConversationConfig
+import com.google.ai.edge.litertlm.Engine
+import com.google.ai.edge.litertlm.EngineConfig
+import com.google.ai.edge.litertlm.LoraConfig
+import com.google.ai.edge.litertlm.SamplerConfig
+
+/**
+ * [FunctionGemma.Runtime] over the litertlm-android Engine/Conversation API.
+ *
+ * Each generate() runs in a fresh one-shot Conversation: FunctionGemma tool
+ * emission is single-turn, and a fresh conversation keeps the KV cache from
+ * growing across commands.
+ */
+class LiteRtLmRuntime(
+    private val modelPath: String,
+    private val loraPath: String? = null,
+) : FunctionGemma.Runtime, AutoCloseable {
+
+    private var engine: Engine? = null
+
+    // Verified on-emulator against 0.14.0: without SDK-side templating the
+    // model emits degraded, non-canonical call syntax (`name:...` instead of
+    // `call:NAME{...}`), so the SDK applies the Gemma chat template.
+    override val appliesChatTemplate: Boolean get() = false
+
+    /** Blocking, up to ~10 s — call from a background thread. */
+    fun initialize() {
+        val e = Engine(EngineConfig(modelPath = modelPath, backend = Backend.CPU()))
+        e.initialize()
+        engine = e
+    }
+
+    override fun generate(prompt: String, maxNewTokens: Int): String {
+        val e = checkNotNull(engine) { "LiteRtLmRuntime not initialized" }
+        // Greedy decoding: sampled decoding makes the 270M model's call
+        // syntax fall apart every few turns (verified on-emulator), while
+        // tool emission wants the single strongest path anyway. maxNewTokens
+        // is unused: released 0.14.0 has no maxOutputToken yet and valid
+        // FunctionGemma calls stop at <end_function_call> on their own.
+        val config = ConversationConfig(
+            samplerConfig = SamplerConfig(topK = 1, topP = 1.0, temperature = 0.0),
+            loraConfig = loraPath?.let { LoraConfig(loraPath = it) },
+        )
+        return e.createConversation(config).use { conversation ->
+            conversation.sendMessage(prompt).toString()
+        }
+    }
+
+    override fun cancel() {
+        // The synchronous Conversation API has no mid-generation cancel; a
+        // 270M tool call completes in well under a second on CPU, so the
+        // demo simply lets in-flight generations finish.
+    }
+
+    override fun close() {
+        engine?.close()
+        engine = null
+    }
+}

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/MemoryMonitor.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/MemoryMonitor.kt
@@ -1,0 +1,68 @@
+package audio.soniqo.speech.control
+
+import java.io.File
+
+/**
+ * Background sampler for current/peak process memory — the Android analog of
+ * soniqo/runner's `memoryFootprintMB()` (mach `phys_footprint`) and
+ * speech-swift's `MemoryMonitor`. Reads PSS from `/proc/self/smaps_rollup`
+ * (readable for our own process, no throttling — unlike
+ * `ActivityManager.getProcessMemoryInfo`, which is rate-limited since O),
+ * falling back to RSS from `/proc/self/statm`.
+ */
+class MemoryMonitor {
+
+    @Volatile private var running = false
+    @Volatile var peakMb: Int = 0
+        private set
+
+    fun currentMb(): Int = readPssKb().let { kb -> if (kb > 0) (kb / 1024).toInt() else 0 }
+
+    /** Record [currentMb] into the peak immediately (call at load milestones). */
+    fun sample(): Int {
+        val mb = currentMb()
+        if (mb > peakMb) peakMb = mb
+        return mb
+    }
+
+    fun start() {
+        if (running) return
+        running = true
+        Thread {
+            while (running) {
+                sample()
+                try { Thread.sleep(SAMPLE_INTERVAL_MS) } catch (_: InterruptedException) { break }
+            }
+        }.apply {
+            name = "MemoryMonitor"
+            isDaemon = true
+        }.start()
+    }
+
+    fun stop() { running = false }
+
+    private fun readPssKb(): Long {
+        // smaps_rollup: "Pss:      123456 kB"
+        runCatching {
+            File("/proc/self/smaps_rollup").useLines { lines ->
+                lines.firstOrNull { it.startsWith("Pss:") }
+                    ?.let { return parseKbLine(it) }
+            }
+        }
+        // Fallback: statm field 2 is resident pages.
+        runCatching {
+            val fields = File("/proc/self/statm").readText().trim().split(' ')
+            val pages = fields.getOrNull(1)?.toLongOrNull() ?: return -1
+            return pages * PAGE_SIZE_BYTES / 1024
+        }
+        return -1
+    }
+
+    private fun parseKbLine(line: String): Long =
+        line.removePrefix("Pss:").trim().removeSuffix("kB").trim().toLongOrNull() ?: -1
+
+    companion object {
+        private const val SAMPLE_INTERVAL_MS = 250L
+        private const val PAGE_SIZE_BYTES = 4096L
+    }
+}

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/MicGain.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/MicGain.kt
@@ -1,0 +1,47 @@
+package audio.soniqo.speech.control
+
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.sqrt
+
+/**
+ * Software input gain for the recognizer path. The VOICE_RECOGNITION audio
+ * source bypasses hardware AGC on most devices; measured speech on this
+ * demo's phone sits near -31 dBFS, starving the INT8 acoustic encoder.
+ * Normalizes toward a -20 dBFS speech RMS with a smoothed gain (bounded,
+ * slow-moving) and a hard safety clip. Stateful per session — call [reset]
+ * when the mic session restarts.
+ */
+class MicGain(
+    private val targetRms: Float = 0.1f,     // ~-20 dBFS
+    private val maxGain: Float = 12f,
+    private val attack: Float = 0.2f,        // per-chunk smoothing toward target
+) {
+    private var smoothedRms = 0f
+    private var gain = 1f
+
+    fun reset() {
+        smoothedRms = 0f
+        gain = 1f
+    }
+
+    /** Apply gain in place to [buffer]'s first [count] samples. */
+    fun process(buffer: FloatArray, count: Int) {
+        var sum = 0f
+        for (i in 0 until count) sum += buffer[i] * buffer[i]
+        val rms = sqrt(sum / max(1, count))
+
+        // Track speech level only — silence must not crank the gain.
+        if (rms > 0.004f) {
+            smoothedRms = if (smoothedRms == 0f) rms
+            else smoothedRms + attack * (rms - smoothedRms)
+            val desired = (targetRms / max(smoothedRms, 1e-4f))
+                .coerceIn(1f, maxGain)
+            gain += attack * (desired - gain)
+        }
+        for (i in 0 until count) {
+            val v = buffer[i] * gain
+            buffer[i] = if (abs(v) > 0.98f) (if (v > 0) 0.98f else -0.98f) else v
+        }
+    }
+}

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/SpeechChunks.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/SpeechChunks.kt
@@ -1,0 +1,64 @@
+package audio.soniqo.speech.control
+
+/**
+ * Split a spoken reply into pieces for pipelined synthesis: the app plays
+ * piece N while synthesizing piece N+1, so the first sound arrives after one
+ * short synthesis instead of after the whole reply. Sentences stay whole; a
+ * sentence longer than [MAX_CHARS] splits at the last clause boundary
+ * (comma, semicolon, colon, dash) inside the budget, falling back to a word
+ * boundary. Mirrors speech-core's synthesis chunker loosely — this split is
+ * for playback latency, the core one is for the model's output capacity.
+ */
+object SpeechChunks {
+    private const val MAX_CHARS = 90
+
+    fun split(text: String, maxChars: Int = MAX_CHARS): List<String> {
+        val out = mutableListOf<String>()
+        for (sentence in splitSentences(text)) {
+            if (sentence.length <= maxChars) out.add(sentence)
+            else out.addAll(splitClauses(sentence, maxChars))
+        }
+        return out
+    }
+
+    private fun splitSentences(text: String): List<String> {
+        val parts = mutableListOf<String>()
+        val current = StringBuilder()
+        for (ch in text) {
+            if (ch == '\n') {
+                current.toString().trim().takeIf { it.isNotEmpty() }?.let { parts.add(it) }
+                current.clear()
+                continue
+            }
+            current.append(ch)
+            if (ch == '.' || ch == '!' || ch == '?') {
+                current.toString().trim().takeIf { it.isNotEmpty() }?.let { parts.add(it) }
+                current.clear()
+            }
+        }
+        current.toString().trim().takeIf { it.isNotEmpty() }?.let { parts.add(it) }
+        return parts
+    }
+
+    private fun splitClauses(sentence: String, maxChars: Int): List<String> {
+        val out = mutableListOf<String>()
+        var rest = sentence.trim()
+        while (rest.length > maxChars) {
+            val window = rest.substring(0, maxChars)
+            val clauseCut = maxOf(
+                window.lastIndexOf(','),
+                window.lastIndexOf(';'),
+                window.lastIndexOf(':'),
+                window.lastIndexOf('—'),
+            )
+            // Keep the delimiter with the leading piece; require enough text
+            // before it that tiny fragments never reach the synthesizer.
+            val cut = if (clauseCut >= 20) clauseCut + 1
+            else window.lastIndexOf(' ').coerceAtLeast(1)
+            out.add(rest.substring(0, cut).trim())
+            rest = rest.substring(cut).trim()
+        }
+        if (rest.isNotEmpty()) out.add(rest)
+        return out
+    }
+}

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/SpeechChunks.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/SpeechChunks.kt
@@ -10,7 +10,14 @@ package audio.soniqo.speech.control
  * for playback latency, the core one is for the model's output capacity.
  */
 object SpeechChunks {
-    private const val MAX_CHARS = 90
+    // Kokoro's 120-frame Android graph is non-streaming per inference. A
+    // large first piece therefore blocks playback until the whole piece has
+    // synthesized, and 30+ phoneme-token clauses can overflow the graph's
+    // guarded output budget and trigger expensive split/retry inference.
+    // Keep app-side pieces clause-sized so the first sound needs one bounded
+    // model run and the following piece can synthesize during playback.
+    private const val MAX_CHARS = 30
+    private const val MIN_CHARS = 10
 
     fun split(text: String, maxChars: Int = MAX_CHARS): List<String> {
         val out = mutableListOf<String>()
@@ -53,8 +60,16 @@ object SpeechChunks {
             )
             // Keep the delimiter with the leading piece; require enough text
             // before it that tiny fragments never reach the synthesizer.
-            val cut = if (clauseCut >= 20) clauseCut + 1
+            var cut = if (clauseCut >= 20) clauseCut + 1
             else window.lastIndexOf(' ').coerceAtLeast(1)
+
+            // Rebalance a tiny final tail by moving the last word from the
+            // leading piece. Small standalone prompts pay the same fixed
+            // graph cost and are the least reliable Kokoro inputs.
+            if (rest.substring(cut).trim().length < MIN_CHARS) {
+                val earlierWord = rest.lastIndexOf(' ', cut - 1)
+                if (earlierWord >= MIN_CHARS) cut = earlierWord
+            }
             out.add(rest.substring(0, cut).trim())
             rest = rest.substring(cut).trim()
         }

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/StreamingPcmPlayer.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/StreamingPcmPlayer.kt
@@ -1,0 +1,196 @@
+package audio.soniqo.speech.control
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTimestamp
+import android.media.AudioTrack
+import android.os.SystemClock
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.delay
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * One continuous low-latency Android output stream for a complete TTS turn.
+ *
+ * Pocket emits 80 ms frames. Recreating a static [AudioTrack] for every frame
+ * inserts device warm-up latency and audible gaps, so the player is opened
+ * once, prefilled with the first frame, and fed until the utterance drains.
+ */
+internal class StreamingPcmPlayer(val sampleRate: Int) : AutoCloseable {
+
+    private val closed = AtomicBoolean(false)
+    private var started = false
+    private var framePositionAtStart = 0L
+    private var underrunsAtStart = 0
+
+    val bufferSizeBytes: Int
+    val track: AudioTrack
+    var framesWritten: Long = 0
+        private set
+
+    val performanceMode: Int
+        get() = track.performanceMode
+
+    val underrunCount: Int
+        get() = (track.underrunCount - underrunsAtStart).coerceAtLeast(0)
+
+    init {
+        require(sampleRate > 0) { "Invalid PCM sample rate: $sampleRate" }
+        val minimum = AudioTrack.getMinBufferSize(
+            sampleRate,
+            AudioFormat.CHANNEL_OUT_MONO,
+            AudioFormat.ENCODING_PCM_16BIT,
+        )
+        require(minimum > 0) { "AudioTrack rejected ${sampleRate} Hz PCM: $minimum" }
+
+        // Capacity is deliberately larger than Pocket's 80 ms frame. Capacity
+        // does not force prebuffering; it gives the faster-than-real-time model
+        // enough scheduling slack to avoid underruns while retaining fast start.
+        val frame160Ms = sampleRate * PCM_BYTES_PER_FRAME * 160 / 1_000
+        bufferSizeBytes = max(minimum, frame160Ms)
+        track = AudioTrack.Builder()
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_ASSISTANT)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build(),
+            )
+            .setAudioFormat(
+                AudioFormat.Builder()
+                    .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                    .setSampleRate(sampleRate)
+                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                    .build(),
+            )
+            .setTransferMode(AudioTrack.MODE_STREAM)
+            .setPerformanceMode(AudioTrack.PERFORMANCE_MODE_LOW_LATENCY)
+            .setBufferSizeInBytes(bufferSizeBytes)
+            .build()
+        if (track.state != AudioTrack.STATE_INITIALIZED) {
+            track.release()
+            error("AudioTrack failed to initialize at ${sampleRate} Hz")
+        }
+    }
+
+    /** Prefill the stream with the first native frame, then start playback. */
+    fun start(firstPcm16: ByteArray) {
+        check(!started) { "Streaming PCM playback already started" }
+        require(firstPcm16.isNotEmpty()) { "First PCM frame is empty" }
+        require(firstPcm16.size % PCM_BYTES_PER_FRAME == 0) { "PCM16 byte count must be even" }
+
+        framePositionAtStart = track.playbackHeadPosition.toLong() and UINT32_MASK
+        underrunsAtStart = track.underrunCount
+
+        // A non-blocking prefill cannot deadlock on a Kokoro-sized callback.
+        // Pocket's 3,840-byte frame fits in the configured buffer in one write.
+        var offset = writeBytes(firstPcm16, 0, min(firstPcm16.size, bufferSizeBytes), blocking = false)
+        track.play()
+        started = true
+        if (offset < firstPcm16.size) {
+            offset = writeBytes(
+                firstPcm16,
+                offset,
+                firstPcm16.size - offset,
+                blocking = true,
+            )
+        }
+        check(offset == firstPcm16.size)
+    }
+
+    fun write(pcm16: ByteArray) {
+        if (pcm16.isEmpty()) return
+        check(started) { "Call start() before write()" }
+        require(pcm16.size % PCM_BYTES_PER_FRAME == 0) { "PCM16 byte count must be even" }
+        val written = writeBytes(pcm16, 0, pcm16.size, blocking = true)
+        check(written == pcm16.size)
+    }
+
+    /**
+     * Estimate when frame zero reached AudioFlinger using its monotonic audio
+     * timestamp. Returns null when this route does not expose timestamps.
+     */
+    suspend fun awaitFirstPresentationNanos(timeoutMs: Long = 500): Long? {
+        if (!started || closed.get()) return null
+        val timestamp = AudioTimestamp()
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (!closed.get() && SystemClock.elapsedRealtime() < deadline) {
+            if (track.getTimestamp(timestamp) && timestamp.framePosition > framePositionAtStart) {
+                val presentedFrames = timestamp.framePosition - framePositionAtStart
+                val elapsedForFrames = presentedFrames * NANOS_PER_SECOND / sampleRate
+                return timestamp.nanoTime - elapsedForFrames
+            }
+            delay(4)
+        }
+        return null
+    }
+
+    /** Wait until every queued frame has been presented, without fixed gaps. */
+    suspend fun awaitDrained() {
+        if (!started || closed.get()) return
+        val durationMs = framesWritten * 1_000 / sampleRate
+        val deadline = SystemClock.elapsedRealtime() + durationMs + DRAIN_GRACE_MS
+        while (!closed.get() && SystemClock.elapsedRealtime() < deadline) {
+            val position = track.playbackHeadPosition.toLong() and UINT32_MASK
+            val played = (position - framePositionAtStart) and UINT32_MASK
+            if (played >= framesWritten) return
+            val remainingMs = (framesWritten - played) * 1_000 / sampleRate
+            delay(remainingMs.coerceIn(4, 20))
+        }
+        if (!closed.get()) {
+            error("AudioTrack drain timed out: played=${track.playbackHeadPosition} written=$framesWritten")
+        }
+    }
+
+    /** Keep the allocated Android output path warm for the next assistant turn. */
+    fun resetForNextUtterance() {
+        check(!closed.get()) { "Streaming PCM playback is closed" }
+        check(started) { "Streaming PCM playback has not started" }
+        track.pause()
+        track.flush()
+        started = false
+        framesWritten = 0
+    }
+
+    private fun writeBytes(
+        pcm16: ByteArray,
+        initialOffset: Int,
+        length: Int,
+        blocking: Boolean,
+    ): Int {
+        check(!closed.get()) { "Streaming PCM playback is closed" }
+        var offset = initialOffset
+        val end = initialOffset + length
+        val mode = if (blocking) AudioTrack.WRITE_BLOCKING else AudioTrack.WRITE_NON_BLOCKING
+        while (offset < end && !closed.get()) {
+            val count = track.write(pcm16, offset, end - offset, mode)
+            when {
+                count > 0 -> {
+                    offset += count
+                    framesWritten += count / PCM_BYTES_PER_FRAME
+                }
+                count == 0 && !blocking -> break
+                count == 0 -> Thread.yield()
+                else -> error("AudioTrack.write failed: $count")
+            }
+        }
+        check(!closed.get()) { "Streaming PCM playback was closed during write" }
+        return offset
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        try {
+            if (track.playState != AudioTrack.PLAYSTATE_STOPPED) track.stop()
+        } catch (_: Exception) {
+        }
+        track.release()
+    }
+
+    private companion object {
+        const val PCM_BYTES_PER_FRAME = 2
+        const val NANOS_PER_SECOND = 1_000_000_000L
+        const val UINT32_MASK = 0xffff_ffffL
+        const val DRAIN_GRACE_MS = 2_000L
+    }
+}

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/TurnMetrics.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/TurnMetrics.kt
@@ -1,0 +1,50 @@
+package audio.soniqo.speech.control
+
+import java.util.Locale
+
+/**
+ * Per-turn latency report, formatted like soniqo/runner's sidecar log lines
+ * (`elapsed=..ms audio=..ms rtf=..`, `round=..ms, memory=.. MB`) and the
+ * per-stage `RTF · tok/s · MB` table in the on-device-voice-agents blog post.
+ */
+data class TurnMetrics(
+    /** STT decode wall time (from the pipeline event). */
+    val sttMs: Float,
+    /** Captured speech length in seconds (SpeechStarted → SpeechEnded). */
+    val speechSec: Float,
+    /** LLM wall time for the tool-call generation. */
+    val llmMs: Long,
+    /** Characters the LLM emitted — proxy for tokens (~4 chars/token). */
+    val llmChars: Int,
+    /** TTS synthesis wall time. */
+    val ttsMs: Long,
+    /** Synthesized audio length in seconds. */
+    val ttsAudioSec: Float,
+    /** Voice-to-action: end of speech → tool executed on the car state. */
+    val actionMs: Long,
+    /** Full round: end of speech → response playback started. */
+    val roundMs: Long,
+    /** Process PSS when the turn finished, in MB (0 = unknown). */
+    val memMb: Int,
+) {
+    val sttRtf: Float get() = if (speechSec > 0f) sttMs / 1000f / speechSec else 0f
+    val ttsRtf: Float get() = if (ttsAudioSec > 0f) ttsMs / 1000f / ttsAudioSec else 0f
+
+    /** Estimated generation speed; chars/4 ≈ tokens for BPE English text. */
+    val tokPerSec: Float get() = if (llmMs > 0) (llmChars / 4f) / (llmMs / 1000f) else 0f
+
+    fun format(): String = buildString {
+        append("stt ${sttMs.toInt()}ms")
+        if (speechSec > 0f) append(" rtf ${sttRtf.f2()}")
+        append(" · llm ${llmMs}ms")
+        if (tokPerSec > 0f) append(" ~${tokPerSec.toInt()} tok/s")
+        append(" · tts ${ttsMs}ms")
+        if (ttsAudioSec > 0f) {
+            append("→${"%.1f".format(Locale.US, ttsAudioSec)}s rtf ${ttsRtf.f2()}")
+        }
+        append(" · action ${actionMs}ms · round ${roundMs}ms")
+        if (memMb > 0) append(" · mem $memMb MB")
+    }
+
+    private fun Float.f2(): String = "%.2f".format(Locale.US, this)
+}

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/ui/ControlScreen.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/ui/ControlScreen.kt
@@ -1,0 +1,444 @@
+package audio.soniqo.speech.control.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import audio.soniqo.speech.control.ControlUiState
+import audio.soniqo.speech.control.FeedItem
+import audio.soniqo.speech.control.MicState
+import audio.soniqo.speech.control.SystemNote
+import audio.soniqo.speech.control.Turn
+
+/** Callbacks the hosting Activity wires to the pipeline/agent. */
+data class ControlActions(
+    val onMicTap: () -> Unit,
+    val onOpenType: () -> Unit,
+    val onSubmitTyped: (String) -> Unit,
+    val onDismissType: () -> Unit,
+    val onOpenInfo: () -> Unit,
+    val onDismissInfo: () -> Unit,
+)
+
+@Composable
+fun ControlScreen(
+    state: ControlUiState,
+    actions: ControlActions,
+) {
+    // Respect the system "remove animations" accessibility setting.
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val reduceMotion = remember {
+        android.provider.Settings.Global.getFloat(
+            context.contentResolver,
+            android.provider.Settings.Global.ANIMATOR_DURATION_SCALE, 1f) == 0f
+    }
+
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(Background)
+            .windowInsetsPadding(WindowInsets.safeDrawing),
+    ) {
+        Header(state, actions)
+        Chat(state.feed, state.downloadPercent != null, state.downloadStage, Modifier.weight(1f))
+        OrbDock(state, actions, reduceMotion)
+        StatusLine(state)
+    }
+
+    if (state.showTypeDialog) {
+        TypeCommandDialog(actions.onSubmitTyped, actions.onDismissType)
+    }
+    if (state.showInfoDialog) {
+        InfoDialog(actions.onDismissInfo)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Header — wordmark, state word, one instrumentation line.
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun Header(state: ControlUiState, actions: ControlActions) {
+    Column(Modifier.padding(start = 22.dp, end = 22.dp, top = 18.dp, bottom = 10.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("SONIQO", color = Foreground, fontFamily = Grotesk,
+                fontWeight = FontWeight.Bold, fontSize = 17.sp, letterSpacing = 3.sp)
+            Text(" CONTROL", color = Primary, fontFamily = Grotesk,
+                fontWeight = FontWeight.Bold, fontSize = 17.sp, letterSpacing = 3.sp)
+            Spacer(Modifier.weight(1f))
+            Text("ⓘ", color = MutedFg, fontSize = 16.sp,
+                modifier = Modifier.clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                ) { actions.onOpenInfo() })
+        }
+        // Status on its own line so a long "downloading …" never collides
+        // with the wordmark.
+        Spacer(Modifier.height(6.dp))
+        Text(state.status, color = MutedFg, fontFamily = Plex, fontSize = 11.sp,
+            maxLines = 1, overflow = TextOverflow.Ellipsis)
+        state.downloadPercent?.let { pct ->
+            Spacer(Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = { pct / 100f },
+                modifier = Modifier.fillMaxWidth().height(3.dp),
+                color = Primary, trackColor = MutedSurface,
+            )
+        }
+    }
+}
+
+/** Footer: `1397 MB · peak 1423 · stt 67ms · llm 663ms · tts 1486ms · round 2175ms` */
+@Composable
+private fun StatusLine(state: ControlUiState) {
+    val parts = buildList {
+        if (state.memNowMb > 0) {
+            add("${state.memNowMb} MB")
+            add("peak ${state.memPeakMb}")
+        }
+        state.lastMetrics?.let { m ->
+            add("stt ${m.sttMs.toInt()}ms")
+            add("llm ${m.llmMs}ms")
+            add("tts ${m.ttsMs}ms")
+            add("round ${m.roundMs}ms")
+        }
+    }
+    Text(
+        if (parts.isEmpty()) "starting up" else parts.joinToString(" · "),
+        color = FaintFg, fontFamily = Plex, fontSize = 9.sp, letterSpacing = 0.sp,
+        maxLines = 1, overflow = TextOverflow.Ellipsis,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 10.dp, end = 10.dp, bottom = 8.dp),
+        textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Chat — transcribed phrases (right) and recognized commands + replies (left).
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun Chat(
+    feed: List<FeedItem>,
+    setupVisible: Boolean,
+    setupStage: String?,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberLazyListState()
+    LaunchedEffect(feed.lastOrNull()?.id, feed.size) {
+        if (feed.isNotEmpty()) listState.animateScrollToItem(feed.size - 1)
+    }
+    Box(modifier.fillMaxWidth()) {
+        if (setupVisible) {
+            SetupPanel(setupStage, Modifier.align(Alignment.Center))
+        } else if (feed.none { it is Turn }) {
+            EmptyHint(Modifier.align(Alignment.Center))
+        }
+        LazyColumn(
+            Modifier.fillMaxSize().padding(horizontal = 18.dp),
+            state = listState,
+            contentPadding = PaddingValues(top = 6.dp, bottom = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            items(feed, key = { it.id }) { item ->
+                AnimatedVisibility(
+                    visibleState = remember {
+                        MutableTransitionState(false).apply { targetState = true }
+                    },
+                    enter = fadeIn(tween(240)) + slideInVertically(tween(240)) { it / 3 },
+                ) {
+                    when (item) {
+                        is SystemNote -> Text(item.text, color = FaintFg, fontFamily = Plex,
+                            fontSize = 10.5.sp, lineHeight = 15.sp,
+                            modifier = Modifier.padding(horizontal = 2.dp))
+                        is Turn -> TurnBlock(item)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * First-run setup panel — the model download (~800 MB, one time). Progress
+ * is shown as one dot per model, filling as each finishes, rather than raw
+ * filenames. The bundle downloads in a foreground worker, so it continues
+ * while the app is backgrounded.
+ */
+@Composable
+private fun SetupPanel(currentStage: String?, modifier: Modifier = Modifier) {
+    // Download order = dot order. Each model is one dot.
+    val models = listOf(
+        "voice detection", "transcription model", "speech synthesis", "language model",
+    )
+    val current = models.indexOf(currentStage).let { if (it < 0) 0 else it }
+
+    val pulse = rememberInfiniteTransition(label = "setup")
+    val activeAlpha by pulse.animateFloat(
+        initialValue = 0.35f, targetValue = 1f,
+        animationSpec = androidx.compose.animation.core.infiniteRepeatable(
+            tween(700), androidx.compose.animation.core.RepeatMode.Reverse),
+        label = "activeAlpha",
+    )
+
+    Column(
+        modifier.fillMaxWidth().padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text("Setting up", color = Foreground, fontFamily = Grotesk,
+            fontWeight = FontWeight.Bold, fontSize = 20.sp)
+        Spacer(Modifier.height(8.dp))
+        Text("Downloading the models — about 800 MB, one time. Everything runs " +
+            "on your phone and the download continues if you leave.",
+            color = MutedFg, fontFamily = Grotesk, fontSize = 13.5.sp, lineHeight = 19.sp,
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center)
+        Spacer(Modifier.height(22.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+            models.indices.forEach { i ->
+                val color = when {
+                    i < current -> Primary                          // downloaded
+                    i == current -> Primary.copy(alpha = activeAlpha) // in progress
+                    else -> Border                                  // pending
+                }
+                Box(Modifier.size(12.dp).clip(CircleShape).background(color))
+            }
+        }
+        Spacer(Modifier.height(12.dp))
+        Text("${current + 1} of ${models.size}", color = FaintFg, fontFamily = Plex,
+            fontSize = 11.sp)
+    }
+}
+
+@Composable
+private fun EmptyHint(modifier: Modifier = Modifier) {
+    Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+        Text("Say something like", color = FaintFg, fontFamily = Grotesk, fontSize = 14.sp)
+        Spacer(Modifier.height(6.dp))
+        Text("“call anna” · “play some music” · “set volume to 3”",
+            color = MutedFg, fontFamily = Grotesk, fontSize = 14.sp)
+    }
+}
+
+@Composable
+private fun TurnBlock(turn: Turn) {
+    Column(Modifier.fillMaxWidth()) {
+        // What the pipeline heard — the user's side.
+        Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
+            Text(
+                turn.utterance,
+                color = Foreground, fontFamily = Grotesk,
+                fontWeight = FontWeight.Medium, fontSize = 16.sp, lineHeight = 22.sp,
+                modifier = Modifier
+                    .widthIn(max = 300.dp)
+                    .clip(RoundedCornerShape(18.dp, 18.dp, 4.dp, 18.dp))
+                    .background(MutedSurface)
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
+            )
+        }
+
+        // What the agent recognized + said back.
+        if (turn.toolLabel != null || turn.spoken != null) {
+            Spacer(Modifier.height(8.dp))
+            Column(
+                Modifier
+                    .widthIn(max = 320.dp)
+                    .clip(RoundedCornerShape(18.dp, 18.dp, 18.dp, 4.dp))
+                    .background(Card)
+                    .border(1.dp, Border, RoundedCornerShape(18.dp, 18.dp, 18.dp, 4.dp))
+                    .padding(horizontal = 14.dp, vertical = 11.dp),
+            ) {
+                turn.toolLabel?.let { label ->
+                    Text(label,
+                        color = if (turn.failed) Destructive else Primary,
+                        fontFamily = Plex, fontSize = 12.sp)
+                }
+                turn.spoken?.let { spoken ->
+                    if (turn.toolLabel != null) Spacer(Modifier.height(6.dp))
+                    Text(spoken, color = Foreground, fontFamily = Grotesk,
+                        fontSize = 15.sp, lineHeight = 21.sp)
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Orb dock.
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun OrbDock(state: ControlUiState, actions: ControlActions, reduceMotion: Boolean) {
+    Column(
+        Modifier.fillMaxWidth().padding(top = 2.dp, bottom = 14.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            Modifier
+                .size(116.dp)
+                .clip(CircleShape)
+                .then(
+                    if (state.micState == MicState.OFFLINE) Modifier
+                    else Modifier.clickable(
+                        onClick = actions.onMicTap,
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() },
+                    ),
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            TalkOrb(state.micState, state.micLevel, reduceMotion = reduceMotion)
+        }
+        Spacer(Modifier.height(6.dp))
+        Text(orbCaption(state.micState), color = MutedFg, fontFamily = Plex, fontSize = 12.sp,
+            letterSpacing = 1.sp)
+        if (state.micState != MicState.OFFLINE) {
+            Spacer(Modifier.height(2.dp))
+            Text("hold to type", color = FaintFg, fontFamily = Plex, fontSize = 10.sp,
+                modifier = Modifier.clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                ) { actions.onOpenType() })
+        }
+    }
+}
+
+@Composable
+private fun InfoDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Card,
+        title = {
+            Row {
+                Text("SONIQO", color = Foreground, fontFamily = Grotesk,
+                    fontWeight = FontWeight.Bold, fontSize = 15.sp, letterSpacing = 2.sp)
+                Text(" CONTROL", color = Primary, fontFamily = Grotesk,
+                    fontWeight = FontWeight.Bold, fontSize = 15.sp, letterSpacing = 2.sp)
+            }
+        },
+        text = {
+            Column(
+                Modifier.verticalScroll(
+                    androidx.compose.foundation.rememberScrollState()),
+            ) {
+                Text("Say it naturally — the on-device model maps your phrase " +
+                    "to one of these commands:",
+                    color = Foreground, fontFamily = Grotesk, fontSize = 14.sp,
+                    lineHeight = 20.sp)
+                Spacer(Modifier.height(14.dp))
+
+                // Rendered straight from the registered tool declarations —
+                // this list is exactly what the agent can react to.
+                audio.soniqo.speech.control.ControlTools.declarations.forEach { tool ->
+                    CapabilityRow(tool)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Close", color = Primary, fontFamily = Grotesk) }
+        },
+    )
+}
+
+@Composable
+private fun CapabilityRow(tool: audio.soniqo.speech.llm.FunctionDeclaration) {
+    @Suppress("UNCHECKED_CAST")
+    val properties = (tool.parameters["properties"] as? Map<String, Any?>).orEmpty()
+    @Suppress("UNCHECKED_CAST")
+    val required = (tool.parameters["required"] as? List<String>).orEmpty()
+    // `say` is the internal spoken-reply argument, not a user-facing input.
+    val signature = properties.keys
+        .filter { it != "say" }
+        .joinToString(", ") { if (it in required) it else "$it?" }
+
+    Column(Modifier.padding(bottom = 8.dp)) {
+        Row(verticalAlignment = Alignment.Bottom) {
+            Text(tool.name, color = Primary, fontFamily = Plex,
+                fontWeight = FontWeight.Medium, fontSize = 12.sp)
+            if (signature.isNotEmpty()) {
+                Text(" ($signature)", color = FaintFg, fontFamily = Plex, fontSize = 11.sp)
+            }
+        }
+        Text(tool.description, color = MutedFg, fontFamily = Grotesk,
+            fontSize = 12.5.sp, lineHeight = 17.sp)
+    }
+}
+
+@Composable
+private fun TypeCommandDialog(onSubmit: (String) -> Unit, onDismiss: () -> Unit) {
+    var text by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Card,
+        title = { Text("Type a command", color = Foreground, fontFamily = Grotesk) },
+        text = {
+            OutlinedTextField(
+                value = text, onValueChange = { text = it }, singleLine = true,
+                placeholder = { Text("call anna · play some music",
+                    color = FaintFg, fontFamily = Plex, fontSize = 13.sp) },
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Go),
+                keyboardActions = KeyboardActions(onGo = {
+                    if (text.isNotBlank()) onSubmit(text.trim())
+                }),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { if (text.isNotBlank()) onSubmit(text.trim()) }) {
+                Text("Run", color = Primary, fontFamily = Grotesk)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel", color = MutedFg, fontFamily = Grotesk) }
+        },
+    )
+}

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/ui/TalkOrb.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/ui/TalkOrb.kt
@@ -1,0 +1,114 @@
+package audio.soniqo.speech.control.ui
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.dp
+import audio.soniqo.speech.control.MicState
+import kotlin.math.sin
+
+/**
+ * Push-to-talk orb in the brand orange. State reads through intensity, not
+ * hue: a quiet ring at idle, a level-reactive bloom while listening, a
+ * rotating sweep while the model thinks, a steady radiate while speaking.
+ */
+@Composable
+fun TalkOrb(
+    micState: MicState,
+    level: Float,
+    reduceMotion: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val transition = rememberInfiniteTransition(label = "orb")
+
+    val breath by transition.animateFloat(
+        initialValue = 0f, targetValue = (2 * Math.PI).toFloat(),
+        animationSpec = infiniteRepeatable(tween(3200), RepeatMode.Restart),
+        label = "breath",
+    )
+    val sweep by transition.animateFloat(
+        initialValue = 0f, targetValue = 360f,
+        animationSpec = infiniteRepeatable(tween(1100), RepeatMode.Restart),
+        label = "sweep",
+    )
+
+    // Status → color, same language as soniqo/runner's MagicRings.
+    val (targetCore, targetGlow) = when (micState) {
+        MicState.OFFLINE -> OrbOffline
+        MicState.IDLE -> OrbIdle
+        MicState.LISTENING -> OrbListening
+        MicState.THINKING -> OrbThinking
+        MicState.SPEAKING -> OrbSpeaking
+    }
+    val core by animateColorAsState(targetCore, tween(400), label = "core")
+    val glow by animateColorAsState(targetGlow, tween(400), label = "glow")
+
+    // Core intensity: mic level while listening, otherwise a slow breath.
+    val target = when (micState) {
+        MicState.LISTENING -> 0.62f + level.coerceIn(0f, 1f) * 0.38f
+        MicState.SPEAKING -> 0.88f
+        MicState.THINKING -> 0.6f
+        MicState.IDLE -> 0.42f + if (reduceMotion) 0f else (sin(breath) + 1f) / 2f * 0.08f
+        MicState.OFFLINE -> 0.34f
+    }
+    val bloom by animateFloatAsState(target, tween(140), label = "bloom")
+
+    Canvas(modifier.size(116.dp)) {
+        val c = Offset(size.width / 2, size.height / 2)
+        val maxR = size.minDimension / 2
+
+        // Ambient glow — the status color bleeding out.
+        drawCircle(
+            brush = Brush.radialGradient(
+                colors = listOf(core.copy(alpha = 0.22f), Color.Transparent),
+                center = c, radius = maxR,
+            ),
+            radius = maxR, center = c,
+        )
+        // Core disc: light center (secondary) → saturated edge (primary).
+        val coreR = maxR * 0.52f * bloom + maxR * 0.24f
+        drawCircle(
+            brush = Brush.radialGradient(
+                colors = listOf(glow.copy(alpha = 0.95f), core.copy(alpha = 0.7f)),
+                center = c, radius = coreR,
+            ),
+            radius = coreR, center = c,
+        )
+        // Outer ring — full at rest; a rotating gap while thinking.
+        val ringR = maxR * 0.78f
+        val stroke = Stroke(width = maxR * 0.045f)
+        if (micState == MicState.THINKING && !reduceMotion) {
+            drawArc(
+                color = core, startAngle = sweep, sweepAngle = 270f, useCenter = false,
+                topLeft = Offset(c.x - ringR, c.y - ringR),
+                size = Size(ringR * 2, ringR * 2),
+                style = stroke,
+            )
+        } else {
+            drawCircle(color = core.copy(alpha = 0.8f), radius = ringR, center = c, style = stroke)
+        }
+    }
+}
+
+/** One-word caption under the orb, matched to the mic state. */
+fun orbCaption(micState: MicState): String = when (micState) {
+    MicState.OFFLINE -> "loading"
+    MicState.IDLE -> "tap to talk"
+    MicState.LISTENING -> "listening"
+    MicState.THINKING -> "thinking"
+    MicState.SPEAKING -> "speaking"
+}

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/ui/Theme.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/ui/Theme.kt
@@ -1,0 +1,58 @@
+package audio.soniqo.speech.control.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+
+// ---------------------------------------------------------------------------
+// soniqo.audio dark-theme tokens (shadcn variables from the site stylesheet):
+//   --background 24 10% 7% · --card 24 10% 9% · --muted 24 8% 14%
+//   --border 24 8% 18% · --foreground 30 25% 96% · --muted-fg 28 12% 65%
+//   --primary 27 88% 56%
+// ---------------------------------------------------------------------------
+
+val Background = Color(0xFF141210)
+val Card = Color(0xFF191614)
+val MutedSurface = Color(0xFF272321)
+val Border = Color(0xFF312D2A)
+val Foreground = Color(0xFFF8F5F0)
+val MutedFg = Color(0xFFB0A59B)
+val FaintFg = Color(0xFF79726B)
+val Primary = Color(0xFFF1862C)
+val Destructive = Color(0xFFD22C2C)
+
+// Talk-orb status colors, matched to soniqo/runner's MagicRings phase palette
+// [primary, secondary]: idle orange · listening red · thinking amber ·
+// speaking green · loading grey. Same status→color language as the desktop app.
+val OrbIdle = Color(0xFFF08030) to Color(0xFFFFB37A)
+val OrbListening = Color(0xFFFF4D4D) to Color(0xFFFF9A9A)
+val OrbThinking = Color(0xFFFFB02E) to Color(0xFFFFD98A)
+val OrbSpeaking = Color(0xFF34D39A) to Color(0xFF9FF0CF)
+val OrbOffline = Color(0xFF5B6470) to Color(0xFF878F9C)
+
+// Keep the demo self-contained and use Android's installed typefaces. The
+// display/instrumentation distinction mirrors the original Control app
+// without adding font binaries to the SDK repository.
+val Grotesk = FontFamily.SansSerif
+val Plex = FontFamily.Monospace
+
+private val SoniqoColors = darkColorScheme(
+    primary = Primary,
+    onPrimary = Background,
+    background = Background,
+    onBackground = Foreground,
+    surface = Card,
+    onSurface = Foreground,
+    surfaceVariant = MutedSurface,
+    onSurfaceVariant = MutedFg,
+    outline = Border,
+    error = Destructive,
+)
+
+@Composable
+fun SoniqoControlTheme(content: @Composable () -> Unit) {
+    // Single-look brand surface (the site's dark palette) in both system themes.
+    MaterialTheme(colorScheme = SoniqoColors, content = content)
+}

--- a/control-demo/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/control-demo/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,17 @@
+<!-- Soniqo Control launcher mark: a warm, five-bar voice waveform. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path android:strokeColor="#F1862C" android:strokeWidth="8.5"
+        android:strokeLineCap="round" android:pathData="M34,46 L34,62" />
+    <path android:strokeColor="#F49B54" android:strokeWidth="8.5"
+        android:strokeLineCap="round" android:pathData="M44,38 L44,70" />
+    <path android:strokeColor="#F1862C" android:strokeWidth="8.5"
+        android:strokeLineCap="round" android:pathData="M54,28 L54,80" />
+    <path android:strokeColor="#F49B54" android:strokeWidth="8.5"
+        android:strokeLineCap="round" android:pathData="M64,38 L64,70" />
+    <path android:strokeColor="#F1862C" android:strokeWidth="8.5"
+        android:strokeLineCap="round" android:pathData="M74,46 L74,62" />
+</vector>

--- a/control-demo/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/control-demo/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/control-demo/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/control-demo/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/control-demo/src/main/res/values/colors.xml
+++ b/control-demo/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<resources>
+    <color name="asphalt">#17181C</color>
+    <!-- Launcher-icon card behind the soniqo mark — the logo's native
+         warm off-white, so the orange reads as the brand. -->
+    <color name="ic_launcher_background">#F7F4EF</color>
+</resources>

--- a/control-demo/src/main/res/values/strings.xml
+++ b/control-demo/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Soniqo Control</string>
+</resources>

--- a/control-demo/src/main/res/values/themes.xml
+++ b/control-demo/src/main/res/values/themes.xml
@@ -1,0 +1,10 @@
+<resources>
+    <!-- Launch/window theme only — Compose owns everything after first frame.
+         Dark window background avoids a white flash before setContent runs. -->
+    <style name="Theme.SoniqoControl" parent="android:Theme.Material.NoActionBar">
+        <item name="android:windowBackground">@color/asphalt</item>
+        <item name="android:statusBarColor">@color/asphalt</item>
+        <item name="android:navigationBarColor">@color/asphalt</item>
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
+</resources>

--- a/control-demo/src/test/kotlin/audio/soniqo/speech/control/CompactPromptTest.kt
+++ b/control-demo/src/test/kotlin/audio/soniqo/speech/control/CompactPromptTest.kt
@@ -1,0 +1,36 @@
+package audio.soniqo.speech.control
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CompactPromptTest {
+
+    @Test
+    fun developerTurn_matchesTrainingSerializationForIdleState() {
+        val tools = ControlTools.availableTools(musicPlaying = false)
+
+        assertEquals(
+            "You are a model that can do function calling with the following functions\n" +
+                "Available functions: call_contact, dial_number, find_contact, find_music, " +
+                "play_music, set_volume, list_capabilities.\n" +
+                "Music state: idle.",
+            CompactPrompt.developerTurn(tools, musicPlaying = false),
+        )
+    }
+
+    @Test
+    fun fullPrompt_matchesTrainingSerializationForPlayingState() {
+        val tools = ControlTools.availableTools(musicPlaying = true)
+
+        assertEquals(
+            "<start_of_turn>developer\n" +
+                "You are a model that can do function calling with the following functions\n" +
+                "Available functions: call_contact, dial_number, find_contact, find_music, " +
+                "play_music, stop_music, set_volume, list_capabilities.\n" +
+                "Music state: playing.<end_of_turn>\n" +
+                "<start_of_turn>user\nstop the music<end_of_turn>\n" +
+                "<start_of_turn>model\n",
+            CompactPrompt.format(tools, musicPlaying = true, userText = "stop the music"),
+        )
+    }
+}

--- a/control-demo/src/test/kotlin/audio/soniqo/speech/control/ControlToolsTest.kt
+++ b/control-demo/src/test/kotlin/audio/soniqo/speech/control/ControlToolsTest.kt
@@ -1,0 +1,311 @@
+package audio.soniqo.speech.control
+
+import audio.soniqo.speech.llm.ArgumentValue
+import audio.soniqo.speech.llm.FunctionCall
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ControlToolsTest {
+
+    private class FakeDevice : DeviceActions {
+        val contacts = mutableMapOf(
+            "anna" to Contact("Anna Miller", "+4917612345678"),
+        )
+        var dialed: String? = null
+        var playing: Track? = Track("Morning Drive", "The Layers")
+        var queryMatches = true
+        var stopped = false
+        var musicPlaying = false
+        var lastVolume = -1
+
+        override val isMusicPlaying: Boolean get() = musicPlaying
+
+        override fun lookupContact(name: String): Contact? =
+            contacts.entries.firstOrNull { name.lowercase().contains(it.key) }?.value
+
+        override fun dial(number: String) { dialed = number }
+
+        override fun playMusic(query: String?): Track? =
+            if (query != null && !queryMatches) null else playing
+
+        var library = listOf(
+            Track("Feeling Good", "Nina Simone"),
+            Track("Hotel California", null),
+            Track("Morning Drive", "The Layers"),
+            Track("Take Five", "Dave Brubeck"),
+        )
+
+        override fun listMusic(query: String?): List<Track> =
+            if (query == null) library
+            else library.filter {
+                it.title.contains(query, ignoreCase = true) ||
+                    it.artist?.contains(query, ignoreCase = true) == true
+            }
+
+        override fun stopMusic() { stopped = true; musicPlaying = false }
+
+        override fun setVolume(level: Int) { lastVolume = level }
+    }
+
+    private val device = FakeDevice()
+
+    private fun call(name: String, vararg args: Pair<String, ArgumentValue>) =
+        FunctionCall(name, args.toMap())
+
+    @Test
+    fun selectSingleCall_acceptsExactlyOneAction() {
+        val only = call("set_volume", "level" to ArgumentValue.Int(3))
+
+        assertEquals(only, ControlTools.selectSingleCall(listOf(only)))
+        assertNull(ControlTools.selectSingleCall(emptyList()))
+        assertNull(ControlTools.selectSingleCall(listOf(only, only)))
+    }
+
+    // ------------------------------------------------------------------
+    // say parameter: honored on actions, overridden by lookup results
+    // ------------------------------------------------------------------
+
+    @Test
+    fun callContact_found_dialsAndSpeaksModelSay() {
+        val outcome = ControlTools.execute(call(
+            "call_contact",
+            "name" to ArgumentValue.Str("anna"),
+            "say" to ArgumentValue.Str("Calling Anna now."),
+        ), device)!!
+
+        assertEquals("+4917612345678", device.dialed)
+        assertEquals("Calling Anna now.", outcome.spoken)
+        assertEquals("call_contact {name: anna}", outcome.label)
+    }
+
+    @Test
+    fun callContact_notFound_neverSpeaksSuccessSay() {
+        val outcome = ControlTools.execute(call(
+            "call_contact",
+            "name" to ArgumentValue.Str("bob"),
+            "say" to ArgumentValue.Str("Calling Bob."),
+        ), device)!!
+
+        assertNull(device.dialed)
+        assertEquals("I couldn't find bob in your contacts.", outcome.spoken)
+    }
+
+    @Test
+    fun callContact_missingSay_usesTemplateWithResolvedName() {
+        val outcome = ControlTools.execute(call(
+            "call_contact", "name" to ArgumentValue.Str("anna")), device)!!
+
+        assertEquals("Calling Anna Miller.", outcome.spoken)
+    }
+
+    @Test
+    fun findContact_speaksActualResult_ignoringSay() {
+        val outcome = ControlTools.execute(call(
+            "find_contact",
+            "name" to ArgumentValue.Str("anna"),
+            "say" to ArgumentValue.Str("Looking up Anna."),
+        ), device)!!
+
+        assertEquals("Anna Miller's number is +4917612345678.", outcome.spoken)
+    }
+
+    @Test
+    fun findContact_miss_speaksNotFound() {
+        val outcome = ControlTools.execute(call(
+            "find_contact", "name" to ArgumentValue.Str("zoe")), device)!!
+
+        assertEquals("No contact named zoe.", outcome.spoken)
+    }
+
+    @Test
+    fun findMusic_noQuery_listsLibrary_ignoringSay() {
+        val outcome = ControlTools.execute(call(
+            "find_music",
+            "say" to ArgumentValue.Str("Here is your music."),
+        ), device)!!
+
+        assertEquals(
+            "You have 4 tracks, including Feeling Good by Nina Simone, " +
+                "Hotel California, Morning Drive by The Layers.",
+            outcome.spoken,
+        )
+        assertEquals("find_music {query: *}", outcome.label)
+    }
+
+    @Test
+    fun findMusic_query_speaksMatches() {
+        val outcome = ControlTools.execute(call(
+            "find_music", "query" to ArgumentValue.Str("nina")), device)!!
+
+        assertEquals("You have: Feeling Good by Nina Simone.", outcome.spoken)
+    }
+
+    @Test
+    fun findMusic_miss_speaksNoMatch() {
+        val outcome = ControlTools.execute(call(
+            "find_music", "query" to ArgumentValue.Str("polka")), device)!!
+
+        assertEquals("No music matching polka.", outcome.spoken)
+    }
+
+    @Test
+    fun findMusic_emptyLibrary_speaksNoMusic() {
+        device.library = emptyList()
+        val outcome = ControlTools.execute(call("find_music"), device)!!
+
+        assertEquals("There is no music on this device.", outcome.spoken)
+    }
+
+    @Test
+    fun playMusic_speaksActualTrack() {
+        val outcome = ControlTools.execute(call(
+            "play_music",
+            "query" to ArgumentValue.Str("morning"),
+            "say" to ArgumentValue.Str("Playing music."),
+        ), device)!!
+
+        assertEquals("Playing Morning Drive by The Layers.", outcome.spoken)
+        assertEquals("play_music {query: morning}", outcome.label)
+    }
+
+    @Test
+    fun playMusic_queryMiss_fallsBackToAnyTrack() {
+        device.queryMatches = false
+        val outcome = ControlTools.execute(call(
+            "play_music", "query" to ArgumentValue.Str("polka")), device)!!
+
+        assertEquals("Playing Morning Drive by The Layers.", outcome.spoken)
+    }
+
+    @Test
+    fun playMusic_emptyLibrary_speaksMiss() {
+        device.playing = null
+        val outcome = ControlTools.execute(call("play_music"), device)!!
+
+        assertEquals("No music found on this device.", outcome.spoken)
+    }
+
+    @Test
+    fun playMusic_unknownArtist_omitsBy() {
+        device.playing = Track("Test Tone", null)
+        val outcome = ControlTools.execute(call("play_music"), device)!!
+
+        assertEquals("Playing Test Tone.", outcome.spoken)
+    }
+
+    // ------------------------------------------------------------------
+    // Simple actions
+    // ------------------------------------------------------------------
+
+    @Test
+    fun dialNumber_dialsAndHonorsSay() {
+        val outcome = ControlTools.execute(call(
+            "dial_number",
+            "number" to ArgumentValue.Str("+493012345"),
+            "say" to ArgumentValue.Str("Dialing."),
+        ), device)!!
+
+        assertEquals("+493012345", device.dialed)
+        assertEquals("Dialing.", outcome.spoken)
+    }
+
+    @Test
+    fun stopMusic_stops() {
+        val outcome = ControlTools.execute(call("stop_music"), device)!!
+
+        assertTrue(device.stopped)
+        assertEquals("Music stopped.", outcome.spoken)
+    }
+
+    @Test
+    fun setVolume_clampsAndTemplates() {
+        val outcome = ControlTools.execute(call(
+            "set_volume", "level" to ArgumentValue.Int(42)), device)!!
+
+        assertEquals(10, device.lastVolume)
+        assertEquals("Volume 10.", outcome.spoken)
+    }
+
+    @Test
+    fun setVolume_coercesStringLevel() {
+        ControlTools.execute(call(
+            "set_volume", "level" to ArgumentValue.Str("3")), device)!!
+
+        assertEquals(3, device.lastVolume)
+    }
+
+    // ------------------------------------------------------------------
+    // Declarations + failure paths
+    // ------------------------------------------------------------------
+
+    @Test
+    fun everyDeclaration_requiresSayParameter() {
+        for (tool in ControlTools.declarations) {
+            @Suppress("UNCHECKED_CAST")
+            val properties = tool.parameters["properties"] as Map<String, Any?>
+            assertTrue("${tool.name} missing say property", "say" in properties)
+            @Suppress("UNCHECKED_CAST")
+            val required = tool.parameters["required"] as List<String>
+            assertTrue("${tool.name} does not require say", "say" in required)
+        }
+    }
+
+    @Test
+    fun listCapabilities_speaksTheRealSurface_ignoringSay() {
+        val outcome = ControlTools.execute(call(
+            "list_capabilities",
+            "say" to ArgumentValue.Str("I can do everything!"),
+        ), device)!!
+
+        assertEquals(ControlTools.CAPABILITIES_SUMMARY, outcome.spoken)
+        // The summary must cover every user-facing capability group.
+        for (word in listOf("contacts", "dial", "music", "volume")) {
+            assertTrue("summary missing '$word'", word in outcome.spoken)
+        }
+    }
+
+    @Test
+    fun listCapabilities_isDeclaredToTheModel() {
+        assertTrue(ControlTools.declarations.any { it.name == "list_capabilities" })
+    }
+
+    @Test
+    fun availableTools_offersStopOnlyWhileMusicPlays() {
+        val idle = ControlTools.availableTools(musicPlaying = false).map { it.name }
+        assertFalse("stop_music must not be offered when nothing plays", "stop_music" in idle)
+        assertTrue("play_music always available", "play_music" in idle)
+        assertTrue("call_contact always available", "call_contact" in idle)
+
+        val playing = ControlTools.availableTools(musicPlaying = true).map { it.name }
+        assertTrue("stop_music offered while playing", "stop_music" in playing)
+    }
+
+    @Test
+    fun callingStopsMusicFirst() {
+        device.musicPlaying = true
+        ControlTools.execute(call(
+            "call_contact", "name" to ArgumentValue.Str("anna")), device)!!
+        assertTrue("a call must stop any playing music", device.stopped)
+        assertEquals("+4917612345678", device.dialed)
+
+        device.stopped = false
+        ControlTools.execute(call(
+            "dial_number", "number" to ArgumentValue.Str("123")), device)!!
+        assertTrue("dialing must stop any playing music", device.stopped)
+    }
+
+    @Test
+    fun unknownTool_returnsNull() {
+        assertNull(ControlTools.execute(call("format_disk"), device))
+    }
+
+    @Test
+    fun missingRequiredArg_returnsNull() {
+        assertNull(ControlTools.execute(call("call_contact"), device))
+        assertNull(ControlTools.execute(call("dial_number"), device))
+        assertNull(ControlTools.execute(call("set_volume"), device))
+    }
+}

--- a/control-demo/src/test/kotlin/audio/soniqo/speech/control/MicGainTest.kt
+++ b/control-demo/src/test/kotlin/audio/soniqo/speech/control/MicGainTest.kt
@@ -1,0 +1,56 @@
+package audio.soniqo.speech.control
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MicGainTest {
+
+    @Test
+    fun silenceRemainsSilent() {
+        val samples = FloatArray(512)
+
+        MicGain().process(samples, samples.size)
+
+        assertTrue(samples.all { it == 0f })
+    }
+
+    @Test
+    fun quietSpeechIsRaisedGradually() {
+        val gain = MicGain()
+        val samples = FloatArray(512)
+
+        repeat(12) {
+            samples.fill(0.01f)
+            gain.process(samples, samples.size)
+        }
+
+        assertTrue(samples[0] > 0.01f)
+        assertTrue(samples[0] <= 0.98f)
+    }
+
+    @Test
+    fun learnedGainNeverExceedsSafetyClip() {
+        val gain = MicGain()
+        val samples = FloatArray(512)
+        repeat(20) {
+            samples.fill(0.005f)
+            gain.process(samples, samples.size)
+        }
+        samples.fill(1f)
+
+        gain.process(samples, samples.size)
+
+        assertTrue(samples.all { it == 0.98f })
+    }
+
+    @Test
+    fun onlyRequestedPrefixIsModified() {
+        val samples = floatArrayOf(0.01f, 0.25f)
+
+        MicGain().process(samples, 1)
+
+        assertTrue(samples[0] > 0.01f)
+        assertEquals(0.25f, samples[1], 0f)
+    }
+}

--- a/control-demo/src/test/kotlin/audio/soniqo/speech/control/SpeechChunksTest.kt
+++ b/control-demo/src/test/kotlin/audio/soniqo/speech/control/SpeechChunksTest.kt
@@ -24,9 +24,10 @@ class SpeechChunksTest {
         val pieces = SpeechChunks.split(ControlTools.CAPABILITIES_SUMMARY)
         assertTrue("expected 2+ pieces, got $pieces", pieces.size >= 2)
         for (piece in pieces) {
-            assertTrue("piece too long: $piece", piece.length <= 90)
+            assertTrue("piece too long: $piece", piece.length <= 30)
             assertTrue("piece too short: $piece", piece.length >= 10)
         }
+        assertEquals("I can call your contacts,", pieces.first())
         assertEquals(
             ControlTools.CAPABILITIES_SUMMARY.replace(" ", ""),
             pieces.joinToString("").replace(" ", ""),
@@ -39,6 +40,14 @@ class SpeechChunksTest {
             "Hotel California, Morning Drive by The Layers."
         val pieces = SpeechChunks.split(reply)
         assertTrue(pieces.size >= 2)
-        for (piece in pieces) assertTrue(piece.length <= 90)
+        for (piece in pieces) assertTrue(piece.length <= 30)
+    }
+
+    @Test
+    fun tinyTailMovesAWordFromPreviousPiece() {
+        assertEquals(
+            listOf("Playing Over the Horizon", "by Samsung."),
+            SpeechChunks.split("Playing Over the Horizon by Samsung."),
+        )
     }
 }

--- a/control-demo/src/test/kotlin/audio/soniqo/speech/control/SpeechChunksTest.kt
+++ b/control-demo/src/test/kotlin/audio/soniqo/speech/control/SpeechChunksTest.kt
@@ -1,0 +1,44 @@
+package audio.soniqo.speech.control
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpeechChunksTest {
+
+    @Test
+    fun shortReplyStaysWhole() {
+        assertEquals(listOf("Music stopped."), SpeechChunks.split("Music stopped."))
+    }
+
+    @Test
+    fun sentencesSplitApart() {
+        assertEquals(
+            listOf("Calling Anna.", "Please wait."),
+            SpeechChunks.split("Calling Anna. Please wait."),
+        )
+    }
+
+    @Test
+    fun longSingleSentenceSplitsAtClauseBoundary() {
+        val pieces = SpeechChunks.split(ControlTools.CAPABILITIES_SUMMARY)
+        assertTrue("expected 2+ pieces, got $pieces", pieces.size >= 2)
+        for (piece in pieces) {
+            assertTrue("piece too long: $piece", piece.length <= 90)
+            assertTrue("piece too short: $piece", piece.length >= 10)
+        }
+        assertEquals(
+            ControlTools.CAPABILITIES_SUMMARY.replace(" ", ""),
+            pieces.joinToString("").replace(" ", ""),
+        )
+    }
+
+    @Test
+    fun findMusicListingSplitsCleanly() {
+        val reply = "You have 25 tracks, including Feeling Good by Nina Simone, " +
+            "Hotel California, Morning Drive by The Layers."
+        val pieces = SpeechChunks.split(reply)
+        assertTrue(pieces.size >= 2)
+        for (piece in pieces) assertTrue(piece.length <= 90)
+    }
+}

--- a/control-demo/src/test/kotlin/audio/soniqo/speech/control/TurnMetricsTest.kt
+++ b/control-demo/src/test/kotlin/audio/soniqo/speech/control/TurnMetricsTest.kt
@@ -1,0 +1,53 @@
+package audio.soniqo.speech.control
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TurnMetricsTest {
+
+    private val metrics = TurnMetrics(
+        sttMs = 420f, speechSec = 2.0f,
+        llmMs = 500, llmChars = 120,   // ~30 tokens
+        ttsMs = 510, ttsAudioSec = 1.7f,
+        actionMs = 940, roundMs = 1450,
+        memMb = 1432,
+    )
+
+    @Test
+    fun rtf_isWallTimeOverAudioSeconds() {
+        assertEquals(0.21f, metrics.sttRtf, 0.001f)
+        assertEquals(0.3f, metrics.ttsRtf, 0.001f)
+    }
+
+    @Test
+    fun tokPerSec_estimatesFourCharsPerToken() {
+        assertEquals(60f, metrics.tokPerSec, 0.001f)
+    }
+
+    @Test
+    fun format_isRunnerStyleSingleLine() {
+        assertEquals(
+            "stt 420ms rtf 0.21 · llm 500ms ~60 tok/s · tts 510ms→1.7s rtf 0.30" +
+                " · action 940ms · round 1450ms · mem 1432 MB",
+            metrics.format(),
+        )
+    }
+
+    @Test
+    fun format_omitsUnknownFields() {
+        val line = TurnMetrics(
+            sttMs = 100f, speechSec = 0f,
+            llmMs = 0, llmChars = 0,
+            ttsMs = 200, ttsAudioSec = 0f,
+            actionMs = 300, roundMs = 400,
+            memMb = 0,
+        ).format()
+
+        assertFalse(line.contains("rtf"))
+        assertFalse(line.contains("tok/s"))
+        assertFalse(line.contains("mem"))
+        assertTrue(line.contains("action 300ms"))
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/sdk/consumer-rules.pro
+++ b/sdk/consumer-rules.pro
@@ -1,6 +1,7 @@
 # Keep JNI callback interfaces — native code looks up methods by name
 -keep class audio.soniqo.speech.NativeBridge { *; }
 -keep class audio.soniqo.speech.NativeBridge$EventCallback { *; }
+-keep class audio.soniqo.speech.NativeBridge$SynthesisCallback { *; }
 -keep class audio.soniqo.speech.NativeBridge$LlmCallback { *; }
 
 # Keep all public SDK classes

--- a/sdk/src/main/cpp/CMakeLists.txt
+++ b/sdk/src/main/cpp/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 #
 # Pull in speech-core via add_subdirectory so we reuse its target definitions
 # rather than re-listing sources here. SPEECH_CORE_WITH_ONNX=ON adds the
-# speech_core_models target (Silero VAD / Parakeet STT / Kokoro TTS /
+# speech_core_models target (Silero VAD / Parakeet STT / Kokoro and Pocket TTS /
 # DeepFilterNet wrappers). Tests and examples are off — the Android NDK
 # can't run host ctest binaries anyway.
 # ---------------------------------------------------------------------------

--- a/sdk/src/main/cpp/jni_bridge.cpp
+++ b/sdk/src/main/cpp/jni_bridge.cpp
@@ -5,6 +5,7 @@
 #include <speech_core/models/kokoro_tts.h>
 #include <speech_core/models/onnx_engine.h>
 #include <speech_core/models/onnx_nemotron_streaming_stt.h>
+#include <speech_core/models/onnx_pocket_tts.h>
 #include <speech_core/models/parakeet_stt.h>
 #include <speech_core/models/nemotron_multilingual_stt.h>
 #include <speech_core/models/silero_vad.h>
@@ -43,7 +44,7 @@
 struct PipelineHandle {
     std::unique_ptr<speech_core::SileroVad> vad;
     std::unique_ptr<speech_core::STTInterface> stt;  // Parakeet-EOU, Parakeet TDT, or Nemotron
-    std::unique_ptr<speech_core::TTSInterface> tts;  // Kokoro (ONNX) or Supertonic (LiteRT)
+    std::unique_ptr<speech_core::TTSInterface> tts;  // Kokoro/Pocket (ONNX) or Supertonic (LiteRT)
     std::unique_ptr<speech_core::DeepFilterEnhancer> enhancer;
     std::unique_ptr<speech_core::VoicePipeline> pipeline;
 
@@ -77,6 +78,7 @@ static constexpr int TTS_SUPERTONIC = 1;
 static constexpr int MODE_ECHO = 0;
 static constexpr int MODE_TRANSCRIBE_ONLY = 1;
 static constexpr int TTS_KOKORO_SHORT_TURN = 2;
+static constexpr int TTS_POCKET = 3;
 
 static std::unique_ptr<speech_core::TTSInterface> create_tts(
     const std::string& dir, bool nnapi, int ttsModel)
@@ -104,6 +106,19 @@ static std::unique_ptr<speech_core::TTSInterface> create_tts(
             dir + "/voices",
             dir,
             nnapi);
+    }
+
+    if (ttsModel == TTS_POCKET) {
+        // The public recurrent graphs are CPU-oriented. Two ORT threads and
+        // four flow steps are the quality/latency profile validated on the
+        // Galaxy S23 Ultra. Pocket assets are namespaced because both the STT
+        // and TTS bundles publish a file named vocab.json.
+        speech_core::PocketTtsConfig config;
+        config.intra_threads = 2;
+        config.flow_steps = 4;
+        config.hardware_acceleration = false;
+        return std::make_unique<speech_core::OnnxPocketTts>(
+            dir + "/pocket_tts", config);
     }
 
     return std::make_unique<speech_core::KokoroTts>(
@@ -523,6 +538,83 @@ static jbyteArray synthesize_pcm16(JNIEnv* env, speech_core::TTSInterface& tts,
     return out;
 }
 
+// Synthesize synchronously while forwarding each safe native model chunk to
+// Kotlin. speech-core invokes the callback before starting the next chunk, so
+// callers can begin playback while the following inference is still running.
+static void synthesize_streaming_pcm16(
+    JNIEnv* env, speech_core::TTSInterface& tts, std::mutex& mutex,
+    jstring text, jstring language, jobject callback)
+{
+    if (!callback) {
+        jclass ex_cls = env->FindClass("java/lang/IllegalArgumentException");
+        if (ex_cls) env->ThrowNew(ex_cls, "Synthesis callback must not be null");
+        return;
+    }
+
+    jclass callback_cls = env->GetObjectClass(callback);
+    if (!callback_cls) return;
+    jmethodID on_chunk = env->GetMethodID(callback_cls, "onChunk", "([BZ)V");
+    if (!on_chunk) {
+        env->DeleteLocalRef(callback_cls);
+        return;
+    }
+
+    std::string input = jstring_to_string(env, text);
+    std::string lang = jstring_to_string(env, language);
+    bool callback_failed = false;
+    try {
+        std::lock_guard<std::mutex> lock(mutex);
+        tts.synthesize(
+            input, lang,
+            [&](const float* samples, size_t length, bool is_final) {
+                if (callback_failed) return;
+                std::vector<int16_t> pcm(length);
+                for (size_t i = 0; i < length; ++i) {
+                    const float clamped = std::max(-1.0f, std::min(1.0f, samples[i]));
+                    pcm[i] = static_cast<int16_t>(std::lrintf(clamped * 32767.0f));
+                }
+
+                const jsize byte_count =
+                    static_cast<jsize>(pcm.size() * sizeof(int16_t));
+                jbyteArray audio = env->NewByteArray(byte_count);
+                if (!audio) {
+                    callback_failed = true;
+                    tts.cancel();
+                    return;
+                }
+                if (byte_count > 0) {
+                    env->SetByteArrayRegion(
+                        audio, 0, byte_count,
+                        reinterpret_cast<const jbyte*>(pcm.data()));
+                }
+                if (env->ExceptionCheck()) {
+                    env->DeleteLocalRef(audio);
+                    callback_failed = true;
+                    tts.cancel();
+                    return;
+                }
+                env->CallVoidMethod(
+                    callback, on_chunk, audio,
+                    is_final ? JNI_TRUE : JNI_FALSE);
+                env->DeleteLocalRef(audio);
+                if (env->ExceptionCheck()) {
+                    callback_failed = true;
+                    tts.cancel();
+                }
+            });
+    } catch (const std::exception& e) {
+        LOGE("Streaming synthesis failed: %s", e.what());
+        if (!env->ExceptionCheck()) {
+            jclass ex_cls = env->FindClass("java/lang/RuntimeException");
+            if (ex_cls) {
+                std::string msg = std::string("Native streaming synthesis failed: ") + e.what();
+                env->ThrowNew(ex_cls, msg.c_str());
+            }
+        }
+    }
+    env->DeleteLocalRef(callback_cls);
+}
+
 JNIEXPORT jbyteArray JNICALL
 Java_audio_soniqo_speech_NativeBridge_nativeSynthesize(
     JNIEnv* env, jobject /*thiz*/, jlong handle, jstring text, jstring language)
@@ -556,6 +648,21 @@ Java_audio_soniqo_speech_NativeBridge_nativePipelineSynthesize(
         return nullptr;
     }
     return synthesize_pcm16(env, *h->tts, h->tts_mutex, text, language);
+}
+
+JNIEXPORT void JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativePipelineSynthesizeStreaming(
+    JNIEnv* env, jobject /*thiz*/, jlong handle, jstring text, jstring language,
+    jobject callback)
+{
+    auto* h = reinterpret_cast<PipelineHandle*>(handle);
+    if (!h || !h->tts) {
+        jclass ex_cls = env->FindClass("java/lang/IllegalStateException");
+        if (ex_cls) env->ThrowNew(ex_cls, "Native pipeline is closed");
+        return;
+    }
+    synthesize_streaming_pcm16(
+        env, *h->tts, h->tts_mutex, text, language, callback);
 }
 
 JNIEXPORT void JNICALL

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
@@ -69,6 +69,9 @@ class ModelDownloadWorker(
         val ttsModel = inputData.getString(KEY_TTS_MODEL)
             ?.let { runCatching { TtsModel.valueOf(it) }.getOrNull() }
             ?: TtsModel.KOKORO_SHORT_TURN
+        val llmModel = inputData.getString(KEY_LLM_MODEL)
+            ?.let { runCatching { LlmModel.valueOf(it) }.getOrNull() }
+            ?: LlmModel.FUNCTIONGEMMA
         // When set, the FunctionGemma bundle is downloaded here too, so the
         // whole ~800 MB setup runs in this foreground worker — surviving doze
         // and Wi-Fi power-save that would kill an in-app download.
@@ -120,7 +123,11 @@ class ModelDownloadWorker(
                 onProgress = report,
             )
             if (includeLlm) {
-                ModelManager.ensureLlmModels(applicationContext, onProgress = report)
+                ModelManager.ensureLlmModels(
+                    applicationContext,
+                    llmModel = llmModel,
+                    onProgress = report,
+                )
             }
             Result.success(workDataOf(KEY_MODEL_DIR to modelDir))
         } catch (e: IOException) {
@@ -201,6 +208,7 @@ class ModelDownloadWorker(
         const val KEY_STT_BACKEND = "sttBackend"
         const val KEY_TTS_MODEL = "ttsModel"
         const val KEY_INCLUDE_LLM = "includeLlm"
+        const val KEY_LLM_MODEL = "llmModel"
 
         // Output keys
         const val KEY_MODEL_DIR = "modelDir"
@@ -233,6 +241,7 @@ class ModelDownloadWorker(
             sttBackend: SttBackend = SttBackend.ONNX,
             ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
             includeLlm: Boolean = false,
+            llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
         ): String {
             if (
                 precision == ModelPrecision.INT8 &&
@@ -243,7 +252,11 @@ class ModelDownloadWorker(
             ) {
                 return UNIQUE_NAME
             }
-            val llm = if (includeLlm) ".llm" else ""
+            val llm = when {
+                !includeLlm -> ""
+                llmModel == LlmModel.FUNCTIONGEMMA -> ".llm"
+                else -> ".llm.${llmModel.name}"
+            }
             val ttsName = if (ttsModel.isKokoro) TtsModel.KOKORO.name else ttsModel.name
             return "$UNIQUE_NAME.${precision.name}.${sttModel.name}.${sttBackend.name}.$ttsName$llm"
         }
@@ -254,6 +267,7 @@ class ModelDownloadWorker(
             sttBackend: SttBackend = SttBackend.ONNX,
             ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
             includeLlm: Boolean = false,
+            llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
         ) =
             OneTimeWorkRequestBuilder<ModelDownloadWorker>()
                 .setInputData(workDataOf(
@@ -262,6 +276,7 @@ class ModelDownloadWorker(
                     KEY_STT_BACKEND to sttBackend.name,
                     KEY_TTS_MODEL to ttsModel.name,
                     KEY_INCLUDE_LLM to includeLlm,
+                    KEY_LLM_MODEL to llmModel.name,
                 ))
                 .build()
 
@@ -277,10 +292,25 @@ class ModelDownloadWorker(
             sttBackend: SttBackend = SttBackend.ONNX,
             ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
             includeLlm: Boolean = false,
+            llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
         ): java.util.UUID {
-            val req = request(precision, sttModel, sttBackend, ttsModel, includeLlm)
+            val req = request(
+                precision = precision,
+                sttModel = sttModel,
+                sttBackend = sttBackend,
+                ttsModel = ttsModel,
+                includeLlm = includeLlm,
+                llmModel = llmModel,
+            )
             WorkManager.getInstance(context).enqueueUniqueWork(
-                uniqueName(precision, sttModel, sttBackend, ttsModel, includeLlm),
+                uniqueName(
+                    precision = precision,
+                    sttModel = sttModel,
+                    sttBackend = sttBackend,
+                    ttsModel = ttsModel,
+                    includeLlm = includeLlm,
+                    llmModel = llmModel,
+                ),
                 ExistingWorkPolicy.KEEP, req,
             )
             return req.id

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -20,6 +20,8 @@ import java.util.concurrent.TimeUnit
 object ModelManager {
 
     private const val BASE_URL = "https://huggingface.co/soniqo"
+    private const val POCKET_TTS_REVISION = "v1.0.0"
+    private const val POCKET_TTS_DIR = "pocket_tts"
 
     // Bump when models on HuggingFace are updated to trigger cache invalidation.
     // v6: default STT switched to Parakeet-EOU-120M-ONNX-INT8, the low-memory
@@ -140,6 +142,28 @@ object ModelManager {
             "voice_styles/M1.json", "voice_styles/M2.json", "voice_styles/M3.json",
             "voice_styles/M4.json", "voice_styles/M5.json",
         ).map { ModelFile("Supertonic-3-LiteRT", it) }
+        TtsModel.POCKET -> listOf(
+            // Runtime files from the immutable public fixed-Alba bundle. Keep
+            // them below pocket_tts/: Parakeet and Pocket both ship vocab.json.
+            "decoder.int8.onnx",
+            "encoder.onnx",
+            "lm_flow.int8.onnx",
+            "lm_main.int8.onnx",
+            "text_conditioner.onnx",
+            "token_scores.json",
+            "vocab.json",
+            // Retain the model/voice license and release manifest beside the
+            // runtime files distributed to the device.
+            "LICENSE",
+            "manifest.json",
+        ).map { filename ->
+            ModelFile(
+                repo = "Pocket-TTS-100M-ONNX-INT8",
+                filename = filename,
+                revision = POCKET_TTS_REVISION,
+                localFilename = "$POCKET_TTS_DIR/$filename",
+            )
+        }
     }
 
     // FunctionGemma is kept out of the pipeline model set: only agent demos
@@ -155,7 +179,15 @@ object ModelManager {
         )
     }
 
-    data class ModelFile(val repo: String, val filename: String)
+    data class ModelFile(
+        val repo: String,
+        /** Path within the Hugging Face repository. */
+        val filename: String,
+        /** Immutable tag/commit where available; existing bundles use main. */
+        val revision: String = "main",
+        /** Cache-relative path. May differ to avoid cross-model collisions. */
+        val localFilename: String = filename,
+    )
 
     data class Progress(
         val file: String,
@@ -203,7 +235,7 @@ object ModelManager {
             fileList
         }
         return allFiles.all { model ->
-            val dest = File(dir, model.filename)
+            val dest = File(dir, model.localFilename)
             dest.exists() && isValidModel(dest, model.filename)
         }
     }
@@ -226,7 +258,7 @@ object ModelManager {
         if (cachedModelSet(dir) != ttsModelSetKey(ttsModel)) return false
 
         return ttsModels(ttsModel).all { model ->
-            val dest = File(dir, model.filename)
+            val dest = File(dir, model.localFilename)
             dest.exists() && isValidModel(dest, model.filename)
         }
     }
@@ -248,14 +280,19 @@ object ModelManager {
         if (cachedModelSet(dir) != llmModelSetKey(llmModel)) return false
 
         return llmModels(llmModel).all { model ->
-            val dest = File(dir, model.filename)
+            val dest = File(dir, model.localFilename)
             dest.exists() && isValidModel(dest, model.filename)
         }
     }
 
     /** Path to the model directory for [precision], without downloading. */
-    fun modelDir(context: Context): String =
-        File(context.filesDir, "models").absolutePath
+    fun modelDir(
+        context: Context,
+        precision: ModelPrecision = ModelPrecision.INT8,
+        sttModel: SttModel = SttModel.PARAKEET_EOU,
+        sttBackend: SttBackend = SttBackend.ONNX,
+        ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
+    ): String = modelDirFile(context, precision, sttModel, sttBackend, ttsModel).absolutePath
 
     /** Path to the TTS-only model directory, without downloading. */
     fun ttsModelDir(context: Context): String =
@@ -411,7 +448,7 @@ object ModelManager {
     ) {
         var completed = 0
         for (model in allFiles) {
-            val dest = File(dir, model.filename)
+            val dest = File(dir, model.localFilename)
             if (dest.exists() && isValidModel(dest, model.filename)) {
                 completed++
                 continue
@@ -423,9 +460,9 @@ object ModelManager {
             }
             dest.parentFile?.mkdirs()
 
-            val url = "$BASE_URL/${model.repo}/resolve/main/${model.filename}"
+            val url = "$BASE_URL/${model.repo}/resolve/${model.revision}/${model.filename}"
             downloadFile(url, dest) { bytes, fileTotal ->
-                onProgress?.invoke(Progress(model.filename, bytes, fileTotal, allFiles.size, completed))
+                onProgress?.invoke(Progress(model.localFilename, bytes, fileTotal, allFiles.size, completed))
             }
             completed++
         }
@@ -617,6 +654,12 @@ object ModelManager {
         "kokoro-e2e.onnx" to 1_000L,                     // Small (weights in .data file)
         "kokoro-e2e-realtime.onnx" to 1_000_000L,        // ~2.5 MB shared-weight graph
         "kokoro-e2e.onnx.data" to 50_000_000L,           // ~310 MB
+        "decoder.int8.onnx" to 20_000_000L,              // Pocket decoder, ~22.7 MB
+        "encoder.onnx" to 400_000L,                      // Pocket Alba encoder, ~0.5 MB
+        "lm_flow.int8.onnx" to 9_000_000L,               // Pocket flow model, ~10.0 MB
+        "lm_main.int8.onnx" to 70_000_000L,              // Pocket recurrent LM, ~76.3 MB
+        "text_conditioner.onnx" to 15_000_000L,          // Pocket text encoder, ~16.4 MB
+        "token_scores.json" to 100_000L,                 // Pocket tokenizer scores
         "silero-vad.onnx" to 500_000L,                   // ~2 MB
         "model.litertlm" to 200_000_000L,                // ~283 MB FunctionGemma bundle
         "model-lora16-android.litertlm" to 300_000_000L, // ~327 MB LoRA-capable base

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -142,12 +142,18 @@ object ModelManager {
         ).map { ModelFile("Supertonic-3-LiteRT", it) }
     }
 
-    // FunctionGemma 270M tool-calling LLM — a single .litertlm bundle for the
-    // LiteRT-LM runtime. Kept out of the pipeline model set: only agent demos
-    // opt in via [ensureLlmModels], so SDK integrations never pull the 283 MB.
-    private fun llmModels(): List<ModelFile> = listOf(
-        ModelFile("FunctionGemma-270M-LiteRT-LM", "model.litertlm"),
-    )
+    // FunctionGemma is kept out of the pipeline model set: only agent demos
+    // opt in via [ensureLlmModels]. The Control profile downloads one reusable
+    // LoRA-capable base and its small adapter as distinct files.
+    private fun llmModels(llmModel: LlmModel): List<ModelFile> = when (llmModel) {
+        LlmModel.FUNCTIONGEMMA -> listOf(
+            ModelFile("FunctionGemma-270M-LiteRT-LM", "model.litertlm"),
+        )
+        LlmModel.FUNCTIONGEMMA_CONTROL_LORA -> listOf(
+            ModelFile("FunctionGemma-270M-LiteRT-LM", "model-lora16-android.litertlm"),
+            ModelFile("FunctionGemma-270M-LiteRT-LM", "control-r4-rank16.tflite"),
+        )
+    }
 
     data class ModelFile(val repo: String, val filename: String)
 
@@ -229,16 +235,19 @@ object ModelManager {
      * True iff the LLM cache contains a valid FunctionGemma bundle.
      * Cheap and side-effect free — does not start a download.
      */
-    fun areLlmModelsReady(context: Context): Boolean {
-        val dir = File(context.filesDir, "models_llm")
+    fun areLlmModelsReady(
+        context: Context,
+        llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
+    ): Boolean {
+        val dir = File(llmModelDir(context, llmModel))
         if (!dir.exists()) return false
 
         val versionFile = File(dir, "version.txt")
         val cached = versionFile.takeIf { it.exists() }?.readText()?.trim()?.toIntOrNull() ?: 0
         if (cached < MODEL_VERSION) return false
-        if (cachedModelSet(dir) != llmModelSetKey()) return false
+        if (cachedModelSet(dir) != llmModelSetKey(llmModel)) return false
 
-        return llmModels().all { model ->
+        return llmModels(llmModel).all { model ->
             val dest = File(dir, model.filename)
             dest.exists() && isValidModel(dest, model.filename)
         }
@@ -253,12 +262,30 @@ object ModelManager {
         File(context.filesDir, "models_tts").absolutePath
 
     /** Path to the LLM model directory, without downloading. */
-    fun llmModelDir(context: Context): String =
-        File(context.filesDir, "models_llm").absolutePath
+    fun llmModelDir(
+        context: Context,
+        llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
+    ): String {
+        val name = when (llmModel) {
+            LlmModel.FUNCTIONGEMMA -> "models_llm"
+            LlmModel.FUNCTIONGEMMA_CONTROL_LORA -> "models_llm-control-lora"
+        }
+        return File(context.filesDir, name).absolutePath
+    }
 
     /** Absolute path of the FunctionGemma .litertlm bundle, without downloading. */
-    fun llmModelFile(context: Context): String =
-        File(llmModelDir(context), llmModels().first().filename).absolutePath
+    fun llmModelFile(
+        context: Context,
+        llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
+    ): String = File(
+        llmModelDir(context, llmModel),
+        llmModels(llmModel).first { it.filename.endsWith(".litertlm") }.filename,
+    ).absolutePath
+
+    /** Adapter path for LoRA profiles, or null for a standalone LLM bundle. */
+    fun llmAdapterFile(context: Context, llmModel: LlmModel): String? =
+        llmModels(llmModel).firstOrNull { it.filename.endsWith(".tflite") }
+            ?.let { File(llmModelDir(context, llmModel), it.filename).absolutePath }
 
     /** Returns the model directory path, downloading models if needed. */
     suspend fun ensureModels(
@@ -334,20 +361,21 @@ object ModelManager {
     }
 
     /**
-     * Returns the path of the FunctionGemma .litertlm bundle, downloading it
-     * if needed. Separate from [ensureModels] so the 283 MB LLM only lands on
-     * devices whose app actually runs the tool-calling agent.
+     * Returns the path of the selected FunctionGemma .litertlm base,
+     * downloading its complete artifact set if needed. Separate from
+     * [ensureModels] so LLM files only land on devices that run an agent.
      */
     suspend fun ensureLlmModels(
         context: Context,
+        llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
         onProgress: ((Progress) -> Unit)? = null,
     ): String = withContext(Dispatchers.IO) {
-        val dir = File(context.filesDir, "models_llm")
+        val dir = File(llmModelDir(context, llmModel))
         dir.mkdirs()
 
         val versionFile = File(dir, "version.txt")
         val setFile = File(dir, MODEL_SET_FILENAME)
-        val requestedModelSet = llmModelSetKey()
+        val requestedModelSet = llmModelSetKey(llmModel)
         val cached = versionFile.takeIf { it.exists() }?.readText()?.trim()?.toIntOrNull() ?: 0
         val cachedSet = cachedModelSet(dir)
 
@@ -368,9 +396,12 @@ object ModelManager {
         setFile.writeText(requestedModelSet)
         versionFile.writeText(MODEL_VERSION.toString())
 
-        downloadMissingModels(dir, llmModels(), onProgress)
+        downloadMissingModels(dir, llmModels(llmModel), onProgress)
 
-        File(dir, llmModels().first().filename).absolutePath
+        File(
+            dir,
+            llmModels(llmModel).first { it.filename.endsWith(".litertlm") }.filename,
+        ).absolutePath
     }
 
     private fun downloadMissingModels(
@@ -453,10 +484,10 @@ object ModelManager {
     private fun ttsCacheName(ttsModel: TtsModel): String =
         if (ttsModel.isKokoro) TtsModel.KOKORO.name else ttsModel.name
 
-    private fun llmModelSetKey(): String = listOf(
+    private fun llmModelSetKey(llmModel: LlmModel): String = listOf(
         "v$MODEL_VERSION",
         "profile=LLM",
-        "llm=FUNCTIONGEMMA_270M",
+        "llm=${llmModel.name}",
     ).joinToString("|")
 
     private fun cachedModelSet(dir: File): String? =
@@ -588,6 +619,8 @@ object ModelManager {
         "kokoro-e2e.onnx.data" to 50_000_000L,           // ~310 MB
         "silero-vad.onnx" to 500_000L,                   // ~2 MB
         "model.litertlm" to 200_000_000L,                // ~283 MB FunctionGemma bundle
+        "model-lora16-android.litertlm" to 300_000_000L, // ~327 MB LoRA-capable base
+        "control-r4-rank16.tflite" to 9_000_000L,        // ~9.5 MB Control adapter
     )
 
     private fun isValidModel(file: File, filename: String): Boolean {

--- a/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
@@ -12,7 +12,7 @@ internal object NativeBridge {
         useInt8: Boolean,
         sttModel: Int,    // SttModel.ordinal: 0=PARAKEET, 1=NEMOTRON_MULTILINGUAL, 2=PARAKEET_EOU
         sttBackend: Int,  // SttBackend.ordinal: 0=ONNX, 1=LITERT
-        ttsModel: Int,    // 0=KOKORO, 1=SUPERTONIC, 2=KOKORO_SHORT_TURN
+        ttsModel: Int,    // 0=KOKORO, 1=SUPERTONIC, 2=KOKORO_SHORT_TURN, 3=POCKET
         pipelineMode: Int, // PipelineMode.ordinal: 0=ECHO, 1=TRANSCRIBE_ONLY
         language: String, // single language hint ("auto", "en-US", ...) — Nemotron prompt + TTS voice
         languageHints: Array<String>, // reserved; no current backend consumes hints
@@ -39,12 +39,18 @@ internal object NativeBridge {
     // TRANSCRIBE_ONLY agent loop speak responses without a second TTS copy.
     external fun nativePipelineTtsSampleRate(handle: Long): Int
     external fun nativePipelineSynthesize(handle: Long, text: String, language: String): ByteArray
+    external fun nativePipelineSynthesizeStreaming(
+        handle: Long,
+        text: String,
+        language: String,
+        callback: SynthesisCallback,
+    )
     external fun nativePipelineCancelSynthesis(handle: Long)
 
     external fun nativeCreateSynthesizer(
         modelDir: String,
         useNnapi: Boolean,
-        ttsModel: Int,    // 0=KOKORO, 1=SUPERTONIC, 2=KOKORO_SHORT_TURN
+        ttsModel: Int,    // 0=KOKORO, 1=SUPERTONIC, 2=KOKORO_SHORT_TURN, 3=POCKET
     ): Long
     external fun nativeDestroySynthesizer(handle: Long)
     external fun nativeStopSynthesizer(handle: Long)
@@ -61,5 +67,10 @@ internal object NativeBridge {
             sttMs: Float,
             ttsMs: Float,
         )
+    }
+
+    /** Called synchronously from native code after each safe TTS model run. */
+    fun interface SynthesisCallback {
+        fun onChunk(audio: ByteArray, isFinal: Boolean)
     }
 }

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
@@ -21,6 +21,14 @@ enum class TtsModel(internal val nativeId: Int) {
     KOKORO_SHORT_TURN(2),
 }
 
+/** Optional on-device language-model bundle. [FUNCTIONGEMMA] is the original
+ *  standalone export. [FUNCTIONGEMMA_CONTROL_LORA] is the reusable
+ *  LoRA-enabled Android base plus the separately loaded Control adapter. */
+enum class LlmModel {
+    FUNCTIONGEMMA,
+    FUNCTIONGEMMA_CONTROL_LORA,
+}
+
 internal val TtsModel.isKokoro: Boolean
     get() = this == TtsModel.KOKORO || this == TtsModel.KOKORO_SHORT_TURN
 

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
@@ -12,13 +12,15 @@ enum class SttModel { PARAKEET, NEMOTRON_MULTILINGUAL, PARAKEET_EOU }
 enum class SttBackend { ONNX, LITERT }
 
 /** On-device TTS model. [KOKORO_SHORT_TURN] uses the same Kokoro weights with
- *  a shorter unrolled graph for bounded, low-latency voice-agent replies.
- *  [KOKORO] keeps the full-capacity graph; [SUPERTONIC] is a LiteRT
- *  flow-matching model (44.1 kHz, 31 languages, G2P-free). */
+ *  a shorter unrolled graph for bounded voice-agent replies. [KOKORO] keeps
+ *  the full-capacity graph; [SUPERTONIC] is a LiteRT flow-matching model
+ *  (44.1 kHz, 31 languages, G2P-free). [POCKET] is the true-streaming ONNX
+ *  profile: English-only, fixed Alba voice, with 80 ms audio frames. */
 enum class TtsModel(internal val nativeId: Int) {
     KOKORO(0),
     SUPERTONIC(1),
     KOKORO_SHORT_TURN(2),
+    POCKET(3),
 }
 
 /** Optional on-device language-model bundle. [FUNCTIONGEMMA] is the original

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
@@ -69,6 +69,20 @@ interface SpeechPipeline : AutoCloseable {
     fun synthesize(text: String, language: String = "en"): SpeechSynthesisResult =
         throw UnsupportedOperationException("This SpeechPipeline does not support direct synthesis")
 
+    /**
+     * Synthesize [text] and deliver each safe native model chunk as soon as it
+     * is available. The call is blocking; invoke it off the main thread. The
+     * default preserves compatibility with custom pipelines by emitting one
+     * buffered result.
+     */
+    fun synthesizeStreaming(
+        text: String,
+        language: String = "en",
+        onChunk: (result: SpeechSynthesisResult, isFinal: Boolean) -> Unit,
+    ) {
+        onChunk(synthesize(text, language), true)
+    }
+
     /** Cancel an in-progress [synthesize]. */
     fun cancelSynthesis() {}
 
@@ -160,6 +174,23 @@ internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
         return SpeechSynthesisResult(
             sampleRate = ttsSampleRate,
             pcm16 = NativeBridge.nativePipelineSynthesize(handle, text, language),
+        )
+    }
+
+    override fun synthesizeStreaming(
+        text: String,
+        language: String,
+        onChunk: (result: SpeechSynthesisResult, isFinal: Boolean) -> Unit,
+    ) {
+        check(handle != 0L) { "SpeechPipeline is closed" }
+        val sampleRate = ttsSampleRate
+        NativeBridge.nativePipelineSynthesizeStreaming(
+            handle,
+            text,
+            language,
+            NativeBridge.SynthesisCallback { audio, isFinal ->
+                onChunk(SpeechSynthesisResult(sampleRate, audio), isFinal)
+            },
         )
     }
 

--- a/sdk/src/main/kotlin/audio/soniqo/speech/llm/FunctionGemmaParser.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/llm/FunctionGemmaParser.kt
@@ -1,9 +1,9 @@
 package audio.soniqo.speech.llm
 
 /**
- * Kotlin port of `function_calls.parse_function_calls` from the Python
- * speech-models export repo. Pure parsing — no I/O, no native deps —
- * so it is safe to call from any thread.
+ * Kotlin port of the Python export parser's
+ * `function_calls.parse_function_calls`. Pure parsing — no I/O, no native
+ * dependencies — so it is safe to call from any thread.
  */
 object FunctionGemmaParser {
 

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelDownloadWorkerTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelDownloadWorkerTest.kt
@@ -177,12 +177,42 @@ class ModelDownloadWorkerTest {
     }
 
     @Test
+    fun doWork_controlLoraInput_downloadsSelectedLlmProfile() = runBlocking {
+        coEvery {
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
+        } returns "/fake"
+        coEvery {
+            ModelManager.ensureLlmModels(any(), any(), any())
+        } returns "/fake/model-lora16-android.litertlm"
+
+        val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context)
+            .setInputData(workDataOf(
+                ModelDownloadWorker.KEY_INCLUDE_LLM to true,
+                ModelDownloadWorker.KEY_LLM_MODEL to
+                    LlmModel.FUNCTIONGEMMA_CONTROL_LORA.name,
+            ))
+            .build()
+
+        worker.doWork()
+
+        coVerify(exactly = 1) {
+            ModelManager.ensureLlmModels(
+                any(),
+                LlmModel.FUNCTIONGEMMA_CONTROL_LORA,
+                any(),
+            )
+        }
+    }
+
+    @Test
     fun request_buildsRequestWithModelInputDataAndNoNetworkConstraint() {
         val req = ModelDownloadWorker.request(
             precision = ModelPrecision.INT8,
             sttModel = SttModel.PARAKEET,
             sttBackend = SttBackend.ONNX,
             ttsModel = TtsModel.KOKORO,
+            includeLlm = true,
+            llmModel = LlmModel.FUNCTIONGEMMA_CONTROL_LORA,
         )
 
         assertEquals(
@@ -200,6 +230,11 @@ class ModelDownloadWorkerTest {
         assertEquals(
             "KOKORO",
             req.workSpec.input.getString(ModelDownloadWorker.KEY_TTS_MODEL),
+        )
+        assertTrue(req.workSpec.input.getBoolean(ModelDownloadWorker.KEY_INCLUDE_LLM, false))
+        assertEquals(
+            "FUNCTIONGEMMA_CONTROL_LORA",
+            req.workSpec.input.getString(ModelDownloadWorker.KEY_LLM_MODEL),
         )
         // No JobScheduler network constraint — the worker handles network
         // failures itself via IOException → retry. See KDoc on `request()`.
@@ -238,6 +273,13 @@ class ModelDownloadWorkerTest {
             ModelDownloadWorker.uniqueName(
                 precision = ModelPrecision.FP32,
                 sttModel = SttModel.PARAKEET,
+            ),
+        )
+        assertNotEquals(
+            ModelDownloadWorker.uniqueName(includeLlm = true),
+            ModelDownloadWorker.uniqueName(
+                includeLlm = true,
+                llmModel = LlmModel.FUNCTIONGEMMA_CONTROL_LORA,
             ),
         )
     }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
@@ -156,30 +156,56 @@ class ModelManagerManifestTest {
     }
 
     @Test
-    fun llmManifest_isSingleFunctionGemmaBundle() {
+    fun llmManifest_keepsStandaloneFunctionGemmaAsDefault() {
         assertEquals(
             listOf(ModelManager.ModelFile("FunctionGemma-270M-LiteRT-LM", "model.litertlm")),
-            llmModelFiles(),
+            llmModelFiles(LlmModel.FUNCTIONGEMMA),
+        )
+    }
+
+    @Test
+    fun controlLoraManifest_hasSeparateReusableBaseAndAdapter() {
+        assertEquals(
+            listOf(
+                ModelManager.ModelFile(
+                    "FunctionGemma-270M-LiteRT-LM",
+                    "model-lora16-android.litertlm",
+                ),
+                ModelManager.ModelFile(
+                    "FunctionGemma-270M-LiteRT-LM",
+                    "control-r4-rank16.tflite",
+                ),
+            ),
+            llmModelFiles(LlmModel.FUNCTIONGEMMA_CONTROL_LORA),
         )
     }
 
     @Test
     fun llmModelSetKey_isSeparateFromPipelineAndTtsCacheKeys() {
-        assertNotEquals(llmModelSetKey(), modelSetKey())
-        assertNotEquals(llmModelSetKey(), ttsModelSetKey(TtsModel.KOKORO))
+        val stock = llmModelSetKey(LlmModel.FUNCTIONGEMMA)
+        val control = llmModelSetKey(LlmModel.FUNCTIONGEMMA_CONTROL_LORA)
+        assertNotEquals(stock, modelSetKey())
+        assertNotEquals(stock, ttsModelSetKey(TtsModel.KOKORO))
+        assertNotEquals(stock, control)
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun llmModelFiles(): List<ModelManager.ModelFile> {
-        val method = ModelManager::class.java.getDeclaredMethod("llmModels")
+    private fun llmModelFiles(llmModel: LlmModel): List<ModelManager.ModelFile> {
+        val method = ModelManager::class.java.getDeclaredMethod(
+            "llmModels",
+            LlmModel::class.java,
+        )
         method.isAccessible = true
-        return method.invoke(ModelManager) as List<ModelManager.ModelFile>
+        return method.invoke(ModelManager, llmModel) as List<ModelManager.ModelFile>
     }
 
-    private fun llmModelSetKey(): String {
-        val method = ModelManager::class.java.getDeclaredMethod("llmModelSetKey")
+    private fun llmModelSetKey(llmModel: LlmModel): String {
+        val method = ModelManager::class.java.getDeclaredMethod(
+            "llmModelSetKey",
+            LlmModel::class.java,
+        )
         method.isAccessible = true
-        return method.invoke(ModelManager) as String
+        return method.invoke(ModelManager, llmModel) as String
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
@@ -30,6 +30,7 @@ class ModelManagerManifestTest {
         assertEquals(0, TtsModel.KOKORO.nativeId)
         assertEquals(1, TtsModel.SUPERTONIC.nativeId)
         assertEquals(2, TtsModel.KOKORO_SHORT_TURN.nativeId)
+        assertEquals(3, TtsModel.POCKET.nativeId)
     }
 
     @Test
@@ -153,6 +154,37 @@ class ModelManagerManifestTest {
         )
 
         assertEquals(expected, styleFiles)
+    }
+
+    @Test
+    fun pocketManifest_isPinnedAndNamespacedAwayFromSttAssets() {
+        val files = ttsModelFiles(TtsModel.POCKET)
+
+        assertEquals(
+            listOf(
+                "decoder.int8.onnx",
+                "encoder.onnx",
+                "lm_flow.int8.onnx",
+                "lm_main.int8.onnx",
+                "text_conditioner.onnx",
+                "token_scores.json",
+                "vocab.json",
+                "LICENSE",
+                "manifest.json",
+            ),
+            files.map { it.filename },
+        )
+        assertTrue(files.all { it.repo == "Pocket-TTS-100M-ONNX-INT8" })
+        assertTrue(files.all { it.revision == "v1.0.0" })
+        assertTrue(files.all { it.localFilename == "pocket_tts/${it.filename}" })
+        assertNotEquals(
+            modelSetKey(ttsModel = TtsModel.KOKORO),
+            modelSetKey(ttsModel = TtsModel.POCKET),
+        )
+        assertNotEquals(
+            modelDirName(ttsModel = TtsModel.KOKORO),
+            modelDirName(ttsModel = TtsModel.POCKET),
+        )
     }
 
     @Test

--- a/sdk/src/test/kotlin/audio/soniqo/speech/SpeechPipelineStreamingTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/SpeechPipelineStreamingTest.kt
@@ -1,0 +1,41 @@
+package audio.soniqo.speech
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpeechPipelineStreamingTest {
+
+    @Test
+    fun defaultAdapterEmitsOneFinalBufferedChunk() {
+        val expected = byteArrayOf(1, 2, 3, 4)
+        val pipeline = BufferedFakePipeline(expected)
+        var callbackCount = 0
+
+        pipeline.synthesizeStreaming("hello") { result, isFinal ->
+            callbackCount++
+            assertArrayEquals(expected, result.pcm16)
+            assertTrue(isFinal)
+        }
+
+        assertTrue(callbackCount == 1)
+    }
+
+    private class BufferedFakePipeline(
+        private val audio: ByteArray,
+    ) : SpeechPipeline {
+        override val events: SharedFlow<SpeechEvent> = MutableSharedFlow()
+        override val state: PipelineState = PipelineState.Idle
+        override val nnapiFallbackReason: String? = null
+
+        override fun start() = Unit
+        override fun stop() = Unit
+        override fun pushAudio(samples: FloatArray) = Unit
+        override fun resumeListening() = Unit
+        override fun synthesize(text: String, language: String) =
+            SpeechSynthesisResult(sampleRate = 24_000, pcm16 = audio)
+        override fun close() = Unit
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,3 +17,4 @@ dependencyResolutionManagement {
 rootProject.name = "speech-android"
 include(":sdk")
 include(":app")
+include(":control-demo")

--- a/setup.sh
+++ b/setup.sh
@@ -119,3 +119,4 @@ fi
 echo ""
 echo "Done. Open the project in Android Studio or run:"
 echo "  ./gradlew :app:assembleDebug"
+echo "  ./gradlew :control-demo:assembleDebug"


### PR DESCRIPTION
## Summary

- Add a separate `control-demo` Compose application for the complete on-device path: Silero VAD → Parakeet-EOU STT → FunctionGemma Control LoRA → Android actions → realtime Kokoro TTS.
- Add an opt-in `FUNCTIONGEMMA_CONTROL_LORA` model profile while preserving the original standalone FunctionGemma profile as the SDK default.
- Download and cache the reusable 327.4 MB Android LoRA base and the separately loadable 9.5 MB Control adapter directly from Hugging Face.
- Keep routing model-driven with a state-filtered tool surface, compact training-compatible prompt, deterministic decoding, and single-call validation.
- Add per-stage latency/memory telemetry, Compose UI, unit coverage, and a 136-case on-device LoRA evaluation.
- Restrict ADB command/replay harness extras to debuggable builds so exported release activities cannot be externally scripted into actions.
- Document the new module in every README translation and in `AGENTS.md`.

## Model artifacts

- Hugging Face release: https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM/commit/d34a12ed4ed517a0d3b1da3d0ac8f12494c55d74
- Base: `model-lora16-android.litertlm` — 327,438,928 bytes
- Adapter: `control-r4-rank16.tflite` — 9,502,720 bytes

## Test plan

- [x] `./gradlew :sdk:test`
- [x] `./gradlew :control-demo:testDebugUnitTest`
- [x] `./gradlew :control-demo:lintDebug`
- [x] `./gradlew :control-demo:assembleDebug`
- [x] `./gradlew :control-demo:assembleDebugAndroidTest`
- [x] Android 35 arm64 emulator, 4 GB: adapter smoke test passed.
- [x] Android 35 arm64 emulator, 4 GB: 120/136 routes correct (88.2%); 109/119 action arguments exact (91.6%); engine load 651 ms; generation mean 202 ms, p50 198 ms, p95 277 ms, max 284 ms.
- [ ] Run fresh-download, microphone, contacts, music, volume, dialer, post-playback microphone recovery, and end-to-end latency checks on the target physical arm64 device.

## Known limitation

The demo prevents acoustic self-trigger by withholding microphone frames from the speech pipeline while Kokoro audio is playing. It resumes the live microphone afterward, but true interrupt-while-speaking barge-in is not implemented in this PR.

## Related issues

No linked issue. Physical-device validation remains the merge-readiness follow-up for this draft PR.


