### PR TITLE
Fix barge-in e2e fixtures so ResponseInterrupted is reachable

### DIFF
--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/BargeInTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/BargeInTest.kt
@@ -43,13 +43,35 @@ class BargeInTest {
 
     @Test
     fun bargeInDuringSpeakingEmitsInterrupted() = runBlocking {
+        // Both fixtures are synthesized before the first push: loading a second
+        // TTS instance while the pipeline streams its response can starve the
+        // emulator enough that the response finishes before the interruption lands.
+        // Two duration constraints keep this scenario honest. The command must
+        // echo back as many TTS chunks, because the pipeline is interruptible
+        // only while later chunks are still synthesizing — on fast hardware a
+        // short response leaves Speaking almost immediately after the first
+        // delta. And the interruption must sustain speech past the turn
+        // detector's min_interruption_duration (1 s), or it is discarded as
+        // residual echo.
+        val command = synthesize(
+            "The quick brown fox jumps over the lazy dog. The slow white cat " +
+                "watches the quiet garden. A small bird sings in the tall green " +
+                "tree. The old dog sleeps near the warm stone wall. The red fox " +
+                "runs across the wide open field. A grey mouse hides under the " +
+                "wooden floor. The young child reads a long story. The tall man " +
+                "walks along the sandy river bank."
+        )
+        val interruption = synthesize(
+            "Stop talking now because I have a completely different question to ask you."
+        )
+
         val delta = async(start = CoroutineStart.UNDISPATCHED) {
             withTimeout(90_000) {
                 pipeline.events.first { it is SpeechEvent.ResponseAudioDelta }
             }
         }
 
-        pushRealtime(synthesize("The quick brown fox jumps over the lazy dog."))
+        pushRealtime(command)
         pushRealtime(FloatArray(16000)) // 1 s of silence ends the utterance
 
         delta.await() // pipeline is now speaking its echo response
@@ -59,25 +81,44 @@ class BargeInTest {
                 pipeline.events.first { it is SpeechEvent.ResponseInterrupted }
             }
         }
-        pushRealtime(synthesize("Stop talking now."))
+        pushRealtime(interruption)
 
         assertNotNull(interrupted.await())
     }
 
     @Test
     fun pipelineStableAfterBargeIn() = runBlocking {
+        // Two duration constraints keep this scenario honest. The command must
+        // echo back as many TTS chunks, because the pipeline is interruptible
+        // only while later chunks are still synthesizing — on fast hardware a
+        // short response leaves Speaking almost immediately after the first
+        // delta. And the interruption must sustain speech past the turn
+        // detector's min_interruption_duration (1 s), or it is discarded as
+        // residual echo.
+        val command = synthesize(
+            "The quick brown fox jumps over the lazy dog. The slow white cat " +
+                "watches the quiet garden. A small bird sings in the tall green " +
+                "tree. The old dog sleeps near the warm stone wall. The red fox " +
+                "runs across the wide open field. A grey mouse hides under the " +
+                "wooden floor. The young child reads a long story. The tall man " +
+                "walks along the sandy river bank."
+        )
+        val interruption = synthesize(
+            "Stop talking now because I have a completely different question to ask you."
+        )
+
         val delta = async(start = CoroutineStart.UNDISPATCHED) {
             withTimeout(90_000) {
                 pipeline.events.first { it is SpeechEvent.ResponseAudioDelta }
             }
         }
 
-        pushRealtime(synthesize("The quick brown fox jumps over the lazy dog."))
+        pushRealtime(command)
         pushRealtime(FloatArray(16000))
 
         delta.await()
 
-        pushRealtime(synthesize("Stop talking now."))
+        pushRealtime(interruption)
         delay(2_000)
         pipeline.resumeListening()
 


### PR DESCRIPTION
## Summary

PR #58 removed the `catch (_: Exception)` hedges from `BargeInTest`, which exposed that `bargeInDuringSpeakingEmitsInterrupted` had never actually completed: it timed out waiting for `ResponseInterrupted` on every honest run. Three separate causes, found via logcat event forensics on the emulator:

1. The interruption fixture was synthesized mid-test, loading a second TTS instance while the pipeline was streaming its response — on the emulator that contention could end the response before the interruption arrived.
2. The pipeline is interruptible only while TTS chunks are still synthesizing, and the old one-sentence command echoed back as a single chunk, so `Speaking` ended almost immediately after the first `ResponseAudioDelta`.
3. Root cause: "Stop talking now." yields ~1.4 s of speech, and after VAD onset (~0.6 s) only ~0.8 s is sustained — under the turn detector's `min_interruption_duration` of 1.0 s, so the detector correctly discarded it as residual echo.

Fixes: both fixtures are pre-synthesized; the command is 8 sentences so the echo keeps synthesizing well past the first delta even on fast hardware; the interruption phrase sustains ~4 s of speech. Comments in the test document both duration constraints.

## Test plan

- `:sdk:connectedAndroidTest` on the arm64 emulator (Android 15, 4 GB): full suite **38 tests, 0 failures, 1 intentional skip** — including all three `BargeInTest` tests. `ResponseInterrupted` is now observed rather than assumed.
- History: old fixture failed 3/3 runs with a 30 s timeout; new fixture passes class-only and full-suite runs.