### PR TITLE
SDK: download multilingual Kokoro voice assets

### DIFF
--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/KokoroMultilingualTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/KokoroMultilingualTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
 
 /**
  * Multilingual TTS phonemizer integration tests.
@@ -18,9 +19,9 @@ import org.junit.runner.RunWith
  * tests exercise the full VAD -> STT -> TTS chain in echo mode and confirm
  * that non-ASCII characters flowing through the pipeline do not cause errors.
  *
- * Each test pushes a speech-like signal, waits for the echo TTS to produce
- * audio, and validates the output. If VAD does not trigger on the synthetic
- * signal the test passes silently (same pattern as KokoroTtsTest).
+ * Most tests push a speech-like signal and tolerate VAD not triggering on the
+ * synthetic input. The direct Chinese synthesis test is strict: it verifies
+ * the compact language voice is present and produces valid PCM.
  */
 @RunWith(AndroidJUnit4::class)
 class KokoroMultilingualTest {
@@ -187,26 +188,35 @@ class KokoroMultilingualTest {
     // -----------------------------------------------------------------
 
     @Test
-    fun chineseTextDoesNotCrashPipeline() = runBlocking {
-        val config = SpeechConfig(modelDir = modelDir, useNnapi = false)
-        val pipeline = SpeechPipeline(config)
-        pipeline.start()
+    fun chinesePinyinSynthesizesWithBundledVoice() {
+        val voice = File(modelDir, "voices/zf_xiaobei.bin")
+        assertTrue("Chinese voice should be downloaded", voice.isFile)
+        assertEquals("Voice must contain one 256-float style vector", 1024L, voice.length())
 
-        pushChunked(pipeline, speechSignal(freqHz = 260.0))
-        pushChunked(pipeline, silenceSignal())
-
+        val synthesizer = SpeechSynthesizer(
+            SpeechSynthesizerConfig(
+                modelDir = modelDir,
+                useNnapi = false,
+                ttsModel = TtsModel.KOKORO_SHORT_TURN,
+            )
+        )
         try {
-            val event = withTimeout(30_000) {
-                pipeline.events.first { it is SpeechEvent.ResponseAudioDelta }
-            }
-            val audio = event as SpeechEvent.ResponseAudioDelta
-            assertTrue("Audio should not be empty", audio.audio.isNotEmpty())
-        } catch (_: Exception) {
-            // Pass silently if VAD does not trigger
+            // speech-core's Chinese G2P currently accepts space-separated
+            // pinyin; Han-to-pinyin conversion remains an upstream concern.
+            val result = synthesizer.synthesize("ni3 hao3, shi4 jie4.", "zh")
+            assertEquals(24_000, result.sampleRate)
+            assertTrue("Chinese TTS output should not be empty", result.pcm16.isNotEmpty())
+            assertTrue(
+                "Chinese TTS output should contain non-zero PCM",
+                result.pcm16.any { it != 0.toByte() },
+            )
+            assertTrue(
+                "Chinese TTS output is suspiciously short (${result.pcm16.size} bytes)",
+                result.pcm16.size >= 4_800,
+            )
+        } finally {
+            synthesizer.close()
         }
-
-        pipeline.stop()
-        pipeline.close()
     }
 
     // -----------------------------------------------------------------

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -134,6 +134,13 @@ object ModelManager {
             ModelFile("Kokoro-82M-ONNX", "dict_pt.json"),
             ModelFile("Kokoro-82M-ONNX", "dict_hi.json"),
             ModelFile("Kokoro-82M-ONNX", "voices/af_heart.bin"),
+            ModelFile("Kokoro-82M-ONNX", "voices/ff_siwis.bin"),
+            ModelFile("Kokoro-82M-ONNX", "voices/ef_dora.bin"),
+            ModelFile("Kokoro-82M-ONNX", "voices/if_sara.bin"),
+            ModelFile("Kokoro-82M-ONNX", "voices/pf_dora.bin"),
+            ModelFile("Kokoro-82M-ONNX", "voices/hf_alpha.bin"),
+            ModelFile("Kokoro-82M-ONNX", "voices/jf_alpha.bin"),
+            ModelFile("Kokoro-82M-ONNX", "voices/zf_xiaobei.bin"),
         )
         // Four LiteRT graphs + the G2P-free tokenizer assets + the 10-voice catalog.
         TtsModel.SUPERTONIC -> listOf(
@@ -682,8 +689,20 @@ object ModelManager {
         "control-r4-rank16.tflite" to 9_000_000L,        // ~9.5 MB Control adapter
     )
 
-    private fun isValidModel(file: File, filename: String): Boolean {
+    @VisibleForTesting
+    internal fun isValidModel(file: File, filename: String): Boolean {
         if (file.length() == 0L) return false
+
+        // speech-core passes one [1, 256] float32 style vector to Kokoro.
+        // Upstream voice tables are much larger and must be compacted before
+        // publication; accepting one here would silently read the wrong row.
+        if (
+            filename.startsWith("voices/") &&
+            filename.endsWith(".bin") &&
+            file.length() != KOKORO_VOICE_BYTES
+        ) {
+            return false
+        }
 
         // Check minimum size for known large files
         MIN_SIZES[filename]?.let { minSize ->
@@ -705,6 +724,8 @@ object ModelManager {
 
         return true
     }
+
+    private const val KOKORO_VOICE_BYTES = 256L * 4L
 
     private fun LOGI(msg: String) = Log.i("Speech", msg)
 }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/DownloadProgressTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/DownloadProgressTest.kt
@@ -35,7 +35,14 @@ class DownloadProgressTest {
         Sized("dict_it.json", 1 * MB),
         Sized("dict_pt.json", 1 * MB),
         Sized("dict_hi.json", 1 * MB),
-        Sized("voices/af_heart.bin", 1 * MB),
+        Sized("voices/af_heart.bin", 1_024),
+        Sized("voices/ff_siwis.bin", 1_024),
+        Sized("voices/ef_dora.bin", 1_024),
+        Sized("voices/if_sara.bin", 1_024),
+        Sized("voices/pf_dora.bin", 1_024),
+        Sized("voices/hf_alpha.bin", 1_024),
+        Sized("voices/jf_alpha.bin", 1_024),
+        Sized("voices/zf_xiaobei.bin", 1_024),
         Sized("deepfilter-auxiliary.bin", 2 * MB),
     )
     private val totalFiles = manifest.size
@@ -75,17 +82,17 @@ class DownloadProgressTest {
 
     @Test
     fun `percent adds completed files plus fraction of the file in flight`() {
-        assertEquals(5, ModelDownloadWorker.progressPercent(1, 19, 0, 132 * MB))
-        assertEquals(7, ModelDownloadWorker.progressPercent(1, 19, 66 * MB, 132 * MB))
-        assertEquals(42, ModelDownloadWorker.progressPercent(8, 19, 0, 325 * MB))
-        assertEquals(100, ModelDownloadWorker.progressPercent(19, 19, 0, 0))
+        assertEquals(3, ModelDownloadWorker.progressPercent(1, totalFiles, 0, 132 * MB))
+        assertEquals(5, ModelDownloadWorker.progressPercent(1, totalFiles, 66 * MB, 132 * MB))
+        assertEquals(30, ModelDownloadWorker.progressPercent(8, totalFiles, 0, 325 * MB))
+        assertEquals(100, ModelDownloadWorker.progressPercent(totalFiles, totalFiles, 0, 0))
     }
 
     @Test
     fun `unknown file size falls back to file count`() {
         // When the server doesn't advertise a length, the in-flight file adds
         // no fraction — whole-file granularity for that file only.
-        assertEquals(5, ModelDownloadWorker.progressPercent(1, 19, 12345, 0))
+        assertEquals(3, ModelDownloadWorker.progressPercent(1, totalFiles, 12345, 0))
     }
 
     @Test
@@ -100,11 +107,11 @@ class DownloadProgressTest {
         val distinct = largeFile.map { it.percent }.toSet()
         assertTrue(
             "large file percent should advance through several values, got $distinct",
-            distinct.size >= 6,
+            distinct.size >= 4,
         )
-        // One file's worth of the 19-file bar: ~42% -> ~47%.
-        assertEquals(42, largeFile.first().percent)
-        assertEquals(47, largeFile.last().percent)
+        // One file's worth of the 26-file bar: ~30% -> ~34%.
+        assertEquals(30, largeFile.first().percent)
+        assertEquals(34, largeFile.last().percent)
         assertTrue(
             "large file percent must never go backwards",
             largeFile.zipWithNext().all { (a, b) -> b.percent >= a.percent },
@@ -116,8 +123,16 @@ class DownloadProgressTest {
         val largeFile = simulate().filter { it.file == "kokoro-e2e.onnx.data" }
         val midpoint = largeFile.first { it.fileBytes >= it.fileTotal / 2 }
         assertTrue(
-            "halfway through the large file the bar should read >= 44, was ${midpoint.percent}",
-            midpoint.percent >= 44,
+            "halfway through the large file the bar should read >= 32, was ${midpoint.percent}",
+            midpoint.percent >= 32,
+        )
+    }
+
+    @Test
+    fun `fixture matches the default model manifest`() {
+        assertEquals(
+            ModelManager.models(ModelPrecision.INT8).map { it.localFilename },
+            manifest.map { it.name },
         )
     }
 

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.nio.file.Files
 
 /**
  * Regression coverage for issue #36.
@@ -87,12 +88,47 @@ class ModelManagerManifestTest {
                 ModelManager.ModelFile("Kokoro-82M-ONNX", "dict_pt.json"),
                 ModelManager.ModelFile("Kokoro-82M-ONNX", "dict_hi.json"),
                 ModelManager.ModelFile("Kokoro-82M-ONNX", "voices/af_heart.bin"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "voices/ff_siwis.bin"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "voices/ef_dora.bin"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "voices/if_sara.bin"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "voices/pf_dora.bin"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "voices/hf_alpha.bin"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "voices/jf_alpha.bin"),
+                ModelManager.ModelFile("Kokoro-82M-ONNX", "voices/zf_xiaobei.bin"),
             ),
             files,
         )
         assertFalse(files.any { it.repo.contains("Parakeet") || it.repo.contains("Silero") })
         assertFalse(files.any { it.filename.startsWith("deepfilter") })
         assertEquals(1, files.count { it.filename == "kokoro-e2e.onnx.data" })
+    }
+
+    @Test
+    fun `Kokoro runtime voices must contain exactly one style vector`() {
+        val dir = Files.createTempDirectory("kokoro-voice-validation").toFile()
+        try {
+            val valid = dir.resolve("valid.bin").apply {
+                writeBytes(ByteArray(256 * 4) { 1 })
+            }
+            val truncated = dir.resolve("truncated.bin").apply {
+                writeBytes(ByteArray(256 * 4 - 1) { 1 })
+            }
+            val upstreamTable = dir.resolve("upstream-table.bin").apply {
+                writeBytes(ByteArray(510 * 256 * 4) { 1 })
+            }
+
+            assertTrue(
+                ModelManager.isValidModel(valid, "voices/zf_xiaobei.bin"),
+            )
+            assertFalse(
+                ModelManager.isValidModel(truncated, "voices/zf_xiaobei.bin"),
+            )
+            assertFalse(
+                ModelManager.isValidModel(upstreamTable, "voices/zf_xiaobei.bin"),
+            )
+        } finally {
+            dir.deleteRecursively()
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- download the compact default voice for every Kokoro language advertised by the Android SDK
- reject truncated files and accidental 522 KB upstream voice tables; speech-core requires exactly one 1,024-byte `[256]` float32 style vector
- replace the permissive Chinese pipeline smoke test with strict direct pinyin synthesis and PCM assertions
- keep download-progress regression fixtures aligned with the expanded manifest

The assets were produced by https://github.com/soniqo/speech-models/pull/59 and published in https://huggingface.co/soniqo/Kokoro-82M-ONNX/commit/2895b2025f1046fad6b51f8773debc3da8ba05df.

## Test plan

- `./gradlew :sdk:test` — passed
- `./gradlew :sdk:assembleDebugAndroidTest` — passed
- targeted arm64 Chinese synthesis — valid non-zero 24 kHz PCM
- `./gradlew :sdk:connectedAndroidTest` on an arm64 API 35 AVD with a clean 12 GB data partition — 38 tests, 1 assumption skip, 0 failures

Fixes #64