### PR TITLE
Fix Nemotron LiteRT INT8 CPU model rollout

### DIFF
--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/NemotronMultilingualSttTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/NemotronMultilingualSttTest.kt
@@ -2,52 +2,81 @@ package audio.soniqo.speech
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.Assert.*
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
 
 /**
  * On-device E2E test for the Nemotron-3.5 ASR streaming multilingual STT
- * (ONNX backend). Unlike ParakeetSttTest this does NOT download from HuggingFace
- * — the bundle is expected to be pre-pushed (via adb) into the app's external
- * files dir under `nemo-models/`, so the test runs offline:
+ * (ONNX or LiteRT backend). Unlike ParakeetSttTest this does NOT download from
+ * Hugging Face — the bundle is expected to be pre-pushed (via adb + run-as)
+ * into the target app's internal files dir under `nemo-models/`, so the test
+ * runs offline:
  *
- *   adb push onnx-320-fp16/.  /sdcard/Android/data/audio.soniqo.speech.test/files/nemo-models/
- *   adb push nemo_en.raw      /sdcard/Android/data/audio.soniqo.speech.test/files/nemo-models/
+ *   ./gradlew :sdk:installDebugAndroidTest
+ *   adb shell run-as audio.soniqo.speech.test mkdir -p files/nemo-models
+ *   # Stream each model/fixture with:
+ *   adb exec-in run-as audio.soniqo.speech.test sh -c \
+ *     'cat > files/nemo-models/<filename>' < <local-file>
  *
- * Each test skips gracefully (returns) if the bundle isn't present, so the
- * suite stays green on CI runners without the model.
+ * Pass `-e nemotronBackend LITERT` to exercise LiteRT (the default is ONNX).
+ * Tests are reported as skipped when the provisioned bundle is absent.
  */
 @RunWith(AndroidJUnit4::class)
 class NemotronMultilingualSttTest {
 
+    private val backend: SttBackend
+        get() {
+            val value = InstrumentationRegistry.getArguments()
+                .getString("nemotronBackend")
+                ?.uppercase()
+            return if (value == SttBackend.LITERT.name) {
+                SttBackend.LITERT
+            } else {
+                SttBackend.ONNX
+            }
+        }
+
     private fun modelDir(): File {
-        // Internal filesDir: provisioned via `adb shell run-as … cp` from
-        // /data/local/tmp (shell-pushed files in the app's *external* dir are
-        // unreadable by the app uid on sdcardfs). App-owned → readable here.
         val ctx = InstrumentationRegistry.getInstrumentation().targetContext
         val dir = File(ctx.filesDir, "nemo-models")
         android.util.Log.i("NemoTest", "modelDir=$dir exists=${dir.exists()} bundle=${hasBundle(dir)}")
         return dir
     }
 
-    private fun hasBundle(dir: File): Boolean =
-        File(dir, "encoder.onnx").exists() &&
-        File(dir, "decoder.onnx").exists() &&
-        File(dir, "joint.onnx").exists() &&
-        File(dir, "vocab.json").exists() &&
-        File(dir, "languages.json").exists()
+    private fun hasBundle(dir: File): Boolean {
+        val sttFiles = when (backend) {
+            SttBackend.ONNX -> listOf("encoder.onnx", "decoder.onnx", "joint.onnx")
+            SttBackend.LITERT -> listOf(
+                "nemotron-multilingual-encoder.tflite",
+                "nemotron-multilingual-decoder.tflite",
+                "nemotron-multilingual-joint.tflite",
+            )
+        }
+        val pipelineFiles = sttFiles + listOf(
+            "vocab.json",
+            "languages.json",
+            "silero-vad.onnx",
+            "kokoro-e2e-realtime.onnx",
+            "kokoro-e2e.onnx.data",
+        )
+        return pipelineFiles.all { File(dir, it).isFile }
+    }
 
     private fun nemotronConfig(dir: File) = SpeechConfig(
         modelDir = dir.absolutePath,
         useNnapi = false,
         sttModel = SttModel.NEMOTRON_MULTILINGUAL,
-        sttBackend = SttBackend.ONNX,
+        sttBackend = backend,
+        ttsModel = TtsModel.KOKORO_SHORT_TURN,
+        pipelineMode = PipelineMode.TRANSCRIBE_ONLY,
         language = "en-US",
     )
 
@@ -55,58 +84,70 @@ class NemotronMultilingualSttTest {
     @Test
     fun pipelineConstructsWithNemotron() {
         val dir = modelDir()
-        if (!hasBundle(dir)) return
+        assumeTrue("provision the $backend Nemotron test bundle in $dir", hasBundle(dir))
         val pipeline = SpeechPipeline(nemotronConfig(dir))
-        assertEquals(PipelineState.Idle, pipeline.state)
-        pipeline.start()
-        assertTrue(
-            pipeline.state == PipelineState.Idle ||
-            pipeline.state == PipelineState.Listening
-        )
-        pipeline.stop()
-        pipeline.close()
+        try {
+            assertEquals(PipelineState.Idle, pipeline.state)
+            pipeline.start()
+            assertTrue(
+                pipeline.state == PipelineState.Idle ||
+                    pipeline.state == PipelineState.Listening,
+            )
+        } finally {
+            pipeline.stop()
+            pipeline.close()
+        }
     }
 
     /** Real English audio → a non-empty transcription mentioning expected words. */
     @Test
     fun transcribesEnglishAudio() = runBlocking {
         val dir = modelDir()
-        if (!hasBundle(dir)) return@runBlocking
+        assumeTrue("provision the $backend Nemotron test bundle in $dir", hasBundle(dir))
         val raw = File(dir, "nemo_en.raw")
-        if (!raw.exists()) return@runBlocking
+        assumeTrue("provision nemo_en.raw in $dir", raw.isFile)
 
         val pipeline = SpeechPipeline(nemotronConfig(dir))
-        pipeline.start()
+        try {
+            pipeline.start()
+            val eventDeferred = async {
+                withTimeout(180_000) {
+                    pipeline.events.first { it is SpeechEvent.TranscriptionCompleted }
+                }
+            }
 
-        val bytes = raw.readBytes()
-        val samples = FloatArray(bytes.size / 4)
-        java.nio.ByteBuffer.wrap(bytes)
-            .order(java.nio.ByteOrder.LITTLE_ENDIAN)
-            .asFloatBuffer().get(samples)
+            val bytes = raw.readBytes()
+            val samples = FloatArray(bytes.size / 4)
+            java.nio.ByteBuffer.wrap(bytes)
+                .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+                .asFloatBuffer().get(samples)
 
-        for (offset in samples.indices step 512) {
-            val end = minOf(offset + 512, samples.size)
-            pipeline.pushAudio(samples.sliceArray(offset until end))
-            delay(8)
+            for (offset in samples.indices step 512) {
+                val end = minOf(offset + 512, samples.size)
+                pipeline.pushAudio(samples.sliceArray(offset until end))
+                delay(8)
+            }
+            // Trailing silence to trigger end-of-speech.
+            val silence = FloatArray(16000)
+            for (offset in silence.indices step 512) {
+                pipeline.pushAudio(silence.sliceArray(offset until minOf(offset + 512, silence.size)))
+                delay(8)
+            }
+
+            val tc = eventDeferred.await() as SpeechEvent.TranscriptionCompleted
+            assertTrue("transcription should not be empty", tc.text.isNotBlank())
+            val text = tc.text.lowercase()
+            val expected = InstrumentationRegistry.getArguments()
+                .getString("nemotronExpectedWords")
+                ?.split(",")
+                ?.map(String::trim)
+                ?.filter(String::isNotEmpty)
+                ?: listOf("alloy", "metal", "mixture", "element")
+            val matched = expected.count { it.lowercase() in text }
+            assertTrue("expected >=1 of $expected in '$text'", matched >= 1)
+        } finally {
+            pipeline.stop()
+            pipeline.close()
         }
-        // Trailing silence to trigger end-of-speech.
-        val silence = FloatArray(16000)
-        for (offset in silence.indices step 512) {
-            pipeline.pushAudio(silence.sliceArray(offset until minOf(offset + 512, silence.size)))
-            delay(8)
-        }
-
-        val event = withTimeout(60_000) {
-            pipeline.events.first { it is SpeechEvent.TranscriptionCompleted }
-        }
-        val tc = event as SpeechEvent.TranscriptionCompleted
-        assertTrue("transcription should not be empty", tc.text.isNotBlank())
-        val text = tc.text.lowercase()
-        val expected = listOf("alloy", "metal", "mixture", "element")
-        val matched = expected.count { it in text }
-        assertTrue("expected >=1 of $expected in '$text'", matched >= 1)
-
-        pipeline.stop()
-        pipeline.close()
     }
 }

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -23,6 +23,9 @@ object ModelManager {
     private const val BASE_URL = "https://huggingface.co/soniqo"
     private const val POCKET_TTS_REVISION = "v1.0.0"
     private const val POCKET_TTS_DIR = "pocket_tts"
+    private const val NEMOTRON_LITERT_INT8_REVISION = "v1.0.0"
+    private const val NEMOTRON_LITERT_FP16_REVISION =
+        "1503a9a1eb75b813b83ba65bf5e9fecea4a46091"
 
     // Bump when models on HuggingFace are updated to trigger cache invalidation.
     // v6: default STT switched to Parakeet-EOU-120M-ONNX-INT8, the low-memory
@@ -90,19 +93,20 @@ object ModelManager {
                     // an implementation for ConvInteger"), so the ONNX backend on
                     // Android always uses FP16 (verified on-device). For an int8
                     // footprint on Android use the LiteRT backend (channelwise int8
-                    // via the NNAPI/XNNPACK delegate).
+                    // weights with FP32 activations/compute on the CPU runtime).
                     SttBackend.ONNX -> listOf("encoder.onnx", "encoder.onnx.data",
                         "decoder.onnx", "decoder.onnx.data", "joint.onnx", "joint.onnx.data",
                         "vocab.json", "languages.json", "config.json")
                         .map { ModelFile("$base-ONNX-FP16", it) }
                     SttBackend.LITERT -> {
-                      val q = if (precision == ModelPrecision.INT8) "INT8" else "FP16"
-                      listOf(
-                        "nemotron-multilingual-encoder.tflite",
-                        "nemotron-multilingual-decoder.tflite",
-                        "nemotron-multilingual-joint.tflite",
-                        "vocab.json", "languages.json", "io_map.json", "config.json")
-                        .map { ModelFile("$base-LiteRT-$q", it) }
+                        val q = if (precision == ModelPrecision.INT8) "INT8" else "FP16"
+                        val revision = nemotronLiteRtRevision(precision)
+                        listOf(
+                            "nemotron-multilingual-encoder.tflite",
+                            "nemotron-multilingual-decoder.tflite",
+                            "nemotron-multilingual-joint.tflite",
+                            "vocab.json", "languages.json", "io_map.json", "config.json",
+                        ).map { ModelFile("$base-LiteRT-$q", it, revision) }
                     }
                 }
             }
@@ -485,13 +489,23 @@ object ModelManager {
         sttModel: SttModel,
         sttBackend: SttBackend,
         ttsModel: TtsModel,
-    ): String = listOf(
-        "v$MODEL_VERSION",
-        "precision=${precision.name}",
-        "stt=${sttModel.name}",
-        "backend=${sttBackend.name}",
-        "tts=${ttsCacheName(ttsModel)}",
-    ).joinToString("|")
+    ): String = buildList {
+        add("v$MODEL_VERSION")
+        add("precision=${precision.name}")
+        add("stt=${sttModel.name}")
+        add("backend=${sttBackend.name}")
+        add("tts=${ttsCacheName(ttsModel)}")
+        if (sttModel == SttModel.NEMOTRON_MULTILINGUAL && sttBackend == SttBackend.LITERT) {
+            add("sttRevision=${nemotronLiteRtRevision(precision)}")
+        }
+    }.joinToString("|")
+
+    private fun nemotronLiteRtRevision(precision: ModelPrecision): String =
+        if (precision == ModelPrecision.INT8) {
+            NEMOTRON_LITERT_INT8_REVISION
+        } else {
+            NEMOTRON_LITERT_FP16_REVISION
+        }
 
     private fun modelDirFile(
         context: Context,
@@ -687,6 +701,9 @@ object ModelManager {
         "model.litertlm" to 200_000_000L,                // ~283 MB FunctionGemma bundle
         "model-lora16-android.litertlm" to 300_000_000L, // ~327 MB LoRA-capable base
         "control-r4-rank16.tflite" to 9_000_000L,        // ~9.5 MB Control adapter
+        "nemotron-multilingual-encoder.tflite" to 600_000_000L, // ~623 MB INT8
+        "nemotron-multilingual-decoder.tflite" to 50_000_000L,  // ~60 MB
+        "nemotron-multilingual-joint.tflite" to 30_000_000L,    // ~38 MB
     )
 
     @VisibleForTesting

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.RandomAccessFile
 import java.nio.file.Files
 
 /**
@@ -224,6 +225,80 @@ class ModelManagerManifestTest {
     }
 
     @Test
+    fun `Nemotron LiteRT manifests are pinned to CPU-compatible revisions`() {
+        val int8Files = modelFiles(
+            precision = ModelPrecision.INT8,
+            sttModel = SttModel.NEMOTRON_MULTILINGUAL,
+            sttBackend = SttBackend.LITERT,
+        ).filter { it.repo.endsWith("-LiteRT-INT8") }
+        val fp16Files = modelFiles(
+            precision = ModelPrecision.FP32,
+            sttModel = SttModel.NEMOTRON_MULTILINGUAL,
+            sttBackend = SttBackend.LITERT,
+        ).filter { it.repo.endsWith("-LiteRT-FP16") }
+
+        assertTrue(int8Files.isNotEmpty())
+        assertTrue(int8Files.all { it.revision == "v1.0.0" })
+        assertTrue(fp16Files.isNotEmpty())
+        assertTrue(
+            fp16Files.all {
+                it.revision == "1503a9a1eb75b813b83ba65bf5e9fecea4a46091"
+            },
+        )
+    }
+
+    @Test
+    fun `Nemotron LiteRT revision invalidates only its model cache`() {
+        val defaultKey = modelSetKey()
+        val nemotronInt8Key = modelSetKey(
+            sttModel = SttModel.NEMOTRON_MULTILINGUAL,
+            sttBackend = SttBackend.LITERT,
+        )
+        val nemotronFp16Key = modelSetKey(
+            precision = ModelPrecision.FP32,
+            sttModel = SttModel.NEMOTRON_MULTILINGUAL,
+            sttBackend = SttBackend.LITERT,
+        )
+
+        assertFalse(defaultKey.contains("sttRevision="))
+        assertTrue(nemotronInt8Key.endsWith("|sttRevision=v1.0.0"))
+        assertTrue(
+            nemotronFp16Key.endsWith(
+                "|sttRevision=1503a9a1eb75b813b83ba65bf5e9fecea4a46091",
+            ),
+        )
+        assertNotEquals(nemotronInt8Key, nemotronFp16Key)
+    }
+
+    @Test
+    fun `Nemotron LiteRT artifacts reject truncated model files`() {
+        val dir = Files.createTempDirectory("nemotron-litert-validation").toFile()
+        try {
+            val encoder = dir.resolve("encoder.tflite").apply {
+                RandomAccessFile(this, "rw").use { it.setLength(599_999_999L) }
+            }
+            val decoder = dir.resolve("decoder.tflite").apply {
+                RandomAccessFile(this, "rw").use { it.setLength(49_999_999L) }
+            }
+            val joint = dir.resolve("joint.tflite").apply {
+                RandomAccessFile(this, "rw").use { it.setLength(29_999_999L) }
+            }
+
+            assertFalse(
+                ModelManager.isValidModel(encoder, "nemotron-multilingual-encoder.tflite"),
+            )
+            assertFalse(
+                ModelManager.isValidModel(decoder, "nemotron-multilingual-decoder.tflite"),
+            )
+            assertFalse(
+                ModelManager.isValidModel(joint, "nemotron-multilingual-joint.tflite"),
+            )
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
     fun `llm manifest keeps standalone FunctionGemma as default`() {
         assertEquals(
             listOf(ModelManager.ModelFile("FunctionGemma-270M-LiteRT-LM", "model.litertlm")),
@@ -258,15 +333,19 @@ class ModelManagerManifestTest {
     }
 
     private fun modelFiles(
+        precision: ModelPrecision = ModelPrecision.INT8,
         sttModel: SttModel = SttModel.PARAKEET_EOU,
+        sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO,
     ): List<ModelManager.ModelFile> =
-        ModelManager.models(ModelPrecision.INT8, sttModel, SttBackend.ONNX, ttsModel)
+        ModelManager.models(precision, sttModel, sttBackend, ttsModel)
 
     private fun modelSetKey(
+        precision: ModelPrecision = ModelPrecision.INT8,
         sttModel: SttModel = SttModel.PARAKEET_EOU,
+        sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO,
-    ): String = ModelManager.modelSetKey(ModelPrecision.INT8, sttModel, SttBackend.ONNX, ttsModel)
+    ): String = ModelManager.modelSetKey(precision, sttModel, sttBackend, ttsModel)
 
     private fun modelDirName(
         sttModel: SttModel = SttModel.PARAKEET_EOU,


### PR DESCRIPTION
## Summary

- pin the multilingual LiteRT manifest to the CPU-compatible [`v1.0.0` model release](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-LiteRT-INT8/tree/v1.0.0)
- include that revision only in the Nemotron/LiteRT model-set cache key so installations discard the incompatible cached encoder without invalidating unrelated model caches
- reject truncated LiteRT graph downloads and cover the LiteRT backend in the offline Nemotron instrumented tests

The corrected encoder keeps the compact channelwise-INT8 weights while restoring the shared non-weight `FULLY_CONNECTED` input constant to FP32, preventing LiteRT from selecting the invalid integer kernel reported in the issue.

## Test plan

- `./gradlew :sdk:test`: 80 debug + 80 release tests, zero failures
- targeted LiteRT 2.1.5 tests on an arm64 API-35 emulator: pipeline construction and real FLEURS audio transcription pass
- `./gradlew :sdk:connectedAndroidTest`: 35 passed, 3 expected opt-in skips, zero failures
- English FLEURS (50 samples): INT8 WER 10.36% vs FP16 9.41%; INT8 RTF 0.118 vs FP16 0.193
- German, French, and Japanese spot checks show no material quality regression

Fixes #65