### PR TITLE
Fix Maven Central publishing for 0.0.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,22 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Verify documented dependency version
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          expected="implementation(\"audio.soniqo:speech:${VERSION}\")"
+          readmes=(
+            README.md README_zh.md README_ja.md README_ko.md README_es.md
+            README_de.md README_fr.md README_hi.md README_pt.md README_ru.md
+          )
+          for readme in "${readmes[@]}"; do
+            if ! grep -Fq "$expected" "$readme"; then
+              echo "::error file=${readme}::Expected dependency snippet: ${expected}"
+              exit 1
+            fi
+          done
+
       - name: Build SDK
         run: ./gradlew :sdk:assembleRelease
 
@@ -64,6 +80,23 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_SONATYPE_CLOSE_TIMEOUT_SECONDS: 3600
+
+      - name: Verify Maven Central availability
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          artifact_url="https://repo1.maven.org/maven2/audio/soniqo/speech/${VERSION}/speech-${VERSION}.pom"
+          for attempt in {1..40}; do
+            if curl --fail --silent --output /dev/null "$artifact_url"; then
+              echo "Maven Central artifact is available: ${artifact_url}"
+              exit 0
+            fi
+            echo "Waiting for Maven Central availability (${attempt}/40)..."
+            sleep 15
+          done
+          echo "::error::Maven Central artifact did not become available: ${artifact_url}"
+          exit 1
 
       - name: Publish to GitHub Packages
         run: ./gradlew :sdk:publishAllPublicationsToGitHubPackagesRepository --no-configuration-cache -PVERSION_NAME=${{ steps.version.outputs.VERSION }}

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Download the [signed APK](https://github.com/soniqo/speech-android/releases/late
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.9")
+    implementation("audio.soniqo:speech:0.0.13")
 }
 ```
 

--- a/README_de.md
+++ b/README_de.md
@@ -52,7 +52,7 @@ Lade das [signierte APK](https://github.com/soniqo/speech-android/releases/lates
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.9")
+    implementation("audio.soniqo:speech:0.0.13")
 }
 ```
 

--- a/README_es.md
+++ b/README_es.md
@@ -52,7 +52,7 @@ Descarga el [APK firmado](https://github.com/soniqo/speech-android/releases/late
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.9")
+    implementation("audio.soniqo:speech:0.0.13")
 }
 ```
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -52,7 +52,7 @@ Téléchargez l'[APK signé](https://github.com/soniqo/speech-android/releases/l
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.9")
+    implementation("audio.soniqo:speech:0.0.13")
 }
 ```
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -52,7 +52,7 @@ Android के लिए ऑन-डिवाइस स्पीच SDK, [ONNX Ru
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.9")
+    implementation("audio.soniqo:speech:0.0.13")
 }
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -52,7 +52,7 @@
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.9")
+    implementation("audio.soniqo:speech:0.0.13")
 }
 ```
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -52,7 +52,7 @@
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.9")
+    implementation("audio.soniqo:speech:0.0.13")
 }
 ```
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -52,7 +52,7 @@ Baixe o [APK assinado](https://github.com/soniqo/speech-android/releases/latest/
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.9")
+    implementation("audio.soniqo:speech:0.0.13")
 }
 ```
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -52,7 +52,7 @@
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.9")
+    implementation("audio.soniqo:speech:0.0.13")
 }
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -52,7 +52,7 @@
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.9")
+    implementation("audio.soniqo:speech:0.0.13")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,5 +5,5 @@ plugins {
     // Kotlin 2.2 compiler used by the full-pipeline Compose demo.
     id("org.jetbrains.kotlin.android") version "2.2.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.2.21" apply false
-    id("com.vanniktech.maven.publish") version "0.30.0" apply false
+    id("com.vanniktech.maven.publish") version "0.35.0" apply false
 }

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -72,8 +72,9 @@ mavenPublishing {
 
         licenses {
             license {
-                name.set("MIT License")
-                url.set("https://github.com/soniqo/speech-android/blob/main/LICENSE")
+                name.set("Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
             }
         }
 
@@ -92,7 +93,7 @@ mavenPublishing {
         }
     }
 
-    publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
     signAllPublications()
 }
 


### PR DESCRIPTION
## Summary

- upgrade the Vanniktech publishing plugin to 0.35.0 so Central deployment validation is awaited
- use the current Central Portal configuration and correct the generated POM license to Apache-2.0
- document audio.soniqo:speech:0.0.13 in every README translation and enforce tag/documentation agreement in the release workflow
- verify the published POM is available from Maven Central before continuing the release

The SDK version remains 0.0.13; 0.35.0 is only the publishing plugin version.

## Test plan

- [x] ./gradlew :sdk:test
- [x] ./gradlew :control-demo:testDebugUnitTest
- [x] generate and validate the 0.0.13 Maven POM
- [x] publish 0.0.13-SNAPSHOT to a temporary Maven repository and assemble a separate Android consumer
- [x] actionlint .github/workflows/release.yml
- [ ] ./gradlew :sdk:connectedAndroidTest (required before tagging the release)

Fixes #60