### PR TITLE
First-run download UX: byte-weighted progress + ETA, and fix Control startup permissions

### DIFF
--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlAgentActivity.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlAgentActivity.kt
@@ -101,6 +101,9 @@ class ControlAgentActivity : ComponentActivity() {
 
     private var pipelineStarted = false
     private var observingDownload = false
+    // True between a mic tap and the mic being stopped. Gates the permission
+    // callback so the startup request can't switch capture on unasked.
+    private var micRequested = false
     // STT model override for on-device A/B: `--es stt_model PARAKEET` selects
     // the 0.6B TDT v3; unset keeps DEMO_STT. Read before models load.
     private var sttOverride: String? = null
@@ -120,6 +123,12 @@ class ControlAgentActivity : ComponentActivity() {
     // grammar and the brand, plus the track titles/artists currently on the
     // device. The command core is always present; without media permission
     // listMusic() returns empty and only the fixed phrases apply.
+    //
+    // Reads the library through the silent [listMusicOrEmpty]: this runs during
+    // startup, and a user who has not yet answered the permission dialog should
+    // not see a "media permission not granted" note about a request they were
+    // never shown. The music tools still report the denial, because there it is
+    // what made the command fail.
     private fun buildContextPhrases(): List<String> {
         val phrases = mutableListOf(
             "Soniqo",
@@ -131,7 +140,7 @@ class ControlAgentActivity : ComponentActivity() {
             "what can you do",
         )
         runCatching {
-            device.listMusic(null).forEach { t ->
+            device.listMusicOrEmpty(null).forEach { t ->
                 if (t.title.isNotBlank()) phrases.add(t.title)
                 t.artist?.let { if (it.isNotBlank()) phrases.add(it) }
             }
@@ -139,11 +148,19 @@ class ControlAgentActivity : ComponentActivity() {
         return phrases.map { it.trim() }.filter { it.isNotEmpty() }.distinct()
     }
 
+    /** Push the current biasing set at the pipeline, if one is running. */
+    private fun applyContextPhrases() {
+        if (EOU_BEAM_SIZE <= 1) return
+        pipeline?.let { runCatching { it.setContextPhrases(buildContextPhrases()) } }
+    }
+
     private var speechStartMs = 0L
     private var speechEndMs = 0L
 
     companion object {
         private const val TAG = "SpeechControl"
+
+        private const val REQ_PERMISSIONS = 1
 
         // STT model for the demo. PARAKEET_EOU is the low-memory default
         // (25 languages, ~232 MB) — fast, ~2 s round trip, ~1.3 GB total.
@@ -204,7 +221,41 @@ class ControlAgentActivity : ComponentActivity() {
             }
         }
         bench("baseline")
+        // Ask up front rather than on the first mic tap. The models take
+        // minutes to download, and the dialogs are dead time that fits inside
+        // it — but more importantly the demo reads contacts and the music
+        // library during startup (STT biasing) and on the very first command,
+        // so deferring the request produced "permission not granted" notes for
+        // dialogs the user had never been shown.
+        requestDemoPermissions()
         loadModels()
+    }
+
+    /**
+     * The runtime permissions the demo needs, requested as one batch. Android
+     * shows them as a sequence of per-group dialogs. On API 33+ the media
+     * permission is READ_MEDIA_AUDIO, which the system surfaces under
+     * "Music and audio" — not the pre-13 "Files and media" storage group.
+     */
+    private fun demoPermissions(): Array<String> = buildList {
+        add(Manifest.permission.RECORD_AUDIO)
+        add(Manifest.permission.READ_CONTACTS)
+        add(mediaPermission)
+        // Without this the foreground download worker runs but its progress
+        // notification is silently dropped, so leaving the app looks like the
+        // download stopped.
+        if (Build.VERSION.SDK_INT >= 33) add(Manifest.permission.POST_NOTIFICATIONS)
+    }.toTypedArray()
+
+    private fun missingPermissions(): List<String> = demoPermissions().filter {
+        checkSelfPermission(it) != PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun requestDemoPermissions() {
+        val missing = missingPermissions()
+        if (missing.isNotEmpty()) {
+            ActivityCompat.requestPermissions(this, missing.toTypedArray(), REQ_PERMISSIONS)
+        }
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -302,6 +353,16 @@ class ControlAgentActivity : ComponentActivity() {
                             store.setStatus("downloading $label")
                             store.setDownloadStage(label)
                             store.setDownload(info.progress.getInt(ModelDownloadWorker.KEY_PERCENT, 0))
+                            // Byte counts, rate and ETA. The LLM bundle alone is
+                            // ~290 MB, so without this the panel gives no way to
+                            // tell a slow link from a stalled one.
+                            store.setDownloadDetail(ModelDownloadWorker.detailLine(
+                                info.progress.getLong(
+                                    ModelDownloadWorker.KEY_TOTAL_BYTES_DOWNLOADED, 0L),
+                                info.progress.getLong(ModelDownloadWorker.KEY_TOTAL_BYTES, 0L),
+                                info.progress.getLong(ModelDownloadWorker.KEY_BYTES_PER_SEC, 0L),
+                                info.progress.getLong(ModelDownloadWorker.KEY_ETA_SECONDS, -1L),
+                            ))
                         }
                     }
                     WorkInfo.State.SUCCEEDED -> {
@@ -354,8 +415,9 @@ class ControlAgentActivity : ComponentActivity() {
                 p.start()
                 // Bias recognition toward the command grammar, the brand, and
                 // whatever music is on this device right now. No-op in greedy
-                // mode; only meaningful once EOU_BEAM_SIZE > 1.
-                if (EOU_BEAM_SIZE > 1) p.setContextPhrases(buildContextPhrases())
+                // mode; only meaningful once EOU_BEAM_SIZE > 1. Rebuilt by
+                // onRequestPermissionsResult if the media grant lands later.
+                applyContextPhrases()
 
                 store.setStatus("downloading language model")
                 store.setDownloadStage("language model")
@@ -364,11 +426,16 @@ class ControlAgentActivity : ComponentActivity() {
                     applicationContext,
                     llmModel = llmProfile,
                 ) { prog ->
-                    if (prog.fileTotalBytes > 0) {
-                        store.setDownload((prog.bytesDownloaded * 100 / prog.fileTotalBytes).toInt())
+                    // Normally a no-op: the worker already fetched the bundle
+                    // with includeLlm = true, so this just revalidates. It only
+                    // streams when that worker path failed and left it behind.
+                    if (prog.totalBytes > 0) {
+                        store.setDownload(ModelDownloadWorker.progressPercent(
+                            prog.totalBytesDownloaded, prog.totalBytes))
+                        store.setDownloadDetail(ModelDownloadWorker.detailLine(
+                            prog.totalBytesDownloaded, prog.totalBytes, 0L, -1L))
                     }
-                    store.setStatus("downloading language model · " +
-                        "${prog.bytesDownloaded / 1_000_000}/${prog.fileTotalBytes / 1_000_000} MB")
+                    store.setStatus("downloading language model")
                 }
                 val adapterPath = requireNotNull(
                     ModelManager.llmAdapterFile(applicationContext, llmProfile),
@@ -387,6 +454,7 @@ class ControlAgentActivity : ComponentActivity() {
 
                 ready = true
                 store.setDownload(null)
+                store.setDownloadDetail(null)
                 store.setMic(MicState.IDLE)
                 store.setStatus("ready · on-device")
                 p.nnapiFallbackReason?.let { Log.w(TAG, "NNAPI unavailable, using CPU: $it") }
@@ -776,6 +844,18 @@ class ControlAgentActivity : ComponentActivity() {
             if (checkSelfPermission(mediaPermission) != PackageManager.PERMISSION_GRANTED) {
                 store.addNote("media permission not granted"); return emptyList()
             }
+            return listMusicOrEmpty(query)
+        }
+
+        /**
+         * [listMusic] without the feed note. For callers where an empty library
+         * is a normal outcome rather than a failed command — STT biasing runs
+         * at startup, possibly before the permission dialog has been answered.
+         */
+        fun listMusicOrEmpty(query: String?): List<Track> {
+            if (checkSelfPermission(mediaPermission) != PackageManager.PERMISSION_GRANTED) {
+                return emptyList()
+            }
             val selection = query?.let {
                 "(${MediaStore.Audio.Media.TITLE} LIKE ? OR ${MediaStore.Audio.Media.ARTIST} LIKE ?)"
             }
@@ -847,18 +927,18 @@ class ControlAgentActivity : ComponentActivity() {
 
     private fun toggleMicrophone() {
         if (recording) {
+            micRequested = false
             stopMicrophone()
             store.setMic(MicState.IDLE)
             store.setStatus("tap to talk")
         } else {
-            val wanted = arrayOf(Manifest.permission.RECORD_AUDIO,
-                Manifest.permission.READ_CONTACTS, mediaPermission)
-            val missing = wanted.filter {
-                checkSelfPermission(it) != PackageManager.PERMISSION_GRANTED
-            }
-            if (missing.isNotEmpty()) {
-                ActivityCompat.requestPermissions(this, missing.toTypedArray(), 1); return
-            }
+            micRequested = true
+            // Normally already granted from onCreate; re-asking covers a user
+            // who dismissed the dialog during setup. Android returns an instant
+            // denial once a permission is permanently denied, and
+            // onRequestPermissionsResult still starts the mic if RECORD_AUDIO
+            // itself came through, so the button never becomes inert.
+            if (missingPermissions().isNotEmpty()) { requestDemoPermissions(); return }
             startMicrophone()
         }
     }
@@ -867,7 +947,20 @@ class ControlAgentActivity : ComponentActivity() {
         requestCode: Int, permissions: Array<String>, results: IntArray,
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, results)
-        if (requestCode == 1 &&
+        if (requestCode != REQ_PERMISSIONS) return
+
+        // Biasing was built during startup, when the media permission was
+        // likely still unanswered and the library read as empty. Now that there
+        // is an answer, rebuild it — otherwise track titles never reach the
+        // decoder until the app is restarted.
+        if (permissions.contains(mediaPermission) &&
+            checkSelfPermission(mediaPermission) == PackageManager.PERMISSION_GRANTED) {
+            applyContextPhrases()
+        }
+        // Only start capturing if the user asked for it: onCreate requests
+        // permissions before any mic tap, and a grant there must not switch the
+        // microphone on by itself.
+        if (micRequested &&
             checkSelfPermission(Manifest.permission.RECORD_AUDIO)
                 == PackageManager.PERMISSION_GRANTED) {
             startMicrophone()

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlStore.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/ControlStore.kt
@@ -30,6 +30,8 @@ data class ControlUiState(
     val downloadPercent: Int? = null,
     /** Friendly label of the model currently downloading (for the setup panel). */
     val downloadStage: String? = null,
+    /** `412 / 580 MB · 3.6 MB/s · 2 min left`, or null before the rate settles. */
+    val downloadDetail: String? = null,
     val memNowMb: Int = 0,
     val memPeakMb: Int = 0,
     /** Latencies of the most recent completed turn, for the status line. */
@@ -61,6 +63,8 @@ class ControlStore {
     fun setDownload(percent: Int?) = _state.update { it.copy(downloadPercent = percent) }
 
     fun setDownloadStage(stage: String?) = _state.update { it.copy(downloadStage = stage) }
+
+    fun setDownloadDetail(detail: String?) = _state.update { it.copy(downloadDetail = detail) }
 
     fun setMemory(nowMb: Int, peakMb: Int) =
         _state.update { it.copy(memNowMb = nowMb, memPeakMb = peakMb) }

--- a/control-demo/src/main/kotlin/audio/soniqo/speech/control/ui/ControlScreen.kt
+++ b/control-demo/src/main/kotlin/audio/soniqo/speech/control/ui/ControlScreen.kt
@@ -90,7 +90,10 @@ fun ControlScreen(
             .windowInsetsPadding(WindowInsets.safeDrawing),
     ) {
         Header(state, actions)
-        Chat(state.feed, state.downloadPercent != null, state.downloadStage, Modifier.weight(1f))
+        Chat(
+            state.feed, state.downloadPercent != null, state.downloadStage,
+            state.downloadDetail, Modifier.weight(1f),
+        )
         OrbDock(state, actions, reduceMotion)
         StatusLine(state)
     }
@@ -173,6 +176,7 @@ private fun Chat(
     feed: List<FeedItem>,
     setupVisible: Boolean,
     setupStage: String?,
+    setupDetail: String?,
     modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
@@ -181,7 +185,7 @@ private fun Chat(
     }
     Box(modifier.fillMaxWidth()) {
         if (setupVisible) {
-            SetupPanel(setupStage, Modifier.align(Alignment.Center))
+            SetupPanel(setupStage, setupDetail, Modifier.align(Alignment.Center))
         } else if (feed.none { it is Turn }) {
             EmptyHint(Modifier.align(Alignment.Center))
         }
@@ -211,13 +215,17 @@ private fun Chat(
 }
 
 /**
- * First-run setup panel — the model download (~800 MB, one time). Progress
+ * First-run setup panel — the model download (~600 MB, one time). Progress
  * is shown as one dot per model, filling as each finishes, rather than raw
- * filenames. The bundle downloads in a foreground worker, so it continues
- * while the app is backgrounded.
+ * filenames, plus a bytes/rate/ETA line. The bundle downloads in a foreground
+ * worker, so it continues while the app is backgrounded.
  */
 @Composable
-private fun SetupPanel(currentStage: String?, modifier: Modifier = Modifier) {
+private fun SetupPanel(
+    currentStage: String?,
+    detail: String?,
+    modifier: Modifier = Modifier,
+) {
     // Download order = dot order. Each model is one dot.
     val models = listOf(
         "voice detection", "transcription model", "speech synthesis", "language model",
@@ -239,7 +247,7 @@ private fun SetupPanel(currentStage: String?, modifier: Modifier = Modifier) {
         Text("Setting up", color = Foreground, fontFamily = Grotesk,
             fontWeight = FontWeight.Bold, fontSize = 20.sp)
         Spacer(Modifier.height(8.dp))
-        Text("Downloading the models — about 800 MB, one time. Everything runs " +
+        Text("Downloading the models — about 600 MB, one time. Everything runs " +
             "on your phone and the download continues if you leave.",
             color = MutedFg, fontFamily = Grotesk, fontSize = 13.5.sp, lineHeight = 19.sp,
             textAlign = androidx.compose.ui.text.style.TextAlign.Center)
@@ -257,6 +265,14 @@ private fun SetupPanel(currentStage: String?, modifier: Modifier = Modifier) {
         Spacer(Modifier.height(12.dp))
         Text("${current + 1} of ${models.size}", color = FaintFg, fontFamily = Plex,
             fontSize = 11.sp)
+        // Bytes, rate and ETA. The dots alone can't distinguish a slow link
+        // from a stalled one — the ~290 MB LLM bundle sits inside a single dot
+        // for minutes.
+        detail?.let {
+            Spacer(Modifier.height(6.dp))
+            Text(it, color = FaintFg, fontFamily = Plex, fontSize = 11.sp,
+                maxLines = 1, overflow = TextOverflow.Ellipsis)
+        }
     }
 }
 

--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/KokoroPrecisionRegressionTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/KokoroPrecisionRegressionTest.kt
@@ -1,0 +1,127 @@
+package audio.soniqo.speech
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Precision A/B for the Kokoro weights, run once per candidate model directory.
+ *
+ * Point it at the published fp32 bundle, then at a candidate, and diff the
+ * dumps. Everything it emits is deterministic for a fixed model: synthesis is
+ * seeded only by the text and the voice embedding here, so any difference
+ * between two runs is the weights.
+ *
+ * The long phrases are the point. Kokoro's vocoder sums over the time axis, so
+ * a reduced-precision build can measure clean on a one-second reply and still
+ * collapse past two seconds — the failure scales with utterance length, not
+ * with the weights alone. A regression check that only synthesizes "playing
+ * music" will not see it.
+ *
+ * ```
+ * ./gradlew :sdk:connectedAndroidTest \
+ *   -Pandroid.testInstrumentationRunnerArguments.class=audio.soniqo.speech.KokoroPrecisionRegressionTest \
+ *   -Pandroid.testInstrumentationRunnerArguments.kokoroModelDir=/data/.../kok32 \
+ *   -Pandroid.testInstrumentationRunnerArguments.kokoroDumpDir=/data/.../dump32
+ * ```
+ */
+@RunWith(AndroidJUnit4::class)
+class KokoroPrecisionRegressionTest {
+
+    private val phrases = listOf(
+        "playing music",
+        "I stopped the music",
+        "sorry, I can't do that",
+        // Past the ~2 s mark, where time-axis accumulation shows up.
+        "I can call a contact, play music, or set the volume",
+        "I can call a contact, play music, or set the volume, " +
+            "and I can also stop the music or dial a number for you",
+    )
+
+    @Test
+    fun synthesizesEveryPhraseAndDumpsPcm() {
+        val args = InstrumentationRegistry.getArguments()
+        val modelDir = args.getString("kokoroModelDir")
+        assumeTrue("set -e kokoroModelDir to run the Kokoro precision test", !modelDir.isNullOrBlank())
+        assumeTrue(File(modelDir!!, "kokoro-e2e-realtime.onnx").isFile)
+        assumeTrue(File(modelDir, "kokoro-e2e.onnx.data").isFile)
+
+        // Resolved under the app's own files directory: the test process can
+        // read a model dir staged in /data/local/tmp but cannot create anything
+        // there, so an absolute path would fail with ENOENT on the first write.
+        val dumpDir = args.getString("kokoroDumpDir")?.let { name ->
+            File(
+                InstrumentationRegistry.getInstrumentation().targetContext.filesDir,
+                File(name).name,
+            ).apply { mkdirs() }
+        }
+
+        SpeechSynthesizer(
+            SpeechSynthesizerConfig(
+                modelDir = modelDir,
+                useNnapi = false,
+                ttsModel = TtsModel.KOKORO_SHORT_TURN,
+            )
+        ).use { synthesizer ->
+            assertEquals(24_000, synthesizer.sampleRate)
+
+            phrases.forEachIndexed { index, text ->
+                val result = synthesizer.synthesize(text, "en")
+                assertEquals(24_000, result.sampleRate)
+                assertTrue("[$index] PCM must not be empty", result.pcm16.isNotEmpty())
+                assertTrue("[$index] PCM must contain audio", result.pcm16.any { it != 0.toByte() })
+
+                // A collapsed build still emits bytes, so check the signal has
+                // real amplitude rather than just being non-zero.
+                val samples = ShortArray(result.pcm16.size / 2) { i ->
+                    ((result.pcm16[i * 2].toInt() and 0xFF) or
+                        (result.pcm16[i * 2 + 1].toInt() shl 8)).toShort()
+                }
+                var sumSquares = 0.0
+                var peak = 0
+                for (s in samples) {
+                    val v = s.toInt()
+                    sumSquares += v.toDouble() * v
+                    if (kotlin.math.abs(v) > peak) peak = kotlin.math.abs(v)
+                }
+                val rms = kotlin.math.sqrt(sumSquares / samples.size.coerceAtLeast(1))
+                val seconds = samples.size / 24_000.0
+
+                // Half-second RMS profile, not just a single figure. A build
+                // that degrades with utterance length looks fine on the
+                // aggregate — the earlier fp16 attempt held level for two
+                // seconds and then fell to a quarter of it — so the shape over
+                // time is what actually has to match between two runs.
+                val window = 12_000
+                val profile = (0 until (samples.size + window - 1) / window).map { w ->
+                    val from = w * window
+                    val to = minOf(from + window, samples.size)
+                    var acc = 0.0
+                    for (i in from until to) acc += samples[i].toDouble() * samples[i]
+                    kotlin.math.sqrt(acc / (to - from).coerceAtLeast(1))
+                }
+
+                // Machine-readable so two runs can be diffed straight from logcat.
+                android.util.Log.i(
+                    "KOKORO_AB",
+                    "idx=$index samples=${samples.size} sec=%.3f rms=%.1f peak=%d profile=%s text=%s"
+                        .format(
+                            seconds, rms, peak,
+                            profile.joinToString(",") { "%.0f".format(it) },
+                            text,
+                        )
+                )
+
+                assertTrue("[$index] audio suspiciously quiet (rms=$rms)", rms > 50.0)
+                assertTrue("[$index] audio suspiciously short (${seconds}s)", seconds > 0.2)
+
+                dumpDir?.let { File(it, "phrase_$index.pcm").writeBytes(result.pcm16) }
+            }
+        }
+    }
+}

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
@@ -79,6 +79,30 @@ class ModelDownloadWorker(
 
         runCatching { setForeground(buildForegroundInfo(0, "Preparing speech models…")) }
 
+        // The pipeline models and the LLM bundle are two back-to-back
+        // ensure*() calls, each reporting bytes only for its own set. Planning
+        // both up front lets them render as one continuous 0→100 bar instead
+        // of two sweeps that visibly reset to zero in the middle.
+        val plannedPipeline = ModelManager.plannedModelBytes(
+            applicationContext, precision, sttModel, sttBackend, ttsModel,
+        )
+        val plannedLlm =
+            if (includeLlm) ModelManager.plannedLlmBytes(applicationContext, llmModel) else 0L
+
+        // Bytes attributed to phases that have already finished, and bytes
+        // planned for phases not yet started. Both are folded into every
+        // sample so the numerator and denominator span the whole download.
+        var phaseBase = 0L
+        var laterPhases = plannedLlm
+
+        // Rate is measured from the first sample rather than from bytes
+        // already on disk, so resuming a partial download doesn't report an
+        // instant multi-hundred-MB/s spike.
+        var startedAtNanos = 0L
+        var baselineBytes = 0L
+        var lastPct = 0
+        var lastDone = 0L
+
         // Only rebuild the foreground notification when the integer percent or
         // the file changes — the underlying progress callback is already
         // throttled to ~1 MB, but re-posting a Notification on every tick still
@@ -86,12 +110,33 @@ class ModelDownloadWorker(
         var lastNotifiedPct = -1
         var lastNotifiedFile = ""
         val report: (ModelManager.Progress) -> Unit = { p ->
-            val pct = progressPercent(
-                p.completed,
-                p.totalFiles,
-                p.bytesDownloaded,
-                p.fileTotalBytes,
-            )
+            val done = phaseBase + p.totalBytesDownloaded
+            val total = phaseBase + p.totalBytes + laterPhases
+            lastDone = done
+
+            if (startedAtNanos == 0L) {
+                startedAtNanos = System.nanoTime()
+                baselineBytes = done
+            }
+            val elapsedSec = (System.nanoTime() - startedAtNanos) / 1_000_000_000.0
+            val transferred = done - baselineBytes
+            // Below a second of samples the rate is mostly noise; suppress it
+            // rather than show an ETA that swings by minutes.
+            val bytesPerSec =
+                if (elapsedSec >= 1.0 && transferred > 0) (transferred / elapsedSec).toLong() else 0L
+            val etaSec =
+                if (bytesPerSec > 0 && total > done) (total - done) / bytesPerSec else -1L
+
+            // Byte-weighted when a total is known, else the legacy file-count
+            // estimate. Clamped monotonic: refining the total against a real
+            // Content-Length can otherwise nudge the bar backwards.
+            val pct = if (total > 0) {
+                progressPercent(done, total)
+            } else {
+                progressPercent(p.completed, p.totalFiles, p.bytesDownloaded, p.fileTotalBytes)
+            }.coerceAtLeast(lastPct)
+            lastPct = pct
+
             setProgressAsync(workDataOf(
                 KEY_FILE to p.file,
                 KEY_COMPLETED to p.completed,
@@ -99,6 +144,10 @@ class ModelDownloadWorker(
                 KEY_BYTES_DOWNLOADED to p.bytesDownloaded,
                 KEY_FILE_TOTAL_BYTES to p.fileTotalBytes,
                 KEY_PERCENT to pct,
+                KEY_TOTAL_BYTES_DOWNLOADED to done,
+                KEY_TOTAL_BYTES to total,
+                KEY_BYTES_PER_SEC to bytesPerSec,
+                KEY_ETA_SECONDS to etaSec,
             ))
             if (pct != lastNotifiedPct || p.file != lastNotifiedFile) {
                 lastNotifiedPct = pct
@@ -106,8 +155,7 @@ class ModelDownloadWorker(
                 runCatching {
                     setForegroundAsync(buildForegroundInfo(
                         percent = pct,
-                        text = "${p.file}  ${formatMb(p.bytesDownloaded)}/${formatMb(p.fileTotalBytes)}" +
-                            "  ·  ${p.completed}/${p.totalFiles}",
+                        text = detailLine(done, total, bytesPerSec, etaSec),
                     ))
                 }
             }
@@ -123,6 +171,12 @@ class ModelDownloadWorker(
                 onProgress = report,
             )
             if (includeLlm) {
+                // Hand the bar over to the LLM phase: what the pipeline phase
+                // actually transferred is now behind us, and nothing is ahead.
+                // Falls back to the estimate when the pipeline was fully cached
+                // and never reported a sample.
+                phaseBase = if (lastDone > 0L) lastDone else plannedPipeline
+                laterPhases = 0L
                 ModelManager.ensureLlmModels(
                     applicationContext,
                     llmModel = llmModel,
@@ -176,6 +230,55 @@ class ModelDownloadWorker(
         const val UNIQUE_NAME = "audio.soniqo.speech.modelDownload"
 
         /**
+         * Byte-weighted completion percent (0-100) over the whole download.
+         *
+         * The file-count form below weights a 2 KB `config.json` the same as a
+         * 325 MB weights blob, so on the default manifest the bar sprints
+         * through fifteen small assets and then appears frozen for minutes on
+         * the two files that are ~93% of the transfer. Scaling by bytes makes
+         * the bar advance at the rate the network actually delivers.
+         *
+         * Pure + side-effect free so it is unit-testable.
+         */
+        fun progressPercent(bytesDownloaded: Long, totalBytes: Long): Int {
+            if (totalBytes <= 0L) return 0
+            return ((bytesDownloaded.toDouble() / totalBytes) * 100.0)
+                .toInt().coerceIn(0, 100)
+        }
+
+        /**
+         * Human-readable transfer line: `412 / 789 MB · 3.6 MB/s · 2 min left`.
+         * Rate and ETA are dropped until there is enough history to make them
+         * meaningful, so the text degrades to just the byte counts.
+         */
+        fun detailLine(
+            bytesDownloaded: Long,
+            totalBytes: Long,
+            bytesPerSec: Long,
+            etaSeconds: Long,
+        ): String = buildList {
+            add(
+                if (totalBytes > 0) {
+                    "%.0f / %.0f MB".format(
+                        bytesDownloaded / 1_000_000.0, totalBytes / 1_000_000.0,
+                    )
+                } else {
+                    "%.0f MB".format(bytesDownloaded / 1_000_000.0)
+                }
+            )
+            if (bytesPerSec > 0) add("%.1f MB/s".format(bytesPerSec / 1_000_000.0))
+            if (etaSeconds >= 0) add("${formatEta(etaSeconds)} left")
+        }.joinToString(" · ")
+
+        // Minutes round rather than truncate: flooring reports 105 s as
+        // "1 min left", which then sits there for nearly two.
+        private fun formatEta(seconds: Long): String = when {
+            seconds < 60 -> "${seconds}s"
+            seconds < 3600 -> "${(seconds + 30) / 60} min"
+            else -> "%.1f h".format(seconds / 3600.0)
+        }
+
+        /**
          * Download completion percent (0-100) that advances *continuously* as
          * the current file streams, instead of only when a whole file lands.
          * It is the count of fully-finished files plus the fraction of the
@@ -221,6 +324,15 @@ class ModelDownloadWorker(
         const val KEY_BYTES_DOWNLOADED = "bytesDownloaded"
         const val KEY_FILE_TOTAL_BYTES = "fileTotalBytes"
         const val KEY_PERCENT = "percent"
+
+        /** Bytes transferred so far across the whole download (Long). */
+        const val KEY_TOTAL_BYTES_DOWNLOADED = "totalBytesDownloaded"
+        /** Estimated size of the whole download (Long); 0 when unknown. */
+        const val KEY_TOTAL_BYTES = "totalBytes"
+        /** Observed transfer rate (Long, bytes/sec); 0 until it settles. */
+        const val KEY_BYTES_PER_SEC = "bytesPerSec"
+        /** Seconds remaining at the current rate (Long); -1 when unknown. */
+        const val KEY_ETA_SECONDS = "etaSeconds"
 
         private const val CHANNEL_ID = "audio.soniqo.speech.models"
         // Stable, unlikely-to-collide id (decimal of 0xC0FFEE).

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -771,6 +771,15 @@ object ModelManager {
         "kokoro-e2e.onnx" to 3_047_254L,
         "kokoro-e2e-realtime.onnx" to 2_413_312L,
         "kokoro-e2e.onnx.data" to 324_564_624L,
+        // Pocket TTS bundle — the Control demo's default TTS, so these matter
+        // for its bar; without them the total under-counts by ~126 MB and then
+        // visibly grows as the files self-correct to Content-Length.
+        "decoder.int8.onnx" to 22_695_710L,
+        "encoder.onnx" to 512_407L,
+        "lm_flow.int8.onnx" to 9_962_530L,
+        "lm_main.int8.onnx" to 76_341_079L,
+        "text_conditioner.onnx" to 16_388_498L,
+        "token_scores.json" to 123_617L,
         "us_gold.json" to 3_000_469L,
         "us_silver.json" to 3_099_517L,
         "dict_fr.json" to 51_497L,

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -200,6 +200,18 @@ object ModelManager {
         val fileTotalBytes: Long,
         val totalFiles: Int,
         val completed: Int,
+        /**
+         * Bytes on disk across every file this call still had to fetch —
+         * finished files plus the one in flight. Cached files contribute
+         * nothing, so this counts only what the transfer is responsible for.
+         */
+        val totalBytesDownloaded: Long = 0L,
+        /**
+         * Best estimate of [totalBytesDownloaded]'s ceiling, seeded from
+         * [EXPECTED_SIZES] and corrected to the real `Content-Length` as each
+         * file's response header arrives. 0 when nothing needs downloading.
+         */
+        val totalBytes: Long = 0L,
     )
 
     // Report intra-file byte progress at most this often. Without throttling,
@@ -450,6 +462,18 @@ object ModelManager {
         allFiles: List<ModelFile>,
         onProgress: ((Progress) -> Unit)?,
     ) {
+        // Byte budget for the progress bar. Weighting every file equally makes
+        // the bar lurch through the small JSON assets and then sit still for
+        // minutes on the two files that are ~93% of the bytes, so the bar is
+        // driven by bytes instead. Cached files are excluded from both sides of
+        // the ratio: the bar measures the transfer, not the manifest.
+        val pending = allFiles.filterNot { model ->
+            File(dir, model.localFilename).let { it.exists() && isValidModel(it, model.filename) }
+        }
+        var totalBytes = pending.sumOf { expectedBytes(it) }
+        // Bytes belonging to files this call has already finished.
+        var priorBytes = 0L
+
         var completed = 0
         for (model in allFiles) {
             val dest = File(dir, model.localFilename)
@@ -464,12 +488,81 @@ object ModelManager {
             }
             dest.parentFile?.mkdirs()
 
+            // Replaced by the real Content-Length on the first callback, which
+            // keeps [totalBytes] honest even when EXPECTED_SIZES is stale.
+            var expected = expectedBytes(model)
+            var fileBytes = 0L
+
             val url = "$BASE_URL/${model.repo}/resolve/${model.revision}/${model.filename}"
             downloadFile(url, dest) { bytes, fileTotal ->
-                onProgress?.invoke(Progress(model.localFilename, bytes, fileTotal, allFiles.size, completed))
+                if (fileTotal > 0 && fileTotal != expected) {
+                    totalBytes += fileTotal - expected
+                    expected = fileTotal
+                }
+                fileBytes = bytes
+                onProgress?.invoke(Progress(
+                    file = model.localFilename,
+                    bytesDownloaded = bytes,
+                    fileTotalBytes = fileTotal,
+                    totalFiles = allFiles.size,
+                    completed = completed,
+                    totalBytesDownloaded = priorBytes + bytes,
+                    totalBytes = totalBytes,
+                ))
             }
+            // Prefer the observed byte count; fall back to the estimate when the
+            // server advertised no length, so the running total still advances.
+            priorBytes += maxOf(fileBytes, expected)
             completed++
         }
+    }
+
+    /**
+     * Estimated bytes [ensureModels] must transfer for this configuration —
+     * expected sizes of every file not already cached and valid, or the whole
+     * manifest when the cache is stale and about to be cleared. 0 when
+     * everything needed is already on disk.
+     *
+     * Lets a caller driving two downloads back to back (pipeline models then
+     * the LLM bundle) render them as one continuous bar instead of two sweeps.
+     */
+    fun plannedModelBytes(
+        context: Context,
+        precision: ModelPrecision = ModelPrecision.INT8,
+        sttModel: SttModel = SttModel.PARAKEET_EOU,
+        sttBackend: SttBackend = SttBackend.ONNX,
+        ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
+    ): Long {
+        val dir = modelDirFile(context, precision, sttModel, sttBackend, ttsModel)
+        val stale = cacheIsStale(dir, modelSetKey(precision, sttModel, sttBackend, ttsModel))
+        return plannedBytes(dir, models(precision, sttModel, sttBackend, ttsModel), stale)
+    }
+
+    /** [plannedModelBytes] for the FunctionGemma bundle fetched by [ensureLlmModels]. */
+    fun plannedLlmBytes(
+        context: Context,
+        llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
+    ): Long {
+        val dir = File(llmModelDir(context, llmModel))
+        // Mirrors ensureLlmModels: a directory with no markers is a fresh or
+        // in-progress download, never a stale cache to be wiped.
+        val hadMarkers = File(dir, "version.txt").exists() || File(dir, MODEL_SET_FILENAME).exists()
+        val stale = hadMarkers && cacheIsStale(dir, llmModelSetKey(llmModel))
+        return plannedBytes(dir, llmModels(llmModel), stale)
+    }
+
+    private fun plannedBytes(dir: File, files: List<ModelFile>, stale: Boolean): Long =
+        files.sumOf { model ->
+            val dest = File(dir, model.localFilename)
+            if (!stale && dest.exists() && isValidModel(dest, model.filename)) 0L
+            else expectedBytes(model)
+        }
+
+    private fun cacheIsStale(dir: File, wantedModelSet: String): Boolean {
+        if (!dir.exists()) return true
+        val cached = File(dir, "version.txt").takeIf { it.exists() }
+            ?.readText()?.trim()?.toIntOrNull() ?: 0
+        return cached < MODEL_VERSION || cachedModelSet(dir) != wantedModelSet
     }
 
     @VisibleForTesting
@@ -656,6 +749,43 @@ object ModelManager {
         // ensureModels() invocation after WorkManager's backoff window.
         throw IOException("Download failed after $maxRetries attempts: ${lastException?.message}", lastException)
     }
+
+    /**
+     * Published sizes of the model files, used to seed a byte-weighted
+     * progress bar before any response header has arrived. Only an estimate:
+     * [downloadMissingModels] corrects each entry to the real `Content-Length`
+     * as the download starts, so a stale value costs bar accuracy for a moment
+     * and nothing else. Files absent here are assumed [DEFAULT_EXPECTED_BYTES]
+     * (they are all small JSON assets).
+     *
+     * Keyed by repo filename like [MIN_SIZES], so the handful of names shared
+     * between bundles (Pocket and Parakeet both ship `vocab.json`, Pocket and
+     * Nemotron both ship `encoder.onnx`) collide. All of them are small enough
+     * that the mis-estimate is immaterial to the bar.
+     */
+    private val EXPECTED_SIZES = mapOf(
+        "silero-vad.onnx" to 2_243_022L,
+        "parakeet-eou-encoder.onnx" to 131_741_896L,
+        "parakeet-eou-decoder.onnx" to 15_757_826L,
+        "parakeet-eou-joint.onnx" to 5_589_132L,
+        "kokoro-e2e.onnx" to 3_047_254L,
+        "kokoro-e2e-realtime.onnx" to 2_413_312L,
+        "kokoro-e2e.onnx.data" to 324_564_624L,
+        "us_gold.json" to 3_000_469L,
+        "us_silver.json" to 3_099_517L,
+        "dict_fr.json" to 51_497L,
+        "dict_pt.json" to 37_438L,
+        "deepfilter-auxiliary.bin" to 126_976L,
+        "model.litertlm" to 297_212_528L,
+        "model-lora16-android.litertlm" to 327_438_928L,
+        "control-r4-rank16.tflite" to 9_502_720L,
+    )
+
+    /** Assumed size of a model file with no [EXPECTED_SIZES] entry. */
+    private const val DEFAULT_EXPECTED_BYTES = 256_000L
+
+    private fun expectedBytes(model: ModelFile): Long =
+        EXPECTED_SIZES[model.filename] ?: DEFAULT_EXPECTED_BYTES
 
     // ONNX files start with these bytes (protobuf magic for ONNX IR)
     private val ONNX_MAGIC = byteArrayOf(0x08, 0x0)

--- a/sdk/src/test/kotlin/audio/soniqo/speech/DownloadProgressTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/DownloadProgressTest.kt
@@ -130,4 +130,92 @@ class DownloadProgressTest {
         )
         assertEquals(100, samples.last().percent)
     }
+
+    // -----------------------------------------------------------------------
+    // Byte-weighted bar. The file-count form above still advances within a
+    // file, but weights a 2 KB config.json the same as the 325 MB weights
+    // blob — so it spends ~60% of the bar on ~2% of the bytes. These cover the
+    // byte-weighted overload that replaces it.
+    // -----------------------------------------------------------------------
+
+    /** Real published sizes, pipeline set then the LLM bundle. */
+    private val pipelineBytes = manifest.sumOf { it.bytes }
+    private val llmBytes = 297 * MB
+
+    private fun byteSamples(): List<Int> {
+        val out = ArrayList<Int>()
+        var done = 0L
+        val total = pipelineBytes + llmBytes
+        for (m in manifest + Sized("model.litertlm", llmBytes)) {
+            var fileBytes = 0L
+            while (fileBytes < m.bytes) {
+                fileBytes = minOf(m.bytes, fileBytes + CHUNK)
+                out += ModelDownloadWorker.progressPercent(done + fileBytes, total)
+            }
+            done += m.bytes
+        }
+        return out
+    }
+
+    @Test
+    fun `byte weighted percent tracks the fraction of bytes transferred`() {
+        assertEquals(0, ModelDownloadWorker.progressPercent(0, 800 * MB))
+        assertEquals(25, ModelDownloadWorker.progressPercent(200 * MB, 800 * MB))
+        assertEquals(50, ModelDownloadWorker.progressPercent(400 * MB, 800 * MB))
+        assertEquals(100, ModelDownloadWorker.progressPercent(800 * MB, 800 * MB))
+    }
+
+    @Test
+    fun `byte weighted percent clamps and tolerates an unknown total`() {
+        assertEquals(0, ModelDownloadWorker.progressPercent(1, 0))
+        // A refined Content-Length can briefly exceed the seeded estimate.
+        assertEquals(100, ModelDownloadWorker.progressPercent(900 * MB, 789 * MB))
+    }
+
+    @Test
+    fun `dominant file gets bar time proportional to its bytes`() {
+        // kokoro-e2e.onnx.data is 325 of 789 MB. Under file-count weighting it
+        // was worth 5 of 100 points while taking ~40% of the wall clock.
+        val total = pipelineBytes + llmBytes
+        val before = manifest.takeWhile { it.name != "kokoro-e2e.onnx.data" }.sumOf { it.bytes }
+        val start = ModelDownloadWorker.progressPercent(before, total)
+        val end = ModelDownloadWorker.progressPercent(before + 325 * MB, total)
+        assertTrue(
+            "the 325 MB blob should own ~40 points of the bar, got ${end - start}",
+            (end - start) in 38..43,
+        )
+    }
+
+    @Test
+    fun `byte weighted run is monotonic, ends at 100, and never resets`() {
+        val samples = byteSamples()
+        assertTrue(
+            "byte-weighted percent must never decrease",
+            samples.zipWithNext().all { (a, b) -> b >= a },
+        )
+        assertEquals(100, samples.last())
+        // The LLM phase used to restart its own 0→100 sweep. Once the pipeline
+        // set is done the bar must already be well past zero and stay there.
+        val afterPipeline = ModelDownloadWorker.progressPercent(
+            pipelineBytes, pipelineBytes + llmBytes,
+        )
+        assertTrue("bar should be ~62% when the LLM phase starts, was $afterPipeline",
+            afterPipeline in 58..66)
+    }
+
+    @Test
+    fun `detail line reports bytes, rate and eta`() {
+        assertEquals(
+            "412 / 789 MB · 3.6 MB/s · 2 min left",
+            ModelDownloadWorker.detailLine(412_000_000, 789_000_000, 3_600_000, 105),
+        )
+    }
+
+    @Test
+    fun `detail line drops rate and eta until they settle`() {
+        assertEquals(
+            "12 / 789 MB",
+            ModelDownloadWorker.detailLine(12_000_000, 789_000_000, 0, -1),
+        )
+    }
 }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerPlanningTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerPlanningTest.kt
@@ -1,0 +1,140 @@
+package audio.soniqo.speech
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.RandomAccessFile
+
+/**
+ * Coverage for [ModelManager.plannedModelBytes] / [ModelManager.plannedLlmBytes],
+ * which supply the denominator of the byte-weighted download bar. Getting these
+ * wrong doesn't fail a download — it silently makes the bar lie — so the cache
+ * states they have to distinguish are pinned here.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ModelManagerPlanningTest {
+
+    private lateinit var context: Context
+    private lateinit var modelDir: File
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        modelDir = File(ModelManager.modelDir(context))
+        modelDir.deleteRecursively()
+        File(ModelManager.llmModelDir(context)).deleteRecursively()
+    }
+
+    /**
+     * A file that passes [ModelManager]'s validity check without costing disk:
+     * ONNX protobuf magic up front, then a sparse extent to clear the
+     * per-file size floor.
+     */
+    private fun writeValid(dir: File, name: String, size: Long) {
+        val f = File(dir, name)
+        f.parentFile?.mkdirs()
+        RandomAccessFile(f, "rw").use { raf ->
+            raf.write(byteArrayOf(0x08, 0x00))
+            if (size > 2) raf.setLength(size)
+        }
+    }
+
+    @Test
+    fun `fresh install plans the whole default manifest`() {
+        val pipeline = ModelManager.plannedModelBytes(context)
+        // Published INT8 Parakeet-EOU + Kokoro set is ~493 MB.
+        assertTrue("expected ~493 MB, got $pipeline", pipeline in 480_000_000..505_000_000)
+    }
+
+    @Test
+    fun `fresh install plans the exact FunctionGemma bundle size`() {
+        assertEquals(297_212_528L, ModelManager.plannedLlmBytes(context))
+    }
+
+    /** Markers that make an existing cache current rather than stale. */
+    private fun writeCurrentMarkers(dir: File) {
+        File(dir, "version.txt").writeText("6")
+        File(dir, "model-set.txt").writeText(
+            ModelManager.modelSetKey(
+                ModelPrecision.INT8, SttModel.PARAKEET_EOU, SttBackend.ONNX,
+                TtsModel.KOKORO_SHORT_TURN,
+            )
+        )
+    }
+
+    @Test
+    fun `cached valid files drop out of the plan`() {
+        // Markers only: nothing cached yet, but the cache is current so
+        // ensureModels will keep whatever lands in it.
+        modelDir.mkdirs()
+        writeCurrentMarkers(modelDir)
+        val before = ModelManager.plannedModelBytes(context)
+
+        // Two files whose published sizes are in the estimate table. Neither
+        // carries a size floor, so any non-empty content is valid.
+        writeValid(modelDir, "us_gold.json", 3_000_469)
+        writeValid(modelDir, "us_silver.json", 3_099_517)
+
+        val after = ModelManager.plannedModelBytes(context)
+        assertEquals(
+            "plan should shrink by exactly the two cached files",
+            3_000_469L + 3_099_517L, before - after,
+        )
+    }
+
+    @Test
+    fun `a fully cached model set plans nothing`() {
+        modelDir.mkdirs()
+        // Sparse extents keep the 325 MB and 132 MB blobs off the disk.
+        writeValid(modelDir, "silero-vad.onnx", 2_243_022)
+        writeValid(modelDir, "parakeet-eou-encoder.onnx", 131_741_896)
+        writeValid(modelDir, "parakeet-eou-decoder.onnx", 15_757_826)
+        writeValid(modelDir, "parakeet-eou-joint.onnx", 5_589_132)
+        writeValid(modelDir, "vocab.json", 17_437)
+        writeValid(modelDir, "config.json", 524)
+        writeValid(modelDir, "kokoro-e2e.onnx", 3_047_254)
+        writeValid(modelDir, "kokoro-e2e-realtime.onnx", 2_413_312)
+        writeValid(modelDir, "kokoro-e2e.onnx.data", 324_564_624)
+        writeValid(modelDir, "vocab_index.json", 2_501)
+        writeValid(modelDir, "us_gold.json", 3_000_469)
+        writeValid(modelDir, "us_silver.json", 3_099_517)
+        listOf("fr", "es", "it", "pt", "hi").forEach { writeValid(modelDir, "dict_$it.json", 5_000) }
+        writeValid(modelDir, "voices/af_heart.bin", 1_024)
+        writeValid(modelDir, "deepfilter-auxiliary.bin", 126_976)
+        writeCurrentMarkers(modelDir)
+
+        assertEquals(0L, ModelManager.plannedModelBytes(context))
+        assertTrue(ModelManager.areModelsReady(context))
+    }
+
+    @Test
+    fun `a stale model version re-plans the whole manifest`() {
+        modelDir.mkdirs()
+        writeValid(modelDir, "us_gold.json", 3_000_469)
+        writeCurrentMarkers(modelDir)
+        File(modelDir, "version.txt").writeText("1")   // below MODEL_VERSION
+
+        // ensureModels wipes this cache before downloading, so the cached file
+        // must not be discounted from the plan.
+        val planned = ModelManager.plannedModelBytes(context)
+        assertTrue("stale cache should plan the full set, got $planned",
+            planned in 480_000_000..505_000_000)
+    }
+
+    @Test
+    fun `an in-progress LLM download is not treated as a stale cache`() {
+        // No markers on disk = a download that never finished. ensureLlmModels
+        // deliberately keeps its .tmp in that state, so the plan must stay the
+        // full bundle rather than collapsing to zero.
+        File(ModelManager.llmModelDir(context)).mkdirs()
+        assertEquals(297_212_528L, ModelManager.plannedLlmBytes(context))
+    }
+}

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerPlanningTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerPlanningTest.kt
@@ -107,7 +107,10 @@ class ModelManagerPlanningTest {
         writeValid(modelDir, "us_gold.json", 3_000_469)
         writeValid(modelDir, "us_silver.json", 3_099_517)
         listOf("fr", "es", "it", "pt", "hi").forEach { writeValid(modelDir, "dict_$it.json", 5_000) }
-        writeValid(modelDir, "voices/af_heart.bin", 1_024)
+        listOf(
+            "af_heart", "ff_siwis", "ef_dora", "if_sara",
+            "pf_dora", "hf_alpha", "jf_alpha", "zf_xiaobei",
+        ).forEach { writeValid(modelDir, "voices/$it.bin", 1_024) }
         writeValid(modelDir, "deepfilter-auxiliary.bin", 126_976)
         writeCurrentMarkers(modelDir)
 


### PR DESCRIPTION
## Summary

Fixes two first-run complaints on the Control demo: the model download "takes ages" (really: the progress bar looked frozen) and a "media permission not granted" note that appeared before the app had asked for anything.

### SDK — byte-weighted download progress (`849e7e5`)

The bar was file-count weighted, so on the default manifest it sprinted through the small JSON assets and then sat still for minutes on the two files that are ~93% of the bytes, then reset to zero for the LLM phase.

- `ModelManager.Progress` carries cumulative `totalBytesDownloaded`/`totalBytes`, seeded from published sizes and corrected to the real `Content-Length` as each file starts. Cached files are excluded, so the bar measures the transfer, not the manifest.
- `plannedModelBytes()` / `plannedLlmBytes()` size the whole download up front, so the pipeline and LLM phases render as one continuous 0→100 bar.
- `ModelDownloadWorker` reports byte-weighted percent plus rate and ETA via `detailLine()` (`412 / 580 MB · 3.6 MB/s · 2 min left`), clamped monotonic. ETA minutes round rather than truncate.

### control-demo — startup permissions + download detail (`a68d857`)

`buildContextPhrases()` runs during startup to bias the STT beam with the on-device music library, and it called `listMusic()`, which reports a denial to the feed — but permissions were only requested on the first mic tap, so a fresh install always showed the note before any dialog.

- Request permissions in `onCreate` as one batch, including `POST_NOTIFICATIONS` (declared but never requested, so the download notification was silently dropped).
- Startup biasing reads through a silent `listMusicOrEmpty()`; the music tools still report a denial, because there it's what made the command fail.
- Rebuild biasing in `onRequestPermissionsResult` when the media grant lands; a `micRequested` flag stops a startup grant from switching the mic on unasked.
- Setup panel shows bytes/rate/ETA; first-run copy corrected `~800 MB → ~600 MB` (the Pocket path).

On Android 13 the media permission is `READ_MEDIA_AUDIO`, surfaced under **"Music and audio"**, not the pre-13 "Files and media" group — which is why it looked absent in App Info.

## Test plan

- `./gradlew :sdk:test` — 87 pass, incl. new byte-weighting/monotonicity and `plannedModelBytes` cache-state coverage.
- `./gradlew :sdk:connectedDebugAndroidTest` (arm64 emulator, excl. the multi-GB Nemotron/Parakeet-TDT suites that exceed the AVD data partition) — 34 pass, 0 fail; exercises the rewritten download path incl. `modelDownloadIsCached` / `corruptModelFileTriggersRedownload`.
- `./gradlew :control-demo:compileDebugKotlin` + `:control-demo:assembleDebug` — clean.
- On-emulator: fresh install shows the permission dialog at startup with no phantom note, and the setup panel renders the byte/rate/ETA line.
