### PR TITLE
Fix resumed model downloads being cached while corrupt

### DIFF
--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -60,6 +60,9 @@ android {
 
     testOptions {
         unitTests.isIncludeAndroidResources = true
+        // android.util.Log is a no-op under unit tests rather than throwing,
+        // so production code can log on paths the tests exercise.
+        unitTests.isReturnDefaultValues = true
     }
 }
 

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -704,45 +704,54 @@ object ModelManager {
                 val contentLength = body.contentLength()
                 val isResume = response.code == 206
 
-                // Full file size: on a 206 resume, contentLength is only the
-                // remaining range, so add what's already on disk. 0 means the
-                // server didn't advertise a length (progress stays file-count
-                // based for this file).
-                // Content-Range carries the authoritative total on a 206 and
-                // is present even when Content-Length is not, so it is the
-                // better source when resuming.
-                val contentRange = if (isResume) response.header("Content-Range") else null
-                val rangeTotal = contentRange
-                    ?.substringAfter('/', "")
-                    ?.trim()
-                    ?.toLongOrNull()
-                    ?: 0L
+                // A 206 must identify exactly which bytes it carries. Without
+                // a valid Content-Range, appending is unsafe: a broken CDN may
+                // have returned the full body from byte 0.
+                val contentRange = if (isResume) {
+                    parseContentRange(response.header("Content-Range"))
+                } else {
+                    null
+                }
+                if (isResume && contentRange == null) {
+                    response.close()
+                    discardPartial(tmp)
+                    throw IOException("Invalid or missing Content-Range for HTTP 206")
+                }
 
-                // A 206 does not guarantee the body starts where we asked. A
-                // server (or CDN) that answers from byte 0 while we append at
-                // our offset produces a file larger than the real one, with a
-                // valid header and a corrupt middle — which no minimum-size
-                // check can catch. Start over when the offsets disagree.
-                val rangeStart = contentRange
-                    ?.substringAfter("bytes ", "")
-                    ?.substringBefore('-', "")
-                    ?.trim()
-                    ?.toLongOrNull()
-                val append = isResume && (rangeStart == null || rangeStart == existingBytes)
+                // A response starting at zero is a usable clean restart. Any
+                // other unexpected offset lacks the prefix needed to build a
+                // complete file, so discard it and retry without Range.
+                if (
+                    contentRange != null &&
+                    contentRange.start != existingBytes &&
+                    contentRange.start != 0L
+                ) {
+                    val rangeStart = contentRange.start
+                    response.close()
+                    discardPartial(tmp)
+                    throw IOException(
+                        "Unexpected Content-Range start: asked $existingBytes, got $rangeStart"
+                    )
+                }
+
+                val append = contentRange != null && contentRange.start == existingBytes
                 if (isResume && !append) {
-                    LOGI("Range ignored by server (asked $existingBytes, got $rangeStart); restarting")
+                    LOGI(
+                        "Range ignored by server " +
+                            "(asked $existingBytes, got ${contentRange?.start}); restarting"
+                    )
                 }
                 val fileTotal = when {
-                    rangeTotal > 0 -> rangeTotal
+                    contentRange != null -> contentRange.total
                     contentLength <= 0 -> 0L
-                    append -> existingBytes + contentLength
                     else -> contentLength
                 }
+                val bytesBeforeResponse = if (append) existingBytes else 0L
 
                 FileOutputStream(tmp, append).use { output ->
                     body.byteStream().use { input ->
                         val buf = ByteArray(65536)
-                        var total = if (append) existingBytes else 0L
+                        var total = bytesBeforeResponse
                         var lastReported = -1L
                         onBytes(total, fileTotal)
                         while (true) {
@@ -761,6 +770,17 @@ object ModelManager {
                 }
 
                 response.close()
+
+                val responseBytes = tmp.length() - bytesBeforeResponse
+                if (contentRange != null && responseBytes != contentRange.length) {
+                    if (responseBytes > contentRange.length) {
+                        discardPartial(tmp)
+                    }
+                    throw IOException(
+                        "Incomplete download range: got $responseBytes bytes, " +
+                            "expected ${contentRange.length}"
+                    )
+                }
 
                 // Validate the finished size whenever the server told us what
                 // to expect. This used to skip the resume path entirely, so a
@@ -845,6 +865,33 @@ object ModelManager {
 
     private fun expectedBytes(model: ModelFile): Long =
         EXPECTED_SIZES[model.filename] ?: DEFAULT_EXPECTED_BYTES
+
+    private data class ContentRange(
+        val start: Long,
+        val endInclusive: Long,
+        val total: Long,
+    ) {
+        val length: Long
+            get() = endInclusive - start + 1L
+    }
+
+    private val CONTENT_RANGE_PATTERN =
+        Regex("""bytes\s+(\d+)-(\d+)/(\d+)""", RegexOption.IGNORE_CASE)
+
+    private fun parseContentRange(value: String?): ContentRange? {
+        val match = CONTENT_RANGE_PATTERN.matchEntire(value?.trim() ?: "") ?: return null
+        val start = match.groupValues[1].toLongOrNull() ?: return null
+        val endInclusive = match.groupValues[2].toLongOrNull() ?: return null
+        val total = match.groupValues[3].toLongOrNull() ?: return null
+        if (start > endInclusive || endInclusive >= total) return null
+        return ContentRange(start, endInclusive, total)
+    }
+
+    private fun discardPartial(file: File) {
+        if (file.exists() && !file.delete()) {
+            FileOutputStream(file, false).use {}
+        }
+    }
 
     // ONNX files start with these bytes (protobuf magic for ONNX IR)
     private val ONNX_MAGIC = byteArrayOf(0x08, 0x0)

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -711,26 +711,38 @@ object ModelManager {
                 // Content-Range carries the authoritative total on a 206 and
                 // is present even when Content-Length is not, so it is the
                 // better source when resuming.
-                val rangeTotal = if (isResume) {
-                    response.header("Content-Range")
-                        ?.substringAfter('/', "")
-                        ?.trim()
-                        ?.toLongOrNull()
-                        ?: 0L
-                } else {
-                    0L
+                val contentRange = if (isResume) response.header("Content-Range") else null
+                val rangeTotal = contentRange
+                    ?.substringAfter('/', "")
+                    ?.trim()
+                    ?.toLongOrNull()
+                    ?: 0L
+
+                // A 206 does not guarantee the body starts where we asked. A
+                // server (or CDN) that answers from byte 0 while we append at
+                // our offset produces a file larger than the real one, with a
+                // valid header and a corrupt middle — which no minimum-size
+                // check can catch. Start over when the offsets disagree.
+                val rangeStart = contentRange
+                    ?.substringAfter("bytes ", "")
+                    ?.substringBefore('-', "")
+                    ?.trim()
+                    ?.toLongOrNull()
+                val append = isResume && (rangeStart == null || rangeStart == existingBytes)
+                if (isResume && !append) {
+                    LOGI("Range ignored by server (asked $existingBytes, got $rangeStart); restarting")
                 }
                 val fileTotal = when {
                     rangeTotal > 0 -> rangeTotal
                     contentLength <= 0 -> 0L
-                    isResume -> existingBytes + contentLength
+                    append -> existingBytes + contentLength
                     else -> contentLength
                 }
 
-                FileOutputStream(tmp, isResume).use { output ->
+                FileOutputStream(tmp, append).use { output ->
                     body.byteStream().use { input ->
                         val buf = ByteArray(65536)
-                        var total = if (isResume) existingBytes else 0L
+                        var total = if (append) existingBytes else 0L
                         var lastReported = -1L
                         onBytes(total, fileTotal)
                         while (true) {

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -708,7 +708,20 @@ object ModelManager {
                 // remaining range, so add what's already on disk. 0 means the
                 // server didn't advertise a length (progress stays file-count
                 // based for this file).
+                // Content-Range carries the authoritative total on a 206 and
+                // is present even when Content-Length is not, so it is the
+                // better source when resuming.
+                val rangeTotal = if (isResume) {
+                    response.header("Content-Range")
+                        ?.substringAfter('/', "")
+                        ?.trim()
+                        ?.toLongOrNull()
+                        ?: 0L
+                } else {
+                    0L
+                }
                 val fileTotal = when {
+                    rangeTotal > 0 -> rangeTotal
                     contentLength <= 0 -> 0L
                     isResume -> existingBytes + contentLength
                     else -> contentLength
@@ -737,10 +750,14 @@ object ModelManager {
 
                 response.close()
 
-                // Validate downloaded size if Content-Length was provided
-                if (!isResume && contentLength > 0 && tmp.length() != contentLength) {
+                // Validate the finished size whenever the server told us what
+                // to expect. This used to skip the resume path entirely, so a
+                // resumed transfer that ended short was renamed into place as
+                // if complete — producing a file that passes the header check
+                // and then fails to parse at load time.
+                if (fileTotal > 0 && tmp.length() != fileTotal) {
                     throw IOException(
-                        "Incomplete download: got ${tmp.length()} bytes, expected $contentLength"
+                        "Incomplete download: got ${tmp.length()} bytes, expected $fileTotal"
                     )
                 }
 

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerDownloadTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerDownloadTest.kt
@@ -181,6 +181,29 @@ class ModelManagerDownloadTest {
     }
 
     @Test
+    fun `206 answering from the wrong offset restarts rather than appending`() {
+        // Seen against a real CDN: we ask for bytes=4- and get a 206 whose
+        // body starts at 0. Appending it produced a file larger than the real
+        // one, with a valid header and a corrupt middle — which a
+        // minimum-size check cannot catch.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setBody("ABCDEFGHIJKLMNOP")
+                .setHeader("Content-Range", "bytes 0-15/16")
+        )
+
+        val dest = File(tmpDir.root, "model.onnx")
+        File(tmpDir.root, "model.onnx.tmp").writeText("ABCD")
+
+        download(dest)
+
+        assertEquals("bytes=4-", server.takeRequest().getHeader("Range"))
+        assertEquals("ABCDEFGHIJKLMNOP", dest.readText())
+        assertEquals(16L, dest.length())
+    }
+
+    @Test
     fun `complete resume is still accepted`() {
         server.enqueue(
             MockResponse()

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerDownloadTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerDownloadTest.kt
@@ -8,8 +8,8 @@ import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
@@ -216,6 +216,86 @@ class ModelManagerDownloadTest {
         File(tmpDir.root, "model.onnx.tmp").writeText("ABCD")
         download(dest)
 
+        assertEquals("ABCDEFGHIJKLMNOP", dest.readText())
+    }
+
+    @Test
+    fun `206 without Content-Range retries from scratch`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setBody("ABCDEFGHIJKLMNOP")
+        )
+        server.enqueue(MockResponse().setBody("ABCDEFGHIJKLMNOP"))
+
+        val dest = File(tmpDir.root, "model.onnx")
+        File(tmpDir.root, "model.onnx.tmp").writeText("ABCD")
+        download(dest)
+
+        assertEquals("bytes=4-", server.takeRequest().getHeader("Range"))
+        assertNull(server.takeRequest().getHeader("Range"))
+        assertEquals("ABCDEFGHIJKLMNOP", dest.readText())
+    }
+
+    @Test
+    fun `wrong nonzero range offset retries from scratch`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setBody("IJKLMNOP")
+                .setHeader("Content-Range", "bytes 8-15/16")
+        )
+        server.enqueue(MockResponse().setBody("ABCDEFGHIJKLMNOP"))
+
+        val dest = File(tmpDir.root, "model.onnx")
+        File(tmpDir.root, "model.onnx.tmp").writeText("ABCD")
+        download(dest)
+
+        assertEquals("bytes=4-", server.takeRequest().getHeader("Range"))
+        assertNull(server.takeRequest().getHeader("Range"))
+        assertEquals("ABCDEFGHIJKLMNOP", dest.readText())
+    }
+
+    @Test
+    fun `range body longer than declared retries from scratch`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setBody("EFGHIJKLMNOP")
+                .setHeader("Content-Range", "bytes 4-7/16")
+        )
+        server.enqueue(MockResponse().setBody("ABCDEFGHIJKLMNOP"))
+
+        val dest = File(tmpDir.root, "model.onnx")
+        File(tmpDir.root, "model.onnx.tmp").writeText("ABCD")
+        download(dest)
+
+        assertEquals("bytes=4-", server.takeRequest().getHeader("Range"))
+        assertNull(server.takeRequest().getHeader("Range"))
+        assertEquals("ABCDEFGHIJKLMNOP", dest.readText())
+    }
+
+    @Test
+    fun `valid intermediate range resumes from its new offset`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setBody("EFGH")
+                .setHeader("Content-Range", "bytes 4-7/16")
+        )
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setBody("IJKLMNOP")
+                .setHeader("Content-Range", "bytes 8-15/16")
+        )
+
+        val dest = File(tmpDir.root, "model.onnx")
+        File(tmpDir.root, "model.onnx.tmp").writeText("ABCD")
+        download(dest)
+
+        assertEquals("bytes=4-", server.takeRequest().getHeader("Range"))
+        assertEquals("bytes=8-", server.takeRequest().getHeader("Range"))
         assertEquals("ABCDEFGHIJKLMNOP", dest.readText())
     }
 

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerDownloadTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerDownloadTest.kt
@@ -8,6 +8,8 @@ import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
@@ -152,6 +154,46 @@ class ModelManagerDownloadTest {
         // On a 206 the response length is only the remaining range; the
         // reported file total must include the bytes already on disk.
         assertEquals(16L to 16L, totals.last())
+    }
+
+    @Test
+    fun `resumed download that ends short is rejected`() {
+        // The quiet case: the server returns fewer bytes than the requested
+        // range and closes cleanly, so the transfer itself looks successful. A
+        // truncated model keeps genuine leading bytes, so the header check
+        // passes too and it is cached as valid — the failure only surfaces
+        // later, when the runtime cannot parse it.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setBody("EFGH")  // 4 bytes, but the range promises 12
+                .setHeader("Content-Range", "bytes 4-15/16")
+        )
+
+        val dest = File(tmpDir.root, "model.onnx")
+        File(tmpDir.root, "model.onnx.tmp").writeText("ABCD")
+
+        // One attempt: a retry would resume again and append more, which is
+        // the right behaviour but not what this test is pinning down.
+        val error = assertThrows(IOException::class.java) { download(dest, maxRetries = 1) }
+        assert(error.message!!.contains("Incomplete download")) { error.message!! }
+        assertFalse("a short resume must not be published", dest.exists())
+    }
+
+    @Test
+    fun `complete resume is still accepted`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setBody("EFGHIJKLMNOP")
+                .setHeader("Content-Range", "bytes 4-15/16")
+        )
+
+        val dest = File(tmpDir.root, "model.onnx")
+        File(tmpDir.root, "model.onnx.tmp").writeText("ABCD")
+        download(dest)
+
+        assertEquals("ABCDEFGHIJKLMNOP", dest.readText())
     }
 
     @Test


### PR DESCRIPTION
## Summary

A resumed download could be renamed into place while incomplete or malformed, cached as valid, and only fail much later when the runtime could not parse it. Two distinct holes, both in `ModelManager.downloadFile`.

Found while adding a 374 MB model, but it applies to every download, and the largest bundles are the most exposed — resume only engages on transfers long enough to be interrupted. An 891 MB Parakeet fetch has far more opportunity to hit this than a small one.

## The two failures

**1. A resumed transfer was never size-checked.** The completeness test was guarded by `!isResume`, so a download that reconnected with `Range` and came back short was treated as finished.

**2. A `206` does not guarantee the body starts where the `Range` asked.** A server or CDN that answers from byte 0 while we append at our offset produces a file *larger* than the real one — genuine header, corrupt middle.

Observed against HuggingFace: an 11,747,400-byte partial with the full 112,413,411-byte body appended, landing at exactly 124,160,811 bytes on disk.

## Why it stayed hidden

`isValidModel` checks the ONNX magic bytes, and a truncated *or* over-appended file keeps genuine leading bytes, so it passes. The size floors in `MIN_SIZES` are minimums, which by construction cannot reject a file that is too big.

So the file was cached as valid and failed at load, as `Protobuf parsing failed` against a file that looks fine on disk and re-downloads to the same state on every retry. Nothing in the failure points at the download.

## The fix

- The finished size is checked on both paths. On a `206` the expected total comes from `Content-Range`, which is authoritative and present even when `Content-Length` is not — the case that would otherwise still slip through, since the transfer itself completes cleanly.
- The `Content-Range` start is compared against what was requested, and the transfer restarts from scratch when they disagree.

## Test plan

`./gradlew :sdk:test` — 13 tests in `ModelManagerDownloadTest`, including two new ones:

- a `206` returning fewer bytes than the requested range, closing cleanly — rejected with `Incomplete download`, nothing published to the destination
- a `206` answering from offset 0 while resuming from 4 — restarts rather than appending, producing the correct 16 bytes

Both were harder to write than expected and worth describing, since the obvious versions do not test the fix:

- an abrupt disconnect is caught by OkHttp itself, so it never reaches this code
- retrying a short response lets each attempt append more until the total coincidentally matches, and the test passes without the fix

The first is pinned to a single attempt for that reason.

`unitTests.isReturnDefaultValues` is enabled for `:sdk` so `android.util.Log` returns defaults instead of throwing, letting the restart path log for field diagnosis.