### PR TITLE
Test suite cleanup: exercise real code paths, make e2e tests assert

### DIFF
--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/BargeInTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/BargeInTest.kt
@@ -2,21 +2,24 @@ package audio.soniqo.speech
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.flow.first
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 
 /**
- * Barge-in / interruption tests.
- *
- * Shares a single pipeline across tests to avoid OOM from loading
- * models multiple times in the same test process.
+ * Barge-in / interruption tests. Uses synthesized speech so the full
+ * VAD -> STT -> TTS chain actually runs; one pipeline per test to avoid OOM
+ * from concurrent model loads.
  */
 @RunWith(AndroidJUnit4::class)
 class BargeInTest {
@@ -38,79 +41,104 @@ class BargeInTest {
         pipeline.close()
     }
 
-    private fun speechSignal(durationSec: Int = 2, freqHz: Double = 200.0): FloatArray {
-        val sr = 16000
-        return FloatArray(sr * durationSec) { i ->
-            val t = i.toFloat() / sr
-            (0.3f * Math.sin(2.0 * Math.PI * freqHz * t)).toFloat()
-        }
-    }
-
-    private fun silenceSignal(): FloatArray = FloatArray(16000)
-
-    private fun pushChunked(audio: FloatArray) {
-        for (offset in audio.indices step 512) {
-            val end = minOf(offset + 512, audio.size)
-            val chunk = audio.sliceArray(offset until end)
-            if (chunk.size == 512) pipeline.pushAudio(chunk)
-        }
-    }
-
     @Test
     fun bargeInDuringSpeakingEmitsInterrupted() = runBlocking {
-        pushChunked(speechSignal(freqHz = 220.0))
-        pushChunked(silenceSignal())
-
-        try {
-            withTimeout(30_000) {
+        val delta = async(start = CoroutineStart.UNDISPATCHED) {
+            withTimeout(90_000) {
                 pipeline.events.first { it is SpeechEvent.ResponseAudioDelta }
             }
+        }
 
-            // Barge-in while speaking
-            pushChunked(speechSignal(durationSec = 1, freqHz = 250.0))
+        pushRealtime(synthesize("The quick brown fox jumps over the lazy dog."))
+        pushRealtime(FloatArray(16000)) // 1 s of silence ends the utterance
 
-            val interrupted = withTimeout(10_000) {
+        delta.await() // pipeline is now speaking its echo response
+
+        val interrupted = async(start = CoroutineStart.UNDISPATCHED) {
+            withTimeout(30_000) {
                 pipeline.events.first { it is SpeechEvent.ResponseInterrupted }
             }
-            assertNotNull("ResponseInterrupted should be emitted", interrupted)
-        } catch (_: Exception) {
-            // Synthetic signal may not trigger full chain
         }
+        pushRealtime(synthesize("Stop talking now."))
+
+        assertNotNull(interrupted.await())
     }
 
     @Test
     fun pipelineStableAfterBargeIn() = runBlocking {
-        pushChunked(speechSignal())
-        pushChunked(silenceSignal())
-
-        try {
-            withTimeout(30_000) {
+        val delta = async(start = CoroutineStart.UNDISPATCHED) {
+            withTimeout(90_000) {
                 pipeline.events.first { it is SpeechEvent.ResponseAudioDelta }
             }
-
-            pushChunked(speechSignal(durationSec = 1, freqHz = 250.0))
-            delay(2_000)
-            pipeline.resumeListening()
-
-            assertTrue(
-                "Pipeline should be in Idle or Listening after barge-in recovery",
-                pipeline.state == PipelineState.Idle || pipeline.state == PipelineState.Listening
-            )
-        } catch (_: Exception) {
-            // Synthetic signal may not trigger full chain
         }
+
+        pushRealtime(synthesize("The quick brown fox jumps over the lazy dog."))
+        pushRealtime(FloatArray(16000))
+
+        delta.await()
+
+        pushRealtime(synthesize("Stop talking now."))
+        delay(2_000)
+        pipeline.resumeListening()
+
+        assertTrue(
+            "Pipeline should be in Idle or Listening after barge-in recovery, " +
+                "was ${pipeline.state}",
+            pipeline.state == PipelineState.Idle || pipeline.state == PipelineState.Listening
+        )
     }
 
     @Test
     fun resumeListeningAfterInterruption() = runBlocking {
-        pushChunked(speechSignal(durationSec = 1))
+        val sr = 16000
+        val tone = FloatArray(sr) { i ->
+            (0.3f * Math.sin(2.0 * Math.PI * 200.0 * i / sr)).toFloat()
+        }
+        pushRealtime(tone)
         pipeline.resumeListening()
 
         assertTrue(
-            "Pipeline should be in a valid state after resumeListening",
+            "Pipeline should be in a valid state after resumeListening, was ${pipeline.state}",
             pipeline.state == PipelineState.Idle ||
             pipeline.state == PipelineState.Listening ||
             pipeline.state == PipelineState.Transcribing
         )
+    }
+
+    private suspend fun pushRealtime(audio: FloatArray) {
+        for (offset in audio.indices step 512) {
+            val end = minOf(offset + 512, audio.size)
+            val chunk = audio.sliceArray(offset until end)
+            if (chunk.size == 512) {
+                pipeline.pushAudio(chunk)
+                delay(32) // 512 samples @ 16 kHz
+            }
+        }
+    }
+
+    private fun synthesize(text: String): FloatArray =
+        SpeechSynthesizer(SpeechSynthesizerConfig(modelDir = modelDir, useNnapi = false)).use {
+            val spoken = it.synthesize(text, "en")
+            assertTrue("synthesized fixture should not be empty", spoken.pcm16.isNotEmpty())
+            pcm16ToFloat16k(spoken.pcm16, spoken.sampleRate)
+        }
+
+    private fun pcm16ToFloat16k(pcm16: ByteArray, sourceSampleRate: Int): FloatArray {
+        val shorts = ShortArray(pcm16.size / 2)
+        ByteBuffer.wrap(pcm16)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .asShortBuffer()
+            .get(shorts)
+        val source = FloatArray(shorts.size) { i -> shorts[i] / 32768.0f }
+        if (sourceSampleRate == 16000) return source
+
+        val outputSize = ((source.size.toLong() * 16000L) / sourceSampleRate).toInt()
+        return FloatArray(outputSize) { i ->
+            val src = i.toDouble() * sourceSampleRate.toDouble() / 16000.0
+            val lo = src.toInt().coerceIn(0, source.lastIndex)
+            val hi = minOf(lo + 1, source.lastIndex)
+            val frac = (src - lo).toFloat()
+            source[lo] * (1.0f - frac) + source[hi] * frac
+        }
     }
 }

--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/ParakeetSttTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/ParakeetSttTest.kt
@@ -15,13 +15,9 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
 /**
- * E2E test: Parakeet TDT 0.6B speech recognition on device.
- *
- * Verifies that:
- * - Encoder + decoder models load and produce transcriptions
- * - Speech-like audio triggers VAD → STT pipeline
- * - Transcription contains expected text (accuracy check)
- * - Pipeline state transitions work correctly
+ * On-device Parakeet TDT STT through the full pipeline: synthesized English
+ * speech must transcribe with the expected key words, and silence must not
+ * produce spurious text.
  */
 @RunWith(AndroidJUnit4::class)
 class ParakeetSttTest {

--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/SileroVadTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/SileroVadTest.kt
@@ -2,20 +2,24 @@ package audio.soniqo.speech
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 
 /**
- * E2E test: Silero VAD ONNX model inference on device.
- *
- * Verifies that:
- * - Model loads successfully
- * - Silence produces low probability
- * - Synthetic speech-like signal produces higher probability
- * - LSTM state carries across chunks correctly
+ * On-device Silero VAD behavior through the public pipeline API: silence must
+ * not raise SpeechStarted, synthesized speech must raise it and close the
+ * segment once silence follows.
  */
 @RunWith(AndroidJUnit4::class)
 class SileroVadTest {
@@ -29,54 +33,96 @@ class SileroVadTest {
     }
 
     @Test
-    fun silenceProducesLowProbability() {
-        // Create pipeline in transcribe-only mode to test VAD
-        val config = SpeechConfig(modelDir = modelDir, useNnapi = false)
-        val pipeline = SpeechPipeline(config)
+    fun silenceDoesNotTriggerSpeechStarted() = runBlocking {
+        val pipeline = SpeechPipeline(SpeechConfig(modelDir = modelDir, useNnapi = false))
+        try {
+            pipeline.start()
+            // Subscribe before pushing — the events flow has no replay.
+            val started = async(start = CoroutineStart.UNDISPATCHED) {
+                withTimeoutOrNull(10_000) {
+                    pipeline.events.first { it is SpeechEvent.SpeechStarted }
+                }
+            }
 
-        // Feed silence (zeros)
-        val silence = FloatArray(512) // 32ms @ 16kHz
-        pipeline.pushAudio(silence)
+            repeat(94) { pipeline.pushAudio(FloatArray(512)) } // ~3 s of silence
 
-        // VAD should not trigger speech event for silence
-        // (Verified via no SpeechStarted event within timeout)
-        pipeline.close()
+            assertNull("silence must not trigger SpeechStarted", started.await())
+        } finally {
+            pipeline.stop()
+            pipeline.close()
+        }
     }
 
     @Test
-    fun syntheticToneDetected() {
-        val events = mutableListOf<SpeechEvent>()
-        val config = SpeechConfig(modelDir = modelDir, useNnapi = false)
-        val pipeline = SpeechPipeline(config)
-
-        // Generate a 300Hz tone (speech-like fundamental frequency)
-        val sampleRate = 16000
-        val duration = 1.0f // 1 second
-        val numSamples = (sampleRate * duration).toInt()
-        val tone = FloatArray(numSamples) { i ->
-            (0.5f * Math.sin(2.0 * Math.PI * 300.0 * i / sampleRate)).toFloat()
-        }
-
-        // Feed in 512-sample chunks
-        for (offset in tone.indices step 512) {
-            val end = minOf(offset + 512, tone.size)
-            val chunk = tone.sliceArray(offset until end)
-            if (chunk.size == 512) {
-                pipeline.pushAudio(chunk)
+    fun synthesizedSpeechTriggersSpeechStartedAndEnded() = runBlocking {
+        val pipeline = SpeechPipeline(SpeechConfig(modelDir = modelDir, useNnapi = false))
+        try {
+            pipeline.start()
+            val started = async(start = CoroutineStart.UNDISPATCHED) {
+                withTimeout(30_000) {
+                    pipeline.events.first { it is SpeechEvent.SpeechStarted }
+                }
             }
-        }
+            val ended = async(start = CoroutineStart.UNDISPATCHED) {
+                withTimeout(60_000) {
+                    pipeline.events.first { it is SpeechEvent.SpeechEnded }
+                }
+            }
 
-        pipeline.close()
+            val audio = synthesize("The quick brown fox jumps over the lazy dog.")
+            for (offset in audio.indices step 512) {
+                val end = minOf(offset + 512, audio.size)
+                val chunk = audio.sliceArray(offset until end)
+                if (chunk.size == 512) {
+                    pipeline.pushAudio(chunk)
+                    delay(32) // real-time pace: 512 samples @ 16 kHz
+                }
+            }
+            repeat(47) { // ~1.5 s of trailing silence closes the segment
+                pipeline.pushAudio(FloatArray(512))
+                delay(32)
+            }
+
+            assertNotNull(started.await())
+            assertNotNull(ended.await())
+        } finally {
+            pipeline.stop()
+            pipeline.close()
+        }
     }
 
     @Test
     fun pipelineCreatesAndDestroys() {
-        // Verify no crash on create/destroy cycle
-        val config = SpeechConfig(modelDir = modelDir, useNnapi = false)
-        val pipeline = SpeechPipeline(config)
+        val pipeline = SpeechPipeline(SpeechConfig(modelDir = modelDir, useNnapi = false))
         assertEquals(PipelineState.Idle, pipeline.state)
         pipeline.start()
         pipeline.stop()
         pipeline.close()
+    }
+
+    private fun synthesize(text: String): FloatArray =
+        SpeechSynthesizer(SpeechSynthesizerConfig(modelDir = modelDir, useNnapi = false)).use {
+            val spoken = it.synthesize(text, "en")
+            assertTrue("synthesized fixture should not be empty", spoken.pcm16.isNotEmpty())
+            pcm16ToFloat16k(spoken.pcm16, spoken.sampleRate)
+        }
+
+    private fun pcm16ToFloat16k(pcm16: ByteArray, sourceSampleRate: Int): FloatArray {
+        val shorts = ShortArray(pcm16.size / 2)
+        ByteBuffer.wrap(pcm16)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .asShortBuffer()
+            .get(shorts)
+        val source = FloatArray(shorts.size) { i -> shorts[i] / 32768.0f }
+        if (sourceSampleRate == 16000) return source
+
+        val outputSize = ((source.size.toLong() * 16000L) / sourceSampleRate).toInt()
+        return FloatArray(outputSize) { i ->
+            val src = i.toDouble() * sourceSampleRate.toDouble() / 16000.0
+            val lo = src.toInt().coerceIn(0, source.lastIndex)
+            val hi = minOf(lo + 1, source.lastIndex)
+            val frac = (src - lo).toFloat()
+            source[lo] * (1.0f - frac) + source[hi] * frac
+        }
     }
 }

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -2,6 +2,7 @@ package audio.soniqo.speech
 
 import android.content.Context
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -40,7 +41,8 @@ object ModelManager {
         .followSslRedirects(true)
         .build()
 
-    private fun models(
+    @VisibleForTesting
+    internal fun models(
         precision: ModelPrecision,
         sttModel: SttModel = SttModel.PARAKEET_EOU,
         sttBackend: SttBackend = SttBackend.ONNX,
@@ -114,7 +116,8 @@ object ModelManager {
         // Note: FP32 Parakeet encoder also needs parakeet-encoder.onnx.data.
     }
 
-    private fun ttsModels(ttsModel: TtsModel): List<ModelFile> = when (ttsModel) {
+    @VisibleForTesting
+    internal fun ttsModels(ttsModel: TtsModel): List<ModelFile> = when (ttsModel) {
         TtsModel.KOKORO, TtsModel.KOKORO_SHORT_TURN -> listOf(
             // Both graph profiles share one external weight blob. Keeping both
             // protos in the same cache makes profile switches a ~2.6 MB fetch,
@@ -169,7 +172,8 @@ object ModelManager {
     // FunctionGemma is kept out of the pipeline model set: only agent demos
     // opt in via [ensureLlmModels]. The Control profile downloads one reusable
     // LoRA-capable base and its small adapter as distinct files.
-    private fun llmModels(llmModel: LlmModel): List<ModelFile> = when (llmModel) {
+    @VisibleForTesting
+    internal fun llmModels(llmModel: LlmModel): List<ModelFile> = when (llmModel) {
         LlmModel.FUNCTIONGEMMA -> listOf(
             ModelFile("FunctionGemma-270M-LiteRT-LM", "model.litertlm"),
         )
@@ -468,7 +472,8 @@ object ModelManager {
         }
     }
 
-    private fun modelSetKey(
+    @VisibleForTesting
+    internal fun modelSetKey(
         precision: ModelPrecision,
         sttModel: SttModel,
         sttBackend: SttBackend,
@@ -489,7 +494,8 @@ object ModelManager {
         ttsModel: TtsModel,
     ): File = File(context.filesDir, modelDirName(precision, sttModel, sttBackend, ttsModel))
 
-    private fun modelDirName(
+    @VisibleForTesting
+    internal fun modelDirName(
         precision: ModelPrecision,
         sttModel: SttModel,
         sttBackend: SttBackend,
@@ -512,7 +518,8 @@ object ModelManager {
         ).joinToString("-").lowercase()
     }
 
-    private fun ttsModelSetKey(ttsModel: TtsModel): String = listOf(
+    @VisibleForTesting
+    internal fun ttsModelSetKey(ttsModel: TtsModel): String = listOf(
         "v$MODEL_VERSION",
         "profile=TTS",
         "tts=${ttsCacheName(ttsModel)}",
@@ -521,7 +528,8 @@ object ModelManager {
     private fun ttsCacheName(ttsModel: TtsModel): String =
         if (ttsModel.isKokoro) TtsModel.KOKORO.name else ttsModel.name
 
-    private fun llmModelSetKey(llmModel: LlmModel): String = listOf(
+    @VisibleForTesting
+    internal fun llmModelSetKey(llmModel: LlmModel): String = listOf(
         "v$MODEL_VERSION",
         "profile=LLM",
         "llm=${llmModel.name}",
@@ -540,12 +548,20 @@ object ModelManager {
         }
     }
 
-    private fun downloadFile(url: String, dest: File, onBytes: (downloaded: Long, fileTotal: Long) -> Unit) {
+    @VisibleForTesting
+    internal fun downloadFile(
+        url: String,
+        dest: File,
+        client: OkHttpClient = this.client,
+        maxRetries: Int = MAX_RETRIES,
+        retryDelayMs: Long = RETRY_DELAY_MS,
+        onBytes: (downloaded: Long, fileTotal: Long) -> Unit,
+    ) {
         val tmp = File(dest.parentFile, "${dest.name}.tmp")
 
         var lastException: IOException? = null
 
-        for (attempt in 1..MAX_RETRIES) {
+        for (attempt in 1..maxRetries) {
             try {
                 val existingBytes = if (tmp.exists()) tmp.length() else 0L
 
@@ -624,10 +640,10 @@ object ModelManager {
 
             } catch (e: IOException) {
                 lastException = e
-                if (attempt < MAX_RETRIES) {
+                if (attempt < maxRetries) {
                     // Longer backoff for server errors (503 etc.)
                     val isServerError = e.message?.contains("temporarily unavailable") == true
-                    val delay = if (isServerError) RETRY_DELAY_MS * attempt * 3 else RETRY_DELAY_MS * attempt
+                    val delay = if (isServerError) retryDelayMs * attempt * 3 else retryDelayMs * attempt
                     Thread.sleep(delay)
                 }
             }
@@ -638,7 +654,7 @@ object ModelManager {
         // Range: header. Particularly important when called from
         // ModelDownloadWorker, where Result.retry() spins up a fresh
         // ensureModels() invocation after WorkManager's backoff window.
-        throw IOException("Download failed after $MAX_RETRIES attempts: ${lastException?.message}", lastException)
+        throw IOException("Download failed after $maxRetries attempts: ${lastException?.message}", lastException)
     }
 
     // ONNX files start with these bytes (protobuf magic for ONNX IR)

--- a/sdk/src/test/kotlin/audio/soniqo/speech/DownloadProgressTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/DownloadProgressTest.kt
@@ -5,21 +5,11 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Regression test for issue #30 — "download bar appears frozen / hung".
- *
- * Pure-JVM (no Robolectric / device / network): it drives the REAL production
- * percent function [ModelDownloadWorker.progressPercent] over the default
- * low-memory INT8 size distribution, replaying the byte-stream contract of
- * [ModelManager.ensureModels] (per-file `bytesDownloaded`, `completed`
- * increments only AFTER each file lands).
- *
- * The old behaviour computed `pct = completed * 100 / totalFiles`, which pinned
- * the bar to a single value for an entire large model file — indistinguishable
- * from a hang. The fix makes the percent byte-aware, so it advances
- * continuously through the dominant file. These assertions lock that in: the
- * bar must MOVE during the large file and never go backwards.
- *
- * Run: `./gradlew :sdk:test --tests '*DownloadProgressTest*'`
+ * Regression tests for issue #30 ("download bar appears frozen"): percent was
+ * once computed per whole file, pinning the bar for the duration of a large
+ * model file. [ModelDownloadWorker.progressPercent] is byte-aware, so the bar
+ * advances within a file and never decreases. Replays the callback contract of
+ * [ModelManager.ensureModels] over the default INT8 manifest sizes.
  */
 class DownloadProgressTest {
 
@@ -28,25 +18,25 @@ class DownloadProgressTest {
     private val MB = 1_000_000L
     /** Default low-memory INT8 manifest order/sizes. */
     private val manifest = listOf(
-        Sized("silero-vad.onnx", 2 * MB),                   // #1
-        Sized("parakeet-eou-encoder.onnx", 132 * MB),       // #2
-        Sized("parakeet-eou-decoder.onnx", 16 * MB),        // #3
-        Sized("parakeet-eou-joint.onnx", 6 * MB),           // #4
-        Sized("vocab.json", 1 * MB),                        // #5
-        Sized("config.json", 1 * MB),                       // #6
-        Sized("kokoro-e2e.onnx", 3 * MB),                   // #7
-        Sized("kokoro-e2e-realtime.onnx", 3 * MB),          // #8
-        Sized("kokoro-e2e.onnx.data", 325 * MB),            // #9  <-- the giant
-        Sized("vocab_index.json", 1 * MB),                  // #10
-        Sized("us_gold.json", 2 * MB),                      // #11
-        Sized("us_silver.json", 4 * MB),                    // #12
-        Sized("dict_fr.json", 1 * MB),                      // #13
-        Sized("dict_es.json", 1 * MB),                      // #14
-        Sized("dict_it.json", 1 * MB),                      // #15
-        Sized("dict_pt.json", 1 * MB),                      // #16
-        Sized("dict_hi.json", 1 * MB),                      // #17
-        Sized("voices/af_heart.bin", 1 * MB),               // #18
-        Sized("deepfilter-auxiliary.bin", 2 * MB),          // #19
+        Sized("silero-vad.onnx", 2 * MB),
+        Sized("parakeet-eou-encoder.onnx", 132 * MB),
+        Sized("parakeet-eou-decoder.onnx", 16 * MB),
+        Sized("parakeet-eou-joint.onnx", 6 * MB),
+        Sized("vocab.json", 1 * MB),
+        Sized("config.json", 1 * MB),
+        Sized("kokoro-e2e.onnx", 3 * MB),
+        Sized("kokoro-e2e-realtime.onnx", 3 * MB),
+        Sized("kokoro-e2e.onnx.data", 325 * MB),
+        Sized("vocab_index.json", 1 * MB),
+        Sized("us_gold.json", 2 * MB),
+        Sized("us_silver.json", 4 * MB),
+        Sized("dict_fr.json", 1 * MB),
+        Sized("dict_es.json", 1 * MB),
+        Sized("dict_it.json", 1 * MB),
+        Sized("dict_pt.json", 1 * MB),
+        Sized("dict_hi.json", 1 * MB),
+        Sized("voices/af_heart.bin", 1 * MB),
+        Sized("deepfilter-auxiliary.bin", 2 * MB),
     )
     private val totalFiles = manifest.size
 
@@ -60,8 +50,7 @@ class DownloadProgressTest {
         val percent: Int,
     )
 
-    /** Replays ensureModels: `completed` lags until a file fully lands; each */
-    /** tick's percent comes from the production [ModelDownloadWorker.progressPercent]. */
+    /** Replays ensureModels: `completed` lags until a file fully lands. */
     private fun simulate(): List<Sample> {
         val samples = ArrayList<Sample>()
         var completed = 0
@@ -85,41 +74,37 @@ class DownloadProgressTest {
     }
 
     @Test
-    fun progressPercent_isByteAware_unitValues() {
-        // Whole files done plus the fraction of the file in flight.
-        assertEquals(5, ModelDownloadWorker.progressPercent(1, 19, 0, 132 * MB))        // start of EOU encoder
-        assertEquals(7, ModelDownloadWorker.progressPercent(1, 19, 66 * MB, 132 * MB))  // half the EOU encoder
-        assertEquals(42, ModelDownloadWorker.progressPercent(8, 19, 0, 325 * MB))       // start of Kokoro weights
-        assertEquals(100, ModelDownloadWorker.progressPercent(19, 19, 0, 0))            // all files done
+    fun `percent adds completed files plus fraction of the file in flight`() {
+        assertEquals(5, ModelDownloadWorker.progressPercent(1, 19, 0, 132 * MB))
+        assertEquals(7, ModelDownloadWorker.progressPercent(1, 19, 66 * MB, 132 * MB))
+        assertEquals(42, ModelDownloadWorker.progressPercent(8, 19, 0, 325 * MB))
+        assertEquals(100, ModelDownloadWorker.progressPercent(19, 19, 0, 0))
     }
 
     @Test
-    fun progressPercent_unknownFileSize_fallsBackToFileCount() {
+    fun `unknown file size falls back to file count`() {
         // When the server doesn't advertise a length, the in-flight file adds
-        // no fraction — degrades to the old whole-file value for that file only.
+        // no fraction — whole-file granularity for that file only.
         assertEquals(5, ModelDownloadWorker.progressPercent(1, 19, 12345, 0))
     }
 
     @Test
-    fun progressPercent_guardsZeroTotal() {
+    fun `zero total files yields zero percent`() {
         assertEquals(0, ModelDownloadWorker.progressPercent(3, 0, 1, 2))
     }
 
     @Test
-    fun fixed_barMovesContinuouslyThroughTheEncoder() {
+    fun `bar advances within the dominant file`() {
         val largeFile = simulate().filter { it.file == "kokoro-e2e.onnx.data" }
 
-        // The whole point of the fix: the bar is NO LONGER frozen on the
-        // dominant file — it advances through several distinct values.
         val distinct = largeFile.map { it.percent }.toSet()
         assertTrue(
             "large file percent should advance through several values, got $distinct",
             distinct.size >= 6,
         )
-        // It spans roughly 42% -> 47% (one file's worth of the 19-file bar).
-        assertEquals("large file starts at ~42%", 42, largeFile.first().percent)
-        assertEquals("large file ends at ~47%", 47, largeFile.last().percent)
-        // ...and is monotonic non-decreasing within the file.
+        // One file's worth of the 19-file bar: ~42% -> ~47%.
+        assertEquals(42, largeFile.first().percent)
+        assertEquals(47, largeFile.last().percent)
         assertTrue(
             "large file percent must never go backwards",
             largeFile.zipWithNext().all { (a, b) -> b.percent >= a.percent },
@@ -127,25 +112,22 @@ class DownloadProgressTest {
     }
 
     @Test
-    fun fixed_byHalfTheLargeFileBarHasMovedPastTheOldFrozenCeiling() {
-        // Before the fix the bar was pinned at the whole-file count for the
-        // entire large file. Now, halfway through the bytes it has climbed.
+    fun `bar has moved by the middle of the dominant file`() {
         val largeFile = simulate().filter { it.file == "kokoro-e2e.onnx.data" }
         val midpoint = largeFile.first { it.fileBytes >= it.fileTotal / 2 }
         assertTrue(
-            "halfway through the large file the bar should read >= 44 (was frozen at 42), " +
-                "was ${midpoint.percent}",
+            "halfway through the large file the bar should read >= 44, was ${midpoint.percent}",
             midpoint.percent >= 44,
         )
     }
 
     @Test
-    fun fixed_wholeRunPercentIsMonotonic() {
+    fun `whole run percent is monotonic and ends at 100`() {
         val samples = simulate()
         assertTrue(
             "reported percent must never decrease across the whole download",
             samples.zipWithNext().all { (a, b) -> b.percent >= a.percent },
         )
-        assertEquals("download ends at 100%", 100, samples.last().percent)
+        assertEquals(100, samples.last().percent)
     }
 }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelDownloadWorkerTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelDownloadWorkerTest.kt
@@ -22,13 +22,9 @@ import org.robolectric.annotation.Config
 import java.io.IOException
 
 /**
- * Robolectric tests for [ModelDownloadWorker].
- *
- * Mocks the [ModelManager] singleton via mockk so the worker can be exercised
- * without touching the network or the file system. Uses
- * [TestListenableWorkerBuilder] which gives the worker a real `Context` and
- * stubs out the `setForeground` / `setProgress` plumbing — sufficient to
- * assert the doWork() result contract.
+ * Robolectric tests for [ModelDownloadWorker]. Mocks the [ModelManager]
+ * singleton so the worker's doWork() contract can be asserted without network
+ * or file-system access.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
@@ -48,7 +44,7 @@ class ModelDownloadWorkerTest {
     }
 
     @Test
-    fun doWork_success_returnsModelDirInOutputData() = runBlocking {
+    fun `success returns model dir in output data`() = runBlocking {
         coEvery {
             ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
         } returns "/fake/model/dir"
@@ -65,9 +61,9 @@ class ModelDownloadWorkerTest {
     }
 
     @Test
-    fun doWork_ioException_returnsRetry() = runBlocking {
-        // The worker should bubble transient network/disk failures up to
-        // WorkManager so it reschedules with exponential backoff.
+    fun `io exception returns retry`() = runBlocking {
+        // Transient network/disk failures go back to WorkManager so it
+        // reschedules with exponential backoff.
         coEvery {
             ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
         } throws IOException("network down")
@@ -79,10 +75,9 @@ class ModelDownloadWorkerTest {
     }
 
     @Test
-    fun doWork_genericThrowable_returnsFailureWithMessage() = runBlocking {
-        // Non-IO exceptions are not transient (e.g. corrupt manifest, OOM)
-        // — emit Failure with the message in outputData so the host activity
-        // can surface a useful error.
+    fun `generic throwable returns failure with message`() = runBlocking {
+        // Non-IO exceptions are not transient — Failure carries the message so
+        // the host activity can surface it.
         coEvery {
             ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
         } throws IllegalStateException("models corrupt")
@@ -96,49 +91,21 @@ class ModelDownloadWorkerTest {
     }
 
     @Test
-    fun doWork_invalidPrecisionInput_defaultsToInt8() = runBlocking {
+    fun `missing or invalid inputs fall back to INT8 and short-turn Kokoro`() = runBlocking {
         coEvery {
             ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
         } returns "/fake"
 
-        val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context)
+        TestListenableWorkerBuilder<ModelDownloadWorker>(context).build().doWork()
+        TestListenableWorkerBuilder<ModelDownloadWorker>(context)
             .setInputData(workDataOf(ModelDownloadWorker.KEY_PRECISION to "NOT_A_PRECISION"))
             .build()
+            .doWork()
 
-        worker.doWork()
-
-        coVerify(exactly = 1) {
-            ModelManager.ensureModels(any(), ModelPrecision.INT8, any(), any(), any(), any())
-        }
-    }
-
-    @Test
-    fun doWork_missingPrecisionInput_defaultsToInt8() = runBlocking {
-        coEvery {
-            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
-        } returns "/fake"
-
-        val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context).build()
-        worker.doWork()
-
-        coVerify(exactly = 1) {
-            ModelManager.ensureModels(any(), ModelPrecision.INT8, any(), any(), any(), any())
-        }
-    }
-
-    @Test
-    fun doWork_missingTtsModelInput_defaultsToShortTurnKokoro() = runBlocking {
-        coEvery {
-            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
-        } returns "/fake"
-
-        val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context).build()
-        worker.doWork()
-
-        coVerify(exactly = 1) {
+        coVerify(exactly = 2) {
             ModelManager.ensureModels(
                 any(),
-                any(),
+                ModelPrecision.INT8,
                 any(),
                 any(),
                 TtsModel.KOKORO_SHORT_TURN,
@@ -148,7 +115,7 @@ class ModelDownloadWorkerTest {
     }
 
     @Test
-    fun doWork_modelInputs_arePassedToModelManager() = runBlocking {
+    fun `model inputs are passed to ModelManager`() = runBlocking {
         coEvery {
             ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
         } returns "/fake"
@@ -177,7 +144,7 @@ class ModelDownloadWorkerTest {
     }
 
     @Test
-    fun doWork_controlLoraInput_downloadsSelectedLlmProfile() = runBlocking {
+    fun `control lora input downloads selected llm profile`() = runBlocking {
         coEvery {
             ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
         } returns "/fake"
@@ -205,7 +172,7 @@ class ModelDownloadWorkerTest {
     }
 
     @Test
-    fun request_buildsRequestWithModelInputDataAndNoNetworkConstraint() {
+    fun `request builds input data without network constraint`() {
         val req = ModelDownloadWorker.request(
             precision = ModelPrecision.INT8,
             sttModel = SttModel.PARAKEET,
@@ -245,7 +212,7 @@ class ModelDownloadWorkerTest {
     }
 
     @Test
-    fun request_defaultUsesShortTurnKokoro() {
+    fun `request defaults to short-turn Kokoro`() {
         val req = ModelDownloadWorker.request()
 
         assertEquals(
@@ -255,7 +222,7 @@ class ModelDownloadWorkerTest {
     }
 
     @Test
-    fun uniqueName_includesNonDefaultModelSet() {
+    fun `unique name includes non-default model set`() {
         assertEquals(
             ModelDownloadWorker.UNIQUE_NAME,
             ModelDownloadWorker.uniqueName(),

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerDownloadTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerDownloadTest.kt
@@ -1,23 +1,26 @@
 package audio.soniqo.speech
 
 import okhttp3.OkHttpClient
-import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import org.junit.After
-import org.junit.Assert.*
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
-import java.io.FileOutputStream
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 /**
- * Unit tests for model download logic: retries, resume, validation.
- * Uses OkHttp MockWebServer — no device or network needed.
+ * Drives [ModelManager.downloadFile] against a local MockWebServer:
+ * retry, resume via Range, timeout, and redirect handling.
  */
 class ModelManagerDownloadTest {
 
@@ -25,16 +28,16 @@ class ModelManagerDownloadTest {
     val tmpDir = TemporaryFolder()
 
     private lateinit var server: MockWebServer
-    private lateinit var client: OkHttpClient
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(5, TimeUnit.SECONDS)
+        .readTimeout(5, TimeUnit.SECONDS)
+        .build()
 
     @Before
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = OkHttpClient.Builder()
-            .connectTimeout(5, TimeUnit.SECONDS)
-            .readTimeout(5, TimeUnit.SECONDS)
-            .build()
     }
 
     @After
@@ -42,150 +45,95 @@ class ModelManagerDownloadTest {
         server.shutdown()
     }
 
-    // -- helpers --
-
-    private fun downloadFile(
-        url: String,
+    private fun download(
         dest: File,
+        path: String = "/model.onnx",
         maxRetries: Int = 3,
-        onBytes: (Long) -> Unit = {},
-    ) {
-        val tmp = File(dest.parentFile, "${dest.name}.tmp")
-        var lastException: IOException? = null
-
-        for (attempt in 1..maxRetries) {
-            try {
-                val existingBytes = if (tmp.exists()) tmp.length() else 0L
-                val rb = Request.Builder().url(url)
-                if (existingBytes > 0) rb.header("Range", "bytes=$existingBytes-")
-
-                val response = client.newCall(rb.build()).execute()
-                if (!response.isSuccessful && response.code != 206) {
-                    response.close()
-                    throw IOException("HTTP ${response.code}")
-                }
-
-                val body = response.body ?: throw IOException("Empty response")
-                val contentLength = body.contentLength()
-                val isResume = response.code == 206
-
-                FileOutputStream(tmp, isResume).use { output ->
-                    body.byteStream().use { input ->
-                        val buf = ByteArray(4096)
-                        var total = if (isResume) existingBytes else 0L
-                        while (true) {
-                            val n = input.read(buf)
-                            if (n == -1) break
-                            output.write(buf, 0, n)
-                            total += n
-                            onBytes(total)
-                        }
-                    }
-                }
-                response.close()
-
-                if (!isResume && contentLength > 0 && tmp.length() != contentLength) {
-                    throw IOException("Incomplete: got ${tmp.length()}, expected $contentLength")
-                }
-
-                if (!tmp.renameTo(dest)) {
-                    tmp.copyTo(dest, overwrite = true)
-                    tmp.delete()
-                }
-                return
-            } catch (e: IOException) {
-                lastException = e
-                if (attempt < maxRetries) Thread.sleep(100L * attempt)
-            }
-        }
-
-        // Preserve tmp for resume on next attempt — mirrors production.
-        throw IOException("Failed after $maxRetries attempts: ${lastException?.message}", lastException)
-    }
-
-    // -- tests --
+        client: OkHttpClient = this.client,
+        onBytes: (downloaded: Long, fileTotal: Long) -> Unit = { _, _ -> },
+    ) = ModelManager.downloadFile(
+        url = server.url(path).toString(),
+        dest = dest,
+        client = client,
+        maxRetries = maxRetries,
+        retryDelayMs = 10,
+        onBytes = onBytes,
+    )
 
     @Test
-    fun `successful download writes correct content`() {
+    fun `successful download writes body to destination`() {
         val content = "hello world model data"
         server.enqueue(MockResponse().setBody(content))
 
         val dest = File(tmpDir.root, "model.onnx")
-        downloadFile(server.url("/model.onnx").toString(), dest)
+        download(dest)
 
-        assertTrue(dest.exists())
         assertEquals(content, dest.readText())
+        assertFalse(File(tmpDir.root, "model.onnx.tmp").exists())
     }
 
     @Test
-    fun `progress callback reports bytes`() {
+    fun `progress callback reports downloaded bytes and file total`() {
         val content = ByteArray(16384) { it.toByte() }
         server.enqueue(MockResponse().setBody(okio.Buffer().write(content)))
 
         val dest = File(tmpDir.root, "model.onnx")
-        val reported = mutableListOf<Long>()
-        downloadFile(server.url("/model.onnx").toString(), dest) { reported.add(it) }
+        val reported = mutableListOf<Pair<Long, Long>>()
+        download(dest) { bytes, total -> reported.add(bytes to total) }
 
-        assertTrue(reported.isNotEmpty())
-        assertEquals(content.size.toLong(), reported.last())
+        assertEquals(0L, reported.first().first)
+        assertEquals(content.size.toLong(), reported.last().first)
+        assertTrue(reported.all { it.second == content.size.toLong() })
     }
 
     @Test
-    fun `retries on server error`() {
+    fun `retries on server error until success`() {
         server.enqueue(MockResponse().setResponseCode(500))
         server.enqueue(MockResponse().setResponseCode(500))
         server.enqueue(MockResponse().setBody("ok"))
 
         val dest = File(tmpDir.root, "model.onnx")
-        downloadFile(server.url("/model.onnx").toString(), dest)
+        download(dest)
 
-        assertTrue(dest.exists())
         assertEquals("ok", dest.readText())
         assertEquals(3, server.requestCount)
     }
 
     @Test(expected = IOException::class)
     fun `throws after max retries exhausted`() {
-        server.enqueue(MockResponse().setResponseCode(500))
-        server.enqueue(MockResponse().setResponseCode(500))
-        server.enqueue(MockResponse().setResponseCode(500))
+        repeat(3) { server.enqueue(MockResponse().setResponseCode(500)) }
 
-        val dest = File(tmpDir.root, "model.onnx")
-        downloadFile(server.url("/model.onnx").toString(), dest, maxRetries = 3)
+        download(File(tmpDir.root, "model.onnx"), maxRetries = 3)
     }
 
     @Test
-    fun `preserves tmp file after all retries fail so next attempt can resume`() {
-        // Simulate every retry attempt failing mid-stream: server promises 16
-        // bytes via Content-Length but disconnects during the body. OkHttp
-        // throws, triggering retry. After all retries exhaust, we expect the
-        // .tmp file to persist (with whatever partial bytes made it to disk)
-        // so the worker can resume via Range: bytes=N- on a future invocation.
+    fun `preserves partial tmp file after all retries fail`() {
+        // DISCONNECT_DURING_RESPONSE_BODY sends half the declared body, so
+        // every attempt fails mid-stream with some bytes on disk. The .tmp
+        // must survive: the next ensureModels() call resumes from it.
         repeat(2) {
             server.enqueue(
                 MockResponse()
                     .setBody("ABCDEFGHIJKLMNOP")
-                    .setSocketPolicy(okhttp3.mockwebserver.SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY)
+                    .setSocketPolicy(SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY)
             )
         }
 
         val dest = File(tmpDir.root, "model.onnx")
         try {
-            downloadFile(server.url("/model.onnx").toString(), dest, maxRetries = 2)
+            download(dest, maxRetries = 2)
+            fail("expected IOException")
         } catch (_: IOException) {}
 
         assertFalse("final file should not exist on failure", dest.exists())
-        val tmp = File(tmpDir.root, "model.onnx.tmp")
-        assertTrue("partial .tmp should be preserved for resume", tmp.exists())
+        assertTrue(
+            "partial .tmp should be preserved for resume",
+            File(tmpDir.root, "model.onnx.tmp").exists(),
+        )
     }
 
     @Test
-    fun `resume sends Range header for partial file`() {
-        // First attempt: server drops after partial content
-        val fullContent = "ABCDEFGHIJKLMNOP"
-        server.enqueue(MockResponse().setResponseCode(500).setBody("ABCD"))
-
-        // Second attempt: server returns remaining bytes
+    fun `resume sends Range header and appends to existing tmp`() {
         server.enqueue(
             MockResponse()
                 .setResponseCode(206)
@@ -193,173 +141,76 @@ class ModelManagerDownloadTest {
                 .setHeader("Content-Range", "bytes 4-15/16")
         )
 
-        // Pre-create a partial tmp file simulating interrupted download
         val dest = File(tmpDir.root, "model.onnx")
-        val tmp = File(tmpDir.root, "model.onnx.tmp")
-        tmp.writeText("ABCD")
+        File(tmpDir.root, "model.onnx.tmp").writeText("ABCD")
 
-        // Should resume from byte 4
-        downloadFile(server.url("/model.onnx").toString(), dest)
+        val totals = mutableListOf<Pair<Long, Long>>()
+        download(dest) { bytes, total -> totals.add(bytes to total) }
 
-        assertTrue(dest.exists())
+        assertEquals("bytes=4-", server.takeRequest().getHeader("Range"))
         assertEquals("ABCDEFGHIJKLMNOP", dest.readText())
-
-        // Verify second request used Range header
-        val req1 = server.takeRequest()
-        val req2 = server.takeRequest()
-        assertEquals("bytes=4-", req2.getHeader("Range"))
-    }
-
-    @Test(expected = IOException::class)
-    fun `rejects HTTP 404`() {
-        server.enqueue(MockResponse().setResponseCode(404))
-        server.enqueue(MockResponse().setResponseCode(404))
-        server.enqueue(MockResponse().setResponseCode(404))
-
-        val dest = File(tmpDir.root, "model.onnx")
-        downloadFile(server.url("/missing.onnx").toString(), dest)
+        // On a 206 the response length is only the remaining range; the
+        // reported file total must include the bytes already on disk.
+        assertEquals(16L to 16L, totals.last())
     }
 
     @Test
-    fun `handles redirect`() {
-        server.enqueue(MockResponse().setResponseCode(302).setHeader("Location", server.url("/actual")))
+    fun `http failure message includes status code`() {
+        server.enqueue(MockResponse().setResponseCode(404))
+
+        try {
+            download(File(tmpDir.root, "model.onnx"), maxRetries = 1)
+            fail("expected IOException")
+        } catch (e: IOException) {
+            assertTrue("message was: ${e.message}", e.message!!.contains("HTTP 404"))
+        }
+    }
+
+    @Test
+    fun `follows redirects`() {
+        server.enqueue(
+            MockResponse().setResponseCode(302).setHeader("Location", server.url("/actual"))
+        )
         server.enqueue(MockResponse().setBody("redirected content"))
 
         val dest = File(tmpDir.root, "model.onnx")
-        downloadFile(server.url("/redirect").toString(), dest)
+        download(dest)
 
         assertEquals("redirected content", dest.readText())
     }
 
     @Test
     fun `read timeout triggers retry`() {
-        // Use a client with very short timeout to simulate slow server
-        val slowClient = client
-        val savedClient = client
-        client = OkHttpClient.Builder()
+        val shortTimeoutClient = OkHttpClient.Builder()
             .connectTimeout(1, TimeUnit.SECONDS)
-            .readTimeout(1, TimeUnit.SECONDS)
+            .readTimeout(500, TimeUnit.MILLISECONDS)
             .build()
 
-        // First response: throttle body to trigger read timeout
+        // 1 byte per 5 s starves the read timeout on the first attempt.
         server.enqueue(
             MockResponse()
                 .setBody("partial")
-                .throttleBody(1, 5, TimeUnit.SECONDS) // 1 byte per 5s → timeout
+                .throttleBody(1, 5, TimeUnit.SECONDS)
         )
-        // Second response: fast
         server.enqueue(MockResponse().setBody("ok"))
 
         val dest = File(tmpDir.root, "model.onnx")
-        downloadFile(server.url("/model.onnx").toString(), dest)
+        download(dest, client = shortTimeoutClient)
 
-        assertTrue(dest.exists())
         assertEquals("ok", dest.readText())
-
-        client = savedClient
-    }
-
-    @Test
-    fun `detects incomplete download via Content-Length`() {
-        // Server claims 1000 bytes but only sends 5
-        server.enqueue(
-            MockResponse()
-                .setBody("short")
-                .setHeader("Content-Length", "1000")
-        )
-        server.enqueue(
-            MockResponse()
-                .setBody("short")
-                .setHeader("Content-Length", "1000")
-        )
-        server.enqueue(
-            MockResponse()
-                .setBody("short")
-                .setHeader("Content-Length", "1000")
-        )
-
-        val dest = File(tmpDir.root, "model.onnx")
-        try {
-            downloadFile(server.url("/model.onnx").toString(), dest)
-            fail("Should have thrown")
-        } catch (e: IOException) {
-            assertTrue(e.message!!.contains("Incomplete") || e.message!!.contains("Failed"))
-        }
-
-        assertFalse(dest.exists())
-    }
-
-    @Test
-    fun `skips already downloaded file`() {
-        // Simulate ModelManager behavior: file already exists, skip download
-        val dest = File(tmpDir.root, "model.onnx")
-        dest.writeText("cached content")
-
-        // No server response enqueued — if download is attempted, it'll fail
-        assertTrue(dest.exists())
-        assertEquals("cached content", dest.readText())
-    }
-
-    @Test
-    fun `stale tmp files do not interfere with fresh download`() {
-        // Leftover .tmp from a previous crashed session
-        val tmp = File(tmpDir.root, "model.onnx.tmp")
-        tmp.writeText("stale garbage from previous crash")
-
-        server.enqueue(MockResponse().setBody("fresh data"))
-
-        val dest = File(tmpDir.root, "model.onnx")
-        // Delete stale tmp first (like ModelManager does on startup)
-        tmpDir.root.walk().filter { it.extension == "tmp" }.forEach { it.delete() }
-
-        downloadFile(server.url("/model.onnx").toString(), dest)
-
-        assertTrue(dest.exists())
-        assertEquals("fresh data", dest.readText())
-        assertFalse(tmp.exists())
-    }
-
-    @Test
-    fun `concurrent downloads to different files succeed`() {
-        val files = (1..3).map { i ->
-            server.enqueue(MockResponse().setBody("content-$i"))
-            File(tmpDir.root, "model-$i.onnx")
-        }
-
-        files.forEachIndexed { i, dest ->
-            downloadFile(server.url("/model-${i + 1}.onnx").toString(), dest)
-        }
-
-        files.forEachIndexed { i, dest ->
-            assertTrue(dest.exists())
-            assertEquals("content-${i + 1}", dest.readText())
-        }
+        assertEquals(2, server.requestCount)
     }
 
     @Test
     fun `large file download preserves all bytes`() {
-        // 1MB of random-ish data
         val size = 1_048_576
         val data = ByteArray(size) { (it % 251).toByte() }
         server.enqueue(MockResponse().setBody(okio.Buffer().write(data)))
 
         val dest = File(tmpDir.root, "large.onnx")
-        downloadFile(server.url("/large.onnx").toString(), dest)
+        download(dest, path = "/large.onnx")
 
         assertEquals(size.toLong(), dest.length())
         assertArrayEquals(data, dest.readBytes())
-    }
-
-    @Test
-    fun `error message includes HTTP status code`() {
-        server.enqueue(MockResponse().setResponseCode(403))
-
-        val dest = File(tmpDir.root, "model.onnx")
-        try {
-            downloadFile(server.url("/model.onnx").toString(), dest, maxRetries = 1)
-            fail("Should have thrown")
-        } catch (e: IOException) {
-            assertTrue(e.message!!.contains("403"))
-        }
     }
 }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
@@ -17,7 +17,7 @@ import org.junit.Test
 class ModelManagerManifestTest {
 
     @Test
-    fun speechConfigDefault_usesLowMemoryParakeetEou() {
+    fun `default SpeechConfig uses low-memory Parakeet EOU`() {
         assertEquals(SttModel.PARAKEET_EOU, SpeechConfig().sttModel)
         assertEquals(TtsModel.KOKORO_SHORT_TURN, SpeechConfig().ttsModel)
         assertFalse(SpeechConfig().useNnapi)
@@ -26,7 +26,7 @@ class ModelManagerManifestTest {
     }
 
     @Test
-    fun ttsNativeIds_areStable() {
+    fun `tts native ids are stable`() {
         assertEquals(0, TtsModel.KOKORO.nativeId)
         assertEquals(1, TtsModel.SUPERTONIC.nativeId)
         assertEquals(2, TtsModel.KOKORO_SHORT_TURN.nativeId)
@@ -34,7 +34,7 @@ class ModelManagerManifestTest {
     }
 
     @Test
-    fun defaultSttManifest_usesParakeetEouBundle() {
+    fun `default stt manifest uses Parakeet EOU bundle`() {
         val eouFiles = modelFiles(sttModel = SttModel.PARAKEET_EOU)
             .filter { it.repo == "Parakeet-EOU-120M-ONNX-INT8" }
 
@@ -50,7 +50,7 @@ class ModelManagerManifestTest {
     }
 
     @Test
-    fun modelSetKey_changesWhenSttModelChanges() {
+    fun `model set key changes when stt model changes`() {
         assertNotEquals(
             modelSetKey(sttModel = SttModel.PARAKEET_EOU),
             modelSetKey(sttModel = SttModel.PARAKEET),
@@ -58,7 +58,7 @@ class ModelManagerManifestTest {
     }
 
     @Test
-    fun modelDirName_separatesNonDefaultModelSets() {
+    fun `model dir name separates non-default model sets`() {
         assertEquals(
             "models",
             modelDirName(sttModel = SttModel.PARAKEET_EOU),
@@ -70,8 +70,8 @@ class ModelManagerManifestTest {
     }
 
     @Test
-    fun ttsOnlyManifest_usesKokoroFilesWithoutPipelineAssets() {
-        val files = ttsModelFiles(TtsModel.KOKORO)
+    fun `tts-only manifest uses Kokoro files without pipeline assets`() {
+        val files = ModelManager.ttsModels(TtsModel.KOKORO)
 
         assertEquals(
             listOf(
@@ -96,18 +96,18 @@ class ModelManagerManifestTest {
     }
 
     @Test
-    fun kokoroProfiles_shareAssetsCachesAndWorkerName() {
+    fun `kokoro profiles share assets caches and worker name`() {
         assertEquals(
-            ttsModelFiles(TtsModel.KOKORO),
-            ttsModelFiles(TtsModel.KOKORO_SHORT_TURN),
+            ModelManager.ttsModels(TtsModel.KOKORO),
+            ModelManager.ttsModels(TtsModel.KOKORO_SHORT_TURN),
         )
         assertEquals(
             modelSetKey(ttsModel = TtsModel.KOKORO),
             modelSetKey(ttsModel = TtsModel.KOKORO_SHORT_TURN),
         )
         assertEquals(
-            ttsModelSetKey(TtsModel.KOKORO),
-            ttsModelSetKey(TtsModel.KOKORO_SHORT_TURN),
+            ModelManager.ttsModelSetKey(TtsModel.KOKORO),
+            ModelManager.ttsModelSetKey(TtsModel.KOKORO_SHORT_TURN),
         )
         assertEquals(
             modelDirName(ttsModel = TtsModel.KOKORO),
@@ -118,25 +118,25 @@ class ModelManagerManifestTest {
             ModelDownloadWorker.uniqueName(ttsModel = TtsModel.KOKORO_SHORT_TURN),
         )
         assertNotEquals(
-            ttsModelSetKey(TtsModel.KOKORO_SHORT_TURN),
-            ttsModelSetKey(TtsModel.SUPERTONIC),
+            ModelManager.ttsModelSetKey(TtsModel.KOKORO_SHORT_TURN),
+            ModelManager.ttsModelSetKey(TtsModel.SUPERTONIC),
         )
         assertTrue(
-            ttsModelFiles(TtsModel.KOKORO_SHORT_TURN)
+            ModelManager.ttsModels(TtsModel.KOKORO_SHORT_TURN)
                 .any { it.filename == "kokoro-e2e-realtime.onnx" },
         )
     }
 
     @Test
-    fun ttsOnlyModelSetKey_isSeparateFromPipelineCacheKey() {
+    fun `tts-only model set key is separate from pipeline cache key`() {
         assertNotEquals(
             modelSetKey(ttsModel = TtsModel.KOKORO),
-            ttsModelSetKey(TtsModel.KOKORO),
+            ModelManager.ttsModelSetKey(TtsModel.KOKORO),
         )
     }
 
     @Test
-    fun supertonicManifest_includesCompleteVoiceCatalogFromLiteRtRepo() {
+    fun `supertonic manifest includes complete voice catalog from LiteRT repo`() {
         val styleFiles = modelFiles(ttsModel = TtsModel.SUPERTONIC)
             .filter { it.filename.startsWith("voice_styles/") }
 
@@ -157,8 +157,8 @@ class ModelManagerManifestTest {
     }
 
     @Test
-    fun pocketManifest_isPinnedAndNamespacedAwayFromSttAssets() {
-        val files = ttsModelFiles(TtsModel.POCKET)
+    fun `pocket manifest is pinned and namespaced away from stt assets`() {
+        val files = ModelManager.ttsModels(TtsModel.POCKET)
 
         assertEquals(
             listOf(
@@ -188,15 +188,15 @@ class ModelManagerManifestTest {
     }
 
     @Test
-    fun llmManifest_keepsStandaloneFunctionGemmaAsDefault() {
+    fun `llm manifest keeps standalone FunctionGemma as default`() {
         assertEquals(
             listOf(ModelManager.ModelFile("FunctionGemma-270M-LiteRT-LM", "model.litertlm")),
-            llmModelFiles(LlmModel.FUNCTIONGEMMA),
+            ModelManager.llmModels(LlmModel.FUNCTIONGEMMA),
         )
     }
 
     @Test
-    fun controlLoraManifest_hasSeparateReusableBaseAndAdapter() {
+    fun `control lora manifest has separate reusable base and adapter`() {
         assertEquals(
             listOf(
                 ModelManager.ModelFile(
@@ -208,122 +208,32 @@ class ModelManagerManifestTest {
                     "control-r4-rank16.tflite",
                 ),
             ),
-            llmModelFiles(LlmModel.FUNCTIONGEMMA_CONTROL_LORA),
+            ModelManager.llmModels(LlmModel.FUNCTIONGEMMA_CONTROL_LORA),
         )
     }
 
     @Test
-    fun llmModelSetKey_isSeparateFromPipelineAndTtsCacheKeys() {
-        val stock = llmModelSetKey(LlmModel.FUNCTIONGEMMA)
-        val control = llmModelSetKey(LlmModel.FUNCTIONGEMMA_CONTROL_LORA)
+    fun `llm model set key is separate from pipeline and tts cache keys`() {
+        val stock = ModelManager.llmModelSetKey(LlmModel.FUNCTIONGEMMA)
+        val control = ModelManager.llmModelSetKey(LlmModel.FUNCTIONGEMMA_CONTROL_LORA)
         assertNotEquals(stock, modelSetKey())
-        assertNotEquals(stock, ttsModelSetKey(TtsModel.KOKORO))
+        assertNotEquals(stock, ModelManager.ttsModelSetKey(TtsModel.KOKORO))
         assertNotEquals(stock, control)
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun llmModelFiles(llmModel: LlmModel): List<ModelManager.ModelFile> {
-        val method = ModelManager::class.java.getDeclaredMethod(
-            "llmModels",
-            LlmModel::class.java,
-        )
-        method.isAccessible = true
-        return method.invoke(ModelManager, llmModel) as List<ModelManager.ModelFile>
-    }
-
-    private fun llmModelSetKey(llmModel: LlmModel): String {
-        val method = ModelManager::class.java.getDeclaredMethod(
-            "llmModelSetKey",
-            LlmModel::class.java,
-        )
-        method.isAccessible = true
-        return method.invoke(ModelManager, llmModel) as String
-    }
-
-    @Suppress("UNCHECKED_CAST")
     private fun modelFiles(
         sttModel: SttModel = SttModel.PARAKEET_EOU,
         ttsModel: TtsModel = TtsModel.KOKORO,
-    ): List<ModelManager.ModelFile> {
-        val models = ModelManager::class.java.getDeclaredMethod(
-            "models",
-            ModelPrecision::class.java,
-            SttModel::class.java,
-            SttBackend::class.java,
-            TtsModel::class.java,
-        )
-        models.isAccessible = true
-        return models.invoke(
-            ModelManager,
-            ModelPrecision.INT8,
-            sttModel,
-            SttBackend.ONNX,
-            ttsModel,
-        ) as List<ModelManager.ModelFile>
-    }
+    ): List<ModelManager.ModelFile> =
+        ModelManager.models(ModelPrecision.INT8, sttModel, SttBackend.ONNX, ttsModel)
 
     private fun modelSetKey(
-        precision: ModelPrecision = ModelPrecision.INT8,
         sttModel: SttModel = SttModel.PARAKEET_EOU,
-        sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO,
-    ): String {
-        val method = ModelManager::class.java.getDeclaredMethod(
-            "modelSetKey",
-            ModelPrecision::class.java,
-            SttModel::class.java,
-            SttBackend::class.java,
-            TtsModel::class.java,
-        )
-        method.isAccessible = true
-        return method.invoke(
-            ModelManager,
-            precision,
-            sttModel,
-            sttBackend,
-            ttsModel,
-        ) as String
-    }
+    ): String = ModelManager.modelSetKey(ModelPrecision.INT8, sttModel, SttBackend.ONNX, ttsModel)
 
     private fun modelDirName(
-        precision: ModelPrecision = ModelPrecision.INT8,
         sttModel: SttModel = SttModel.PARAKEET_EOU,
-        sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO,
-    ): String {
-        val method = ModelManager::class.java.getDeclaredMethod(
-            "modelDirName",
-            ModelPrecision::class.java,
-            SttModel::class.java,
-            SttBackend::class.java,
-            TtsModel::class.java,
-        )
-        method.isAccessible = true
-        return method.invoke(
-            ModelManager,
-            precision,
-            sttModel,
-            sttBackend,
-            ttsModel,
-        ) as String
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun ttsModelFiles(ttsModel: TtsModel): List<ModelManager.ModelFile> {
-        val method = ModelManager::class.java.getDeclaredMethod(
-            "ttsModels",
-            TtsModel::class.java,
-        )
-        method.isAccessible = true
-        return method.invoke(ModelManager, ttsModel) as List<ModelManager.ModelFile>
-    }
-
-    private fun ttsModelSetKey(ttsModel: TtsModel): String {
-        val method = ModelManager::class.java.getDeclaredMethod(
-            "ttsModelSetKey",
-            TtsModel::class.java,
-        )
-        method.isAccessible = true
-        return method.invoke(ModelManager, ttsModel) as String
-    }
+    ): String = ModelManager.modelDirName(ModelPrecision.INT8, sttModel, SttBackend.ONNX, ttsModel)
 }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/SpeechConfigTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/SpeechConfigTest.kt
@@ -6,14 +6,7 @@ import org.junit.Test
 class SpeechConfigTest {
 
     @Test
-    fun endOfSpeechSilence_usesSnappyCommandDefault() {
+    fun `end-of-speech silence defaults to snappy command value`() {
         assertEquals(0.5f, SpeechConfig().endOfSpeechSilenceSec, 0f)
-    }
-
-    @Test
-    fun endOfSpeechSilence_acceptsLongerPauseForDictation() {
-        val config = SpeechConfig(endOfSpeechSilenceSec = 0.8f)
-
-        assertEquals(0.8f, config.endOfSpeechSilenceSec, 0f)
     }
 }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/llm/FunctionGemmaParserTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/llm/FunctionGemmaParserTest.kt
@@ -51,4 +51,11 @@ class FunctionGemmaParserTest {
     @Test fun `no call returns empty list`() {
         assertTrue(FunctionGemmaParser.parseFunctionCalls("hello world").isEmpty())
     }
+
+    @Test fun `rejects body without brace or with junk name`() {
+        assertTrue(FunctionGemmaParser.parseFunctionCalls(
+            "<start_function_call>no braces here<end_function_call>").isEmpty())
+        assertTrue(FunctionGemmaParser.parseFunctionCalls(
+            "<start_function_call>some junk text {x:1}<end_function_call>").isEmpty())
+    }
 }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/llm/FunctionGemmaTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/llm/FunctionGemmaTest.kt
@@ -43,7 +43,7 @@ class FunctionGemmaTest {
     )
 
     @Test
-    fun rawRuntime_receivesCanonicalDeveloperTurnPrompt() {
+    fun `raw runtime receives canonical developer-turn prompt`() {
         val runtime = CapturingRuntime(appliesChatTemplate = false)
         FunctionGemma(runtime).generateToolCall("set temp to 21", tools)
 
@@ -61,7 +61,7 @@ class FunctionGemmaTest {
     }
 
     @Test
-    fun templatingRuntime_receivesBareDeclarationsAndText() {
+    fun `templating runtime receives bare declarations and text`() {
         val runtime = CapturingRuntime(appliesChatTemplate = true)
         FunctionGemma(runtime).generateToolCall("set temp to 21", tools)
 
@@ -72,7 +72,7 @@ class FunctionGemmaTest {
     }
 
     @Test
-    fun parse_acceptsBareFunctionNameWithoutCallPrefix() {
+    fun `parse accepts bare function name without call prefix`() {
         // The released FunctionGemma-270M weights emit `NAME {args}` without
         // the `call:` prefix from the training-format spec (seen on-device).
         val response = "<start_function_call>call_contact {name:<escape>Anna<escape>," +
@@ -85,15 +85,7 @@ class FunctionGemmaTest {
     }
 
     @Test
-    fun parse_rejectsBodyWithoutBraceOrWithJunkName() {
-        assertTrue(FunctionGemmaParser.parseFunctionCalls(
-            "<start_function_call>no braces here<end_function_call>").isEmpty())
-        assertTrue(FunctionGemmaParser.parseFunctionCalls(
-            "<start_function_call>some junk text {x:1}<end_function_call>").isEmpty())
-    }
-
-    @Test
-    fun parse_toleratesNewlinesAroundCallBody() {
+    fun `parse tolerates newlines around call body`() {
         // litertlm-android's Conversation output puts the call body on its
         // own line after the marker (seen on-device with 0.14.0).
         val response = "<start_function_call>\n" +
@@ -106,7 +98,7 @@ class FunctionGemmaTest {
     }
 
     @Test
-    fun generateAndParse_roundTripsAToolCall() {
+    fun `generate and parse round-trips a tool call`() {
         val response = "<start_function_call>call:set_temperature{celsius:21," +
             "say:<escape>Temperature set to 21 degrees.<escape>}<end_function_call>"
         val gemma = FunctionGemma(CapturingRuntime(appliesChatTemplate = true, response = response))

--- a/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechRecognitionServiceTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/service/SpeechRecognitionServiceTest.kt
@@ -37,13 +37,10 @@ import org.robolectric.android.controller.ServiceController
 import org.robolectric.annotation.Config
 
 /**
- * Robolectric tests for [SpeechRecognitionService].
- *
- * Uses the protected seams [SpeechRecognitionService.createPipeline],
- * [SpeechRecognitionService.resolveModelDir], and
- * [SpeechRecognitionService.newAudioRecord] to inject a fake pipeline and a
- * mocked AudioRecord — no native library load, no real microphone, no model
- * download. Each test runs in well under a second.
+ * Robolectric tests for [SpeechRecognitionService]. The protected seams
+ * (createPipeline / resolveModelDir / newAudioRecord) inject a fake pipeline
+ * and a mocked AudioRecord, so no native library, microphone, or model
+ * download is involved.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
@@ -63,8 +60,7 @@ class SpeechRecognitionServiceTest {
         fakePipeline = FakeSpeechPipeline()
         fakeRecord = mockk(relaxed = true) {
             every { state } returns AudioRecord.STATE_INITIALIZED
-            // Returning -1 makes the mic loop exit immediately so it doesn't
-            // hot-spin during the test. We're not exercising the mic path here.
+            // -1 makes the mic loop exit immediately instead of hot-spinning.
             every { read(any<FloatArray>(), any(), any(), any()) } returns -1
         }
 
@@ -81,17 +77,17 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun startListening_setsUpPipelineAndSignalsReady() {
+    fun `startListening sets up pipeline and signals ready`() {
         service.startListening(Intent(), listener)
 
         verify(timeout = 1500) { listener.readyForSpeech(any()) }
     }
 
     @Test
-    fun startListening_concurrentCallReturnsBusy() {
-        // Regression test for the race fix: the first call must claim the
-        // `starting` flag synchronously so a second call hits the busy branch
-        // before the suspending setup of the first one completes.
+    fun `concurrent startListening returns busy`() {
+        // The first call must claim the `starting` flag synchronously so the
+        // second call hits the busy branch before the first's suspending
+        // setup completes.
         service.startListening(Intent(), listener)
 
         val second = mockk<RecognitionService.Callback>(relaxed = true)
@@ -101,7 +97,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun startListening_requestedRegionalLanguageIsAccepted() {
+    fun `requested regional language is accepted`() {
         val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE, "fr-FR")
 
         service.startListening(intent, listener)
@@ -111,7 +107,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun startListening_requestedLanguagePreferenceIsAccepted() {
+    fun `requested language preference is accepted`() {
         val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, "en-US")
 
         service.startListening(intent, listener)
@@ -121,7 +117,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun startListening_allowedLanguagesArePassedAsHints() {
+    fun `allowed languages are passed as hints`() {
         val intent = Intent().putStringArrayListExtra(
             RecognizerIntent.EXTRA_LANGUAGE_DETECTION_ALLOWED_LANGUAGES,
             arrayListOf("fr-FR", "de-DE", "ja-JP"),
@@ -135,7 +131,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun startListening_requestedLanguageTakesPriorityOverAllowedLanguages() {
+    fun `requested language takes priority over allowed languages`() {
         val intent = Intent()
             .putExtra(RecognizerIntent.EXTRA_LANGUAGE, "en-US")
             .putStringArrayListExtra(
@@ -151,7 +147,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun startListening_unsupportedLanguageReportsLanguageNotSupported() {
+    fun `unsupported language reports language-not-supported`() {
         val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE, "ja-JP")
 
         service.startListening(intent, listener)
@@ -161,7 +157,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun startListening_modelsNotReadyReportsLanguageUnavailableAndSchedulesDownload() {
+    fun `models not ready reports language-unavailable and schedules download`() {
         service.modelsReady = false
 
         service.startListening(Intent(), listener)
@@ -172,11 +168,9 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun stopListening_flushesPipelineWithSilence() {
-        // Regression test for the stop-hang fix: VAD detects end-of-utterance
-        // from silence in the audio stream, and nativeStop does not flush. We
-        // expect ~32 chunks × 32 ms ≈ 1 s of zero frames pushed after the mic
-        // is cut so the pipeline emits its final TranscriptionCompleted.
+    fun `stopListening flushes pipeline with silence`() {
+        // nativeStop does not flush; VAD only detects end-of-utterance from
+        // silence in the stream, so ~1 s of zero frames must follow mic cut.
         service.startListening(Intent(), listener)
         verify(timeout = 1500) { listener.readyForSpeech(any()) }
 
@@ -186,7 +180,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun startListening_withoutPermission_reportsInsufficient() {
+    fun `startListening without permission reports insufficient permissions`() {
         val app = ApplicationProvider.getApplicationContext<Application>()
         shadowOf(app).denyPermissions(Manifest.permission.RECORD_AUDIO)
 
@@ -196,7 +190,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun transcriptionCompleted_emitsResultsAndTearsDownSession() {
+    fun `transcription completed emits results and tears down session`() {
         service.startListening(Intent(), listener)
         verify(timeout = 1500) { listener.readyForSpeech(any()) }
 
@@ -210,7 +204,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun startListening_doesNotRequestAudioFocusFromCallingApp() {
+    fun `startListening does not request audio focus from calling app`() {
         service.startListening(Intent(), listener)
         verify(timeout = 1500) { listener.readyForSpeech(any()) }
 
@@ -220,7 +214,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun onCheckRecognitionSupport_modelsNotReady_marksLanguagesSupportedForDownload() {
+    fun `support check with models not ready marks languages supported for download`() {
         service.modelsReady = false
         val callback = mockk<RecognitionService.SupportCallback>(relaxed = true)
         service.checkRecognitionSupport(Intent(), callback)
@@ -229,8 +223,6 @@ class SpeechRecognitionServiceTest {
         verify(timeout = 1500) { callback.onSupportResult(capture(supportSlot)) }
         val support = supportSlot.captured
 
-        // Models aren't on disk in the test, so all advertised languages
-        // should be supported for download — never installed.
         assertTrue("installed should be empty", support.installedOnDeviceLanguages.isEmpty())
         assertTrue(
             "supported should include 'en'",
@@ -244,7 +236,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun onCheckRecognitionSupport_requestedRegionalLanguageReturnsExactLocale() {
+    fun `support check returns exact locale for requested regional language`() {
         val callback = mockk<RecognitionService.SupportCallback>(relaxed = true)
         val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE, "en-US")
 
@@ -259,7 +251,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun onCheckRecognitionSupport_unsupportedRequestedLanguageReportsError() {
+    fun `support check reports error for unsupported requested language`() {
         val callback = mockk<RecognitionService.SupportCallback>(relaxed = true)
         val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE, "ja-JP")
 
@@ -269,7 +261,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun languageHintTags_deduplicatesAndFiltersUnsupportedLanguages() {
+    fun `language hint tags deduplicate and filter unsupported languages`() {
         val intent = Intent()
             .putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, "en-US")
             .putStringArrayListExtra(
@@ -284,7 +276,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun triggerModelDownload_supportedLanguageEnqueuesDownload() {
+    fun `model download trigger for supported language enqueues download`() {
         val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE, "de-DE")
 
         service.triggerModelDownload(intent)
@@ -293,7 +285,7 @@ class SpeechRecognitionServiceTest {
     }
 
     @Test
-    fun triggerModelDownload_unsupportedLanguageDoesNotEnqueueDownload() {
+    fun `model download trigger for unsupported language does not enqueue download`() {
         val intent = Intent().putExtra(RecognizerIntent.EXTRA_LANGUAGE, "ja-JP")
 
         service.triggerModelDownload(intent)


### PR DESCRIPTION
## Summary

Tightens the unit and e2e suites so tests exercise production code and read like the rest of the codebase:

- `ModelManagerDownloadTest` previously defined its own private `downloadFile()` and tested that copy; it now drives the real `ModelManager.downloadFile` through MockWebServer (resume via Range header, 206 totals, tmp preservation, timeout retry). Three no-op tests that asserted the test's own actions are deleted.
- The only production change is a test seam: eight `ModelManager` helpers went `private` → `@VisibleForTesting internal`, and `downloadFile` gained defaulted `client`/`maxRetries`/`retryDelayMs` parameters whose defaults are the previous constants — production behavior unchanged.
- `SileroVadTest`: previously assertion-free tests now assert — silence produces no `SpeechStarted` within a 10 s timeout; synthesized speech produces `SpeechStarted`/`SpeechEnded`.
- `BargeInTest`: removed the `catch (_: Exception)` wrappers that made failures invisible; timeouts now fail the tests.
- Removed comments that restate the next line and overwrought KDoc; replaced ~100 lines of reflection scaffolding in `ModelManagerManifestTest` with direct calls to the now-internal helpers; merged near-duplicate `ModelDownloadWorkerTest` cases; moved pure parse tests into `FunctionGemmaParserTest`; deleted a trivial constructor test.

Net: −628/+408 lines.

## Test plan

- `./gradlew :sdk:test` — 75 tests each in debug and release, green
- `./gradlew :control-demo:testDebugUnitTest` — 40 tests, green
- `./gradlew :sdk:compileDebugAndroidTestKotlin` — builds; device suites run before the next release per repo policy