### PR TITLE
Fix Android 16 KB native library alignment

### DIFF
--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -12,6 +12,8 @@ val speechCoreDir = providers.gradleProperty("SPEECH_CORE_DIR")
 android {
     namespace = "audio.soniqo.speech"
     compileSdk = 35
+    // NDK r28+ defaults to 16 KB ELF alignment; pin r29 for reproducible AARs.
+    ndkVersion = "29.0.14206865"
 
     defaultConfig {
         minSdk = 26


### PR DESCRIPTION
## Summary

- pin the SDK native build to NDK 29.0.14206865
- make the generated JNI library use 16 KB ELF LOAD alignment by default
- preserve the existing compatible packaging for ONNX Runtime, LiteRT, and libc++

Fixes #62

## Test plan

- [x] `./gradlew :sdk:test`
- [x] `./gradlew :sdk:clean :sdk:assembleRelease :app:assembleDebug :sdk:test`
- [x] verify every arm64-v8a and x86_64 `.so` in the release AAR has `0x4000` LOAD alignment with NDK r29 `llvm-readelf`
- [x] verify the debug APK with `zipalign -c -P 16 -v 4`
- [x] load the rebuilt JNI library on an ARM64 Android 15 emulator with a focused instrumentation smoke test