### PR TITLE
Publish the Control Demo APK with Android releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,19 +32,24 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build SDK
         run: ./gradlew :sdk:assembleRelease
 
       - name: Run unit tests
-        run: ./gradlew :sdk:testReleaseUnitTest
+        run: ./gradlew :sdk:testReleaseUnitTest :control-demo:testDebugUnitTest
 
       - name: Decode signing keystore
         run: echo "${{ secrets.SIGNING_KEYSTORE_BASE64 }}" | base64 -d > /tmp/release.keystore
 
-      - name: Build signed demo APK
-        run: ./gradlew :app:assembleRelease -PVERSION_NAME=${{ steps.version.outputs.VERSION }} -PVERSION_CODE=${{ github.run_number }}
+      - name: Build signed demo APKs
+        run: |
+          ./gradlew \
+            :app:assembleRelease \
+            :control-demo:assembleRelease \
+            -PVERSION_NAME=${{ steps.version.outputs.VERSION }} \
+            -PVERSION_CODE=${{ github.run_number }}
         env:
           SIGNING_KEYSTORE: /tmp/release.keystore
           SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
@@ -70,9 +75,11 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             sdk/build/outputs/aar/sdk-release.aar
             app/build/outputs/apk/release/app-release.apk
+            control-demo/build/outputs/apk/release/control-demo-release.apk
+          fail_on_unmatched_files: true
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Low-memory streaming speech recognition (25 languages by default, 114-language T
 
 **[📚 Android Documentation](https://soniqo.audio/getting-started/android)**
 
-**[Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Models](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple counterpart) · **[speech-core](https://github.com/soniqo/speech-core)** (pipeline engine + Linux/embedded build)
+**[Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Control Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)** · **[Models](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple counterpart) · **[speech-core](https://github.com/soniqo/speech-core)** (pipeline engine + Linux/embedded build)
 
 ## Scope
 
@@ -161,6 +161,9 @@ The separate [`control-demo/`](control-demo/) app runs the complete agent
 locally: Silero VAD → Parakeet-EOU STT → FunctionGemma 270M tool calls →
 Android device actions → Pocket TTS. It reports per-stage latency and links
 directly to this checkout's `:sdk`, so local speech optimizations are used.
+
+Download the [signed Control Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)
+from the latest release, or install a development build from source:
 
 ```bash
 ./gradlew :control-demo:installDebug

--- a/README_de.md
+++ b/README_de.md
@@ -8,7 +8,7 @@ Speicherarme Streaming-Spracherkennung (standardmäßig 25 Sprachen, optionales 
 
 **[📚 Android-Dokumentation](https://soniqo.audio/de/getting-started/android)**
 
-**[Demo-APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modelle](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple-Pendant) · **[speech-core](https://github.com/soniqo/speech-core)** (Pipeline-Engine + Linux/Embedded-Build)
+**[Demo-APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Control-Demo-APK](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)** · **[Modelle](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple-Pendant) · **[speech-core](https://github.com/soniqo/speech-core)** (Pipeline-Engine + Linux/Embedded-Build)
 
 ## Geltungsbereich
 
@@ -105,6 +105,9 @@ lokal aus: Silero VAD → Parakeet-EOU STT → FunctionGemma-270M-Tool-Aufrufe �
 Android-Geräteaktionen → Pocket TTS. Sie zeigt die Latenz jeder Stufe an und
 bindet direkt das `:sdk` dieses Checkouts ein, sodass lokale
 Sprachoptimierungen verwendet werden.
+
+Lade das [signierte Control-Demo-APK](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)
+aus dem neuesten Release herunter oder installiere einen Entwicklungs-Build aus dem Quellcode:
 
 ```bash
 ./gradlew :control-demo:installDebug

--- a/README_es.md
+++ b/README_es.md
@@ -8,7 +8,7 @@ Reconocimiento de voz en streaming de baja memoria (25 idiomas por defecto; TDT 
 
 **[📚 Documentación de Android](https://soniqo.audio/es/getting-started/android)**
 
-**[APK de demostración](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modelos](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (contraparte Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (motor de pipeline + compilación Linux/embebido)
+**[APK de demostración](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[APK de Control Demo](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)** · **[Modelos](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (contraparte Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (motor de pipeline + compilación Linux/embebido)
 
 ## Alcance
 
@@ -105,6 +105,9 @@ localmente: Silero VAD → Parakeet-EOU STT → llamadas a herramientas con
 FunctionGemma 270M → acciones del dispositivo Android → Pocket TTS. Muestra la
 latencia de cada etapa y enlaza directamente con el `:sdk` de este checkout,
 por lo que usa las optimizaciones de voz locales.
+
+Descarga el [APK firmado de Control Demo](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)
+de la versión más reciente, o instala una compilación de desarrollo desde el código fuente:
 
 ```bash
 ./gradlew :control-demo:installDebug

--- a/README_fr.md
+++ b/README_fr.md
@@ -8,7 +8,7 @@ Reconnaissance vocale en streaming à faible mémoire (25 langues par défaut, T
 
 **[📚 Documentation Android](https://soniqo.audio/fr/getting-started/android)**
 
-**[APK de démo](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modèles](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (équivalent Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (moteur de pipeline + build Linux/embarqué)
+**[APK de démo](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[APK Control Demo](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)** · **[Modèles](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (équivalent Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (moteur de pipeline + build Linux/embarqué)
 
 ## Périmètre
 
@@ -105,6 +105,9 @@ Silero VAD → Parakeet-EOU STT → appels d'outils FunctionGemma 270M → actio
 l'appareil Android → Pocket TTS. Elle affiche la latence de chaque étape et se
 lie directement au `:sdk` de ce checkout, afin d'utiliser les optimisations
 vocales locales.
+
+Téléchargez l'[APK signé de Control Demo](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)
+depuis la dernière version, ou installez un build de développement depuis les sources :
 
 ```bash
 ./gradlew :control-demo:installDebug

--- a/README_hi.md
+++ b/README_hi.md
@@ -8,7 +8,7 @@ Android के लिए ऑन-डिवाइस स्पीच SDK, [ONNX Ru
 
 **[📚 Android दस्तावेज़](https://soniqo.audio/hi/getting-started/android)**
 
-**[डेमो APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[मॉडल](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple समकक्ष) · **[speech-core](https://github.com/soniqo/speech-core)** (पाइपलाइन इंजन + Linux/एम्बेडेड बिल्ड)
+**[डेमो APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Control Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)** · **[मॉडल](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (Apple समकक्ष) · **[speech-core](https://github.com/soniqo/speech-core)** (पाइपलाइन इंजन + Linux/एम्बेडेड बिल्ड)
 
 ## स्कोप
 
@@ -104,6 +104,9 @@ cd speech-android
 Silero VAD → Parakeet-EOU STT → FunctionGemma 270M टूल कॉल → Android डिवाइस
 एक्शन → Pocket TTS। यह हर चरण की लेटेंसी दिखाता है और इस checkout के `:sdk`
 से सीधे लिंक होता है, इसलिए स्थानीय स्पीच ऑप्टिमाइज़ेशन उपयोग होते हैं।
+
+नवीनतम रिलीज़ से [हस्ताक्षरित Control Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)
+डाउनलोड करें, या सोर्स से डेवलपमेंट बिल्ड इंस्टॉल करें:
 
 ```bash
 ./gradlew :control-demo:installDebug

--- a/README_ja.md
+++ b/README_ja.md
@@ -8,7 +8,7 @@
 
 **[📚 Android ドキュメント](https://soniqo.audio/ja/getting-started/android)**
 
-**[デモ APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[モデル](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 版)· **[speech-core](https://github.com/soniqo/speech-core)**(パイプラインエンジン + Linux/組み込みビルド)
+**[デモ APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Control Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)** · **[モデル](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 版)· **[speech-core](https://github.com/soniqo/speech-core)**(パイプラインエンジン + Linux/組み込みビルド)
 
 ## スコープ
 
@@ -105,6 +105,8 @@ Parakeet-EOU STT → FunctionGemma 270M ツール呼び出し → Android
 デバイス操作 → Pocket TTS というエージェント全体をローカルで実行します。
 各段階のレイテンシを表示し、このチェックアウトの `:sdk` に直接リンクするため、
 ローカルの音声最適化が使われます。
+
+最新リリースから[署名済み Control Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)をダウンロードするか、ソースから開発ビルドをインストールします：
 
 ```bash
 ./gradlew :control-demo:installDebug

--- a/README_ko.md
+++ b/README_ko.md
@@ -8,7 +8,7 @@
 
 **[📚 Android 문서](https://soniqo.audio/ko/getting-started/android)**
 
-**[데모 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[모델](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 버전) · **[speech-core](https://github.com/soniqo/speech-core)**(파이프라인 엔진 + Linux/임베디드 빌드)
+**[데모 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Control Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)** · **[모델](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 버전) · **[speech-core](https://github.com/soniqo/speech-core)**(파이프라인 엔진 + Linux/임베디드 빌드)
 
 ## 범위
 
@@ -104,6 +104,8 @@ cd speech-android
 Parakeet-EOU STT → FunctionGemma 270M 도구 호출 → Android 기기 동작 →
 Pocket TTS로 이어지는 전체 에이전트를 로컬에서 실행합니다. 단계별 지연 시간을
 표시하고 이 체크아웃의 `:sdk`에 직접 연결하므로 로컬 음성 최적화를 사용합니다.
+
+최신 릴리스에서 [서명된 Control Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)를 다운로드하거나 소스에서 개발 빌드를 설치하세요.
 
 ```bash
 ./gradlew :control-demo:installDebug

--- a/README_pt.md
+++ b/README_pt.md
@@ -8,7 +8,7 @@ Reconhecimento de fala em streaming com baixa memória (25 idiomas por padrão, 
 
 **[📚 Documentação Android](https://soniqo.audio/pt/getting-started/android)**
 
-**[APK de demonstração](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Modelos](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (contraparte Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (motor de pipeline + build Linux/embarcado)
+**[APK de demonstração](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[APK do Control Demo](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)** · **[Modelos](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (contraparte Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (motor de pipeline + build Linux/embarcado)
 
 ## Escopo
 
@@ -105,6 +105,9 @@ localmente: Silero VAD → Parakeet-EOU STT → chamadas de ferramentas do
 FunctionGemma 270M → ações do dispositivo Android → Pocket TTS. Ele mostra a
 latência de cada etapa e vincula diretamente o `:sdk` deste checkout, usando
 assim as otimizações locais de voz.
+
+Baixe o [APK assinado do Control Demo](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)
+da versão mais recente ou instale um build de desenvolvimento a partir do código-fonte:
 
 ```bash
 ./gradlew :control-demo:installDebug

--- a/README_ru.md
+++ b/README_ru.md
@@ -8,7 +8,7 @@
 
 **[📚 Документация Android](https://soniqo.audio/ru/getting-started/android)**
 
-**[Демо APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Модели](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (аналог для Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (движок конвейера + сборка для Linux/встраиваемых систем)
+**[Демо APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[APK Control Demo](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)** · **[Модели](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)** (аналог для Apple) · **[speech-core](https://github.com/soniqo/speech-core)** (движок конвейера + сборка для Linux/встраиваемых систем)
 
 ## Область применения
 
@@ -105,6 +105,9 @@ cd speech-android
 FunctionGemma 270M → действия Android-устройства → Pocket TTS. Оно показывает
 задержку каждого этапа и напрямую подключает `:sdk` из этой рабочей копии,
 поэтому использует локальные оптимизации речи.
+
+Скачайте [подписанный APK Control Demo](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)
+из последнего релиза или установите сборку для разработки из исходного кода:
 
 ```bash
 ./gradlew :control-demo:installDebug

--- a/README_zh.md
+++ b/README_zh.md
@@ -8,7 +8,7 @@
 
 **[📚 Android 文档](https://soniqo.audio/zh/getting-started/android)**
 
-**[演示 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[模型](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 对应版本)· **[speech-core](https://github.com/soniqo/speech-core)**(管线引擎 + Linux/嵌入式构建)
+**[演示 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)** · **[Control Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk)** · **[模型](https://huggingface.co/collections/aufklarer/speech-android-models-69bb8a156cac0b96a2247f26)** · **[speech-swift](https://github.com/soniqo/speech-swift)**(Apple 对应版本)· **[speech-core](https://github.com/soniqo/speech-core)**(管线引擎 + Linux/嵌入式构建)
 
 ## 范围
 
@@ -103,6 +103,8 @@ cd speech-android
 Silero VAD → Parakeet-EOU STT → FunctionGemma 270M 工具调用 →
 Android 设备操作 → Pocket TTS。它显示各阶段延迟,并直接链接此检出的
 `:sdk`,因此会使用本地语音优化。
+
+从最新版本下载[已签名的 Control Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk),或从源码安装开发版本:
 
 ```bash
 ./gradlew :control-demo:installDebug

--- a/control-demo/README.md
+++ b/control-demo/README.md
@@ -14,6 +14,12 @@ The app always pairs the adapter with its compact prompt serialization. The
 exact base and adapter files are published under
 [`soniqo/FunctionGemma-270M-LiteRT-LM`](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM).
 
+## Install
+
+Download the latest signed
+[Control Demo APK](https://github.com/soniqo/speech-android/releases/latest/download/control-demo-release.apk),
+or install a development build from source as described below.
+
 ## Run
 
 Use an arm64 Android device with at least 4 GB RAM:

--- a/control-demo/build.gradle.kts
+++ b/control-demo/build.gradle.kts
@@ -17,10 +17,25 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        create("release") {
+            val keystore = System.getenv("SIGNING_KEYSTORE")
+            if (keystore != null) {
+                storeFile = file(keystore)
+                storePassword = System.getenv("SIGNING_STORE_PASSWORD")
+                keyAlias = System.getenv("SIGNING_KEY_ALIAS")
+                keyPassword = System.getenv("SIGNING_KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
+            if (System.getenv("SIGNING_KEYSTORE") != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- publish a signed Control Demo APK alongside the SDK and existing demo APK
- fail release creation when any expected artifact is missing and use the supported release action version
- link the stable Control Demo download from the demo README, main README, and every translated README

## Validation

- `actionlint .github/workflows/release.yml`
- `./gradlew :sdk:test :control-demo:testDebugUnitTest :control-demo:lintDebug`
- `./gradlew :sdk:assembleRelease :app:assembleRelease :control-demo:assembleRelease -PVERSION_NAME=0.0.12 -PVERSION_CODE=12` with a temporary signing keystore
- verified the release APK package, version, and v2 signature
- `./gradlew :sdk:connectedAndroidTest` — 39 tests finished, one precondition skip, zero failures
- Control Demo LoRA/tool-call instrumentation smoke test — one test, zero failures
- installed and cold-launched the signed Control Demo release APK on an ARM64 emulator