### PR TITLE
Add Canary STT and bump speech-core to v0.0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repo is the **Android packaging**: Kotlin SDK, JNI bridge, demo app. The C+
 | --- | --- | --- | --- | --- |
 | [Parakeet-EOU 120M](https://soniqo.audio/guides/dictate) | Streaming STT + end-of-utterance (default) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/guides/parakeet/android) | Broad-coverage STT (optional) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
+| [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | Offline STT + translation (optional) | [273 MB](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | not yet measured | 4 (en, de, es, fr) |
 | [Kokoro 82M](https://soniqo.audio/guides/kokoro/android) | Text-to-speech (default) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Streaming text-to-speech (optional, fixed Alba voice) | ~126 MB | not yet measured | English |
 | [Supertonic-3](https://soniqo.audio/guides/supertonic) | Text-to-speech (LiteRT, flow-matching, G2P-free, 44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |

--- a/README_de.md
+++ b/README_de.md
@@ -29,6 +29,7 @@ Dieses Repo ist das **Android-Packaging**: Kotlin-SDK, JNI-Bridge, Demo-App. Die
 | --- | --- | --- | --- | --- |
 | [Parakeet-EOU 120M](https://soniqo.audio/de/guides/dictate) | Streaming-STT + EOU (Standard) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/de/guides/parakeet/android) | Breite STT-Abdeckung (optional) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1,1-1,3 GB | 114 |
+| [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | Offline-STT + Übersetzung (optional) | [273 MB](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | noch nicht gemessen | 4 (en, de, es, fr) |
 | [Kokoro 82M](https://soniqo.audio/de/guides/kokoro/android) | Text-to-Speech (Standard) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Streaming-Text-to-Speech (optional, feste Alba-Stimme) | ~126 MB | noch nicht gemessen | Englisch |
 | [Supertonic-3](https://soniqo.audio/de/guides/supertonic) | Text-to-Speech (LiteRT, Flow-Matching, G2P-frei, 44,1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |

--- a/README_es.md
+++ b/README_es.md
@@ -29,6 +29,7 @@ Este repositorio es el **empaquetado para Android**: SDK de Kotlin, puente JNI, 
 | --- | --- | --- | --- | --- |
 | [Parakeet-EOU 120M](https://soniqo.audio/es/guides/dictate) | STT en streaming + EOU (por defecto) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/es/guides/parakeet/android) | STT de cobertura amplia (opcional) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
+| [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | STT sin conexión + traducción (opcional) | [273 MB](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | aún sin medir | 4 (en, de, es, fr) |
 | [Kokoro 82M](https://soniqo.audio/es/guides/kokoro/android) | Texto a voz (por defecto) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Texto a voz en streaming (opcional, voz Alba fija) | ~126 MB | aún no medido | Inglés |
 | [Supertonic-3](https://soniqo.audio/es/guides/supertonic) | Texto a voz (LiteRT, flow-matching, G2P-free, 44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |

--- a/README_fr.md
+++ b/README_fr.md
@@ -29,6 +29,7 @@ Ce dépôt fournit le **packaging Android** : SDK Kotlin, pont JNI, application 
 | --- | --- | --- | --- | --- |
 | [Parakeet-EOU 120M](https://soniqo.audio/fr/guides/dictate) | STT streaming + EOU (défaut) | [153 Mo](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 Mo | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/fr/guides/parakeet/android) | STT large couverture (optionnel) | [891 Mo](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1,1-1,3 Go | 114 |
+| [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | STT hors ligne + traduction (optionnel) | [273 MB](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | pas encore mesuré | 4 (en, de, es, fr) |
 | [Kokoro 82M](https://soniqo.audio/fr/guides/kokoro/android) | Synthèse vocale (défaut) | [330 Mo](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 Mo | 8 (en, fr, es, it, pt, hi, ja, zh) |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Synthèse vocale streaming (optionnel, voix Alba fixe) | ~126 Mo | pas encore mesuré | Anglais |
 | [Supertonic-3](https://soniqo.audio/fr/guides/supertonic) | Synthèse vocale (LiteRT, flow-matching, G2P-free, 44,1 kHz) | [~380 Mo](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 Mo | 31 |

--- a/README_hi.md
+++ b/README_hi.md
@@ -29,6 +29,7 @@ Android के लिए ऑन-डिवाइस स्पीच SDK, [ONNX Ru
 | --- | --- | --- | --- | --- |
 | [Parakeet-EOU 120M](https://soniqo.audio/hi/guides/dictate) | स्ट्रीमिंग STT + EOU (डिफ़ॉल्ट) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/hi/guides/parakeet/android) | व्यापक STT (वैकल्पिक) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
+| [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | Offline STT + translation (optional) | [273 MB](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | not yet measured | 4 (en, de, es, fr) |
 | [Kokoro 82M](https://soniqo.audio/hi/guides/kokoro/android) | टेक्स्ट-टू-स्पीच (डिफ़ॉल्ट) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | स्ट्रीमिंग टेक्स्ट-टू-स्पीच (वैकल्पिक, स्थिर Alba आवाज़) | ~126 MB | अभी मापा नहीं गया | अंग्रेज़ी |
 | [Supertonic-3](https://soniqo.audio/hi/guides/supertonic) | टेक्स्ट-टू-स्पीच (LiteRT, फ़्लो-मैचिंग, G2P-free, 44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |

--- a/README_ja.md
+++ b/README_ja.md
@@ -29,6 +29,7 @@
 | --- | --- | --- | --- | --- |
 | [Parakeet-EOU 120M](https://soniqo.audio/ja/guides/dictate) | ストリーミング STT + EOU(既定) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/ja/guides/parakeet/android) | 広範囲 STT(任意) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
+| [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | オフライン STT + 翻訳（任意） | [273 MB](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | 未計測 | 4 (en, de, es, fr) |
 | [Kokoro 82M](https://soniqo.audio/ja/guides/kokoro/android) | テキスト読み上げ(既定) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | ストリーミング音声合成(任意、固定 Alba 音声) | ~126 MB | 未計測 | 英語 |
 | [Supertonic-3](https://soniqo.audio/ja/guides/supertonic) | テキスト読み上げ(LiteRT、flow-matching、G2P-free、44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |

--- a/README_ko.md
+++ b/README_ko.md
@@ -29,6 +29,7 @@
 | --- | --- | --- | --- | --- |
 | [Parakeet-EOU 120M](https://soniqo.audio/ko/guides/dictate) | 스트리밍 STT + EOU(기본) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/ko/guides/parakeet/android) | 광범위 STT(선택) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
+| [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | 오프라인 STT + 번역 (선택) | [273 MB](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | 아직 측정하지 않음 | 4 (en, de, es, fr) |
 | [Kokoro 82M](https://soniqo.audio/ko/guides/kokoro/android) | 텍스트 음성 변환(기본) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8(en, fr, es, it, pt, hi, ja, zh) |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | 스트리밍 음성 합성(선택, 고정 Alba 음성) | ~126 MB | 미측정 | 영어 |
 | [Supertonic-3](https://soniqo.audio/ko/guides/supertonic) | 텍스트 음성 변환(LiteRT, flow-matching, G2P-free, 44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |

--- a/README_pt.md
+++ b/README_pt.md
@@ -29,6 +29,7 @@ Este repositório é o **empacotamento Android**: SDK Kotlin, ponte JNI, app de 
 | --- | --- | --- | --- | --- |
 | [Parakeet-EOU 120M](https://soniqo.audio/pt/guides/dictate) | STT em streaming + EOU (padrão) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/pt/guides/parakeet/android) | STT de ampla cobertura (opcional) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1,1-1,3 GB | 114 |
+| [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | STT offline + tradução (opcional) | [273 MB](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | ainda não medido | 4 (en, de, es, fr) |
 | [Kokoro 82M](https://soniqo.audio/pt/guides/kokoro/android) | Texto para fala (padrão) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8 (en, fr, es, it, pt, hi, ja, zh) |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Texto para fala em streaming (opcional, voz Alba fixa) | ~126 MB | ainda não medido | Inglês |
 | [Supertonic-3](https://soniqo.audio/pt/guides/supertonic) | Texto para fala (LiteRT, flow-matching, G2P-free, 44,1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |

--- a/README_ru.md
+++ b/README_ru.md
@@ -29,6 +29,7 @@
 | --- | --- | --- | --- | --- |
 | [Parakeet-EOU 120M](https://soniqo.audio/ru/guides/dictate) | Потоковый STT + EOU (по умолчанию) | [153 МБ](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 МБ | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/ru/guides/parakeet/android) | STT с широким покрытием (опционально) | [891 МБ](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1,1-1,3 ГБ | 114 |
+| [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | Офлайн STT + перевод (опционально) | [273 MB](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | ещё не измерено | 4 (en, de, es, fr) |
 | [Kokoro 82M](https://soniqo.audio/ru/guides/kokoro/android) | Синтез речи (по умолчанию) | [330 МБ](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 МБ | 8 (en, fr, es, it, pt, hi, ja, zh) |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Потоковый синтез речи (опционально, фиксированный голос Alba) | ~126 МБ | ещё не измерено | Английский |
 | [Supertonic-3](https://soniqo.audio/ru/guides/supertonic) | Синтез речи (LiteRT, flow-matching, G2P-free, 44,1 кГц) | [~380 МБ](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 МБ | 31 |

--- a/README_zh.md
+++ b/README_zh.md
@@ -29,6 +29,7 @@
 | --- | --- | --- | --- | --- |
 | [Parakeet-EOU 120M](https://soniqo.audio/zh/guides/dictate) | 流式 STT + 端点检测(默认) | [153 MB](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) | 232 MB | 25 |
 | [Parakeet TDT v3](https://soniqo.audio/zh/guides/parakeet/android) | 广覆盖 STT(可选) | [891 MB](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) | ~1.1-1.3 GB | 114 |
+| [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | 离线 STT + 翻译（可选） | [273 MB](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | 尚未测量 | 4 (en, de, es, fr) |
 | [Kokoro 82M](https://soniqo.audio/zh/guides/kokoro/android) | 文本转语音(默认) | [330 MB](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | 640 MB | 8(en、fr、es、it、pt、hi、ja、zh) |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | 流式文本转语音(可选,固定 Alba 音色) | ~126 MB | 尚未测量 | 英语 |
 | [Supertonic-3](https://soniqo.audio/zh/guides/supertonic) | 文本转语音(LiteRT、流匹配、免 G2P、44.1 kHz) | [~380 MB](https://huggingface.co/soniqo/Supertonic-3-LiteRT) | 832 MB | 31 |

--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/CanarySttTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/CanarySttTest.kt
@@ -1,0 +1,175 @@
+package audio.soniqo.speech
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.flow.first
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * On-device Canary STT through the full pipeline.
+ *
+ * Canary is offline per utterance — the encoder consumes the whole segment
+ * before the first token — so there is nothing streaming to assert here.
+ * Starting the pipeline is itself a real check: the wrapper reads its prompt,
+ * decoder cache shape and end-of-text id from the bundle's graph metadata and
+ * throws if any of it is missing, so a partially downloaded bundle fails loudly
+ * instead of decoding something fluent and wrong.
+ */
+@RunWith(AndroidJUnit4::class)
+class CanarySttTest {
+
+    private lateinit var modelDir: String
+
+    @Before
+    fun setup() = runBlocking {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        modelDir = ModelManager.ensureModels(ctx, sttModel = SttModel.CANARY)
+    }
+
+    @Test
+    fun pipelineStateTransitions() {
+        val pipeline = SpeechPipeline(canaryConfig())
+        try {
+            assertEquals(PipelineState.Idle, pipeline.state)
+            pipeline.start()
+            assertTrue(
+                pipeline.state == PipelineState.Idle ||
+                pipeline.state == PipelineState.Listening
+            )
+            pipeline.stop()
+        } finally {
+            pipeline.close()
+        }
+    }
+
+    @Test
+    fun acceptsEverySupportedLanguage() {
+        // en, de, es and fr have prompt tokens in the bundle. An unknown code
+        // leaves the bundle's default in place rather than failing to build the
+        // pipeline, so "zz" must start just as cleanly.
+        for (language in listOf("en", "de", "es", "fr", "zz")) {
+            val pipeline = SpeechPipeline(canaryConfig(language))
+            try {
+                pipeline.start()
+                pipeline.stop()
+            } finally {
+                pipeline.close()
+            }
+        }
+    }
+
+    @Test
+    fun sttTranscribesSynthesizedEnglish() = runBlocking {
+        val pipeline = SpeechPipeline(canaryConfig())
+        try {
+            pipeline.start()
+            val eventDeferred = async {
+                withTimeout(60_000) {
+                    pipeline.events.first { it is SpeechEvent.TranscriptionCompleted }
+                }
+            }
+
+            val synthesizer = SpeechSynthesizer(
+                SpeechSynthesizerConfig(modelDir = modelDir, useNnapi = false)
+            )
+            val audio = synthesizer.use {
+                val spoken = it.synthesize("The quick brown fox jumps over the dog.", "en")
+                assertTrue("Synthesized fixture should not be empty", spoken.pcm16.isNotEmpty())
+                pcm16ToFloat16k(spoken.pcm16, spoken.sampleRate)
+            }
+            assertTrue("Synthesized fixture should contain audio", audio.isNotEmpty())
+
+            for (offset in audio.indices step 512) {
+                val end = minOf(offset + 512, audio.size)
+                pipeline.pushAudio(audio.sliceArray(offset until end))
+                delay(32) // 512 samples @ 16 kHz = 32 ms
+            }
+
+            // Silence closes the turn, which is when Canary decodes.
+            val silence = FloatArray(16000)
+            for (offset in silence.indices step 512) {
+                pipeline.pushAudio(
+                    silence.sliceArray(offset until minOf(offset + 512, silence.size))
+                )
+                delay(32)
+            }
+
+            val tc = eventDeferred.await() as SpeechEvent.TranscriptionCompleted
+            assertTrue("Transcription should not be empty", tc.text.isNotBlank())
+            assertTrue(
+                "Confidence should be in range, was ${tc.confidence}",
+                tc.confidence in 0.0f..1.0f
+            )
+
+            val text = tc.text.lowercase()
+            val expectedWords = listOf("quick", "brown", "fox", "dog")
+            val matched = expectedWords.count { it in text }
+            assertTrue(
+                "Expected at least 2 of $expectedWords in '$text', matched $matched",
+                matched >= 2
+            )
+        } finally {
+            pipeline.stop()
+            pipeline.close()
+        }
+    }
+
+    @Test
+    fun silenceProducesNoTranscript() = runBlocking {
+        val pipeline = SpeechPipeline(canaryConfig())
+        try {
+            pipeline.start()
+            val silence = FloatArray(16000 * 3)
+            for (offset in silence.indices step 512) {
+                pipeline.pushAudio(
+                    silence.sliceArray(offset until minOf(offset + 512, silence.size))
+                )
+                delay(32)
+            }
+            delay(1000)
+            assertTrue(
+                "Silence should leave the pipeline idle or listening, was ${pipeline.state}",
+                pipeline.state == PipelineState.Idle ||
+                pipeline.state == PipelineState.Listening
+            )
+        } finally {
+            pipeline.stop()
+            pipeline.close()
+        }
+    }
+
+    private fun pcm16ToFloat16k(pcm16: ByteArray, sourceSampleRate: Int): FloatArray {
+        val shorts = ShortArray(pcm16.size / 2)
+        ByteBuffer.wrap(pcm16)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .asShortBuffer()
+            .get(shorts)
+        val source = FloatArray(shorts.size) { i -> shorts[i] / 32768.0f }
+        if (sourceSampleRate == 16000) return source
+
+        val outputSize = ((source.size.toLong() * 16000L) / sourceSampleRate).toInt()
+        return FloatArray(outputSize) { i ->
+            val src = i.toDouble() * sourceSampleRate.toDouble() / 16000.0
+            val lo = src.toInt().coerceIn(0, source.lastIndex)
+            val hi = (lo + 1).coerceAtMost(source.lastIndex)
+            val frac = (src - lo).toFloat()
+            source[lo] * (1f - frac) + source[hi] * frac
+        }
+    }
+
+    private fun canaryConfig(language: String = "en"): SpeechConfig = SpeechConfig(
+        modelDir = modelDir,
+        useNnapi = false,
+        sttModel = SttModel.CANARY,
+        language = language,
+    )
+}

--- a/sdk/src/main/cpp/jni_bridge.cpp
+++ b/sdk/src/main/cpp/jni_bridge.cpp
@@ -4,6 +4,7 @@
 #include <speech_core/models/deepfilter.h>
 #include <speech_core/models/kokoro_tts.h>
 #include <speech_core/models/onnx_engine.h>
+#include <speech_core/models/onnx_canary_stt.h>
 #include <speech_core/models/onnx_nemotron_streaming_stt.h>
 #include <speech_core/models/onnx_pocket_tts.h>
 #include <speech_core/models/parakeet_stt.h>
@@ -71,6 +72,7 @@ struct SynthesizerHandle {
 static constexpr int STT_PARAKEET = 0;
 static constexpr int STT_NEMOTRON_MULTILINGUAL = 1;
 static constexpr int STT_PARAKEET_EOU = 2;
+static constexpr int STT_CANARY = 3;
 static constexpr int BACKEND_ONNX = 0;
 static constexpr int BACKEND_LITERT = 1;
 static constexpr int TTS_KOKORO = 0;
@@ -286,6 +288,24 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
                 if (lang != "auto" && !lang.empty()) m->set_language(lang);
                 h->stt = std::move(m);
             }
+        } else if (sttModel == STT_CANARY) {
+            // Canary 180M Flash is offline per utterance: the encoder runs on
+            // the whole VAD segment, then tokens decode one at a time. The
+            // wrapper reads its prompt, cache shape and end-of-text from the
+            // bundle's graph metadata, so nothing is configured here beyond
+            // the language. English, German, Spanish and French; an unknown
+            // code leaves the bundle's default in place rather than failing
+            // the whole pipeline.
+            auto m = std::make_unique<speech_core::OnnxCanaryStt>(
+                dir + "/canary-encoder-int8.onnx",
+                dir + "/canary-decoder-int8.onnx",
+                dir + "/vocab.json",
+                nnapi);
+            if (lang != "auto" && !lang.empty() && !m->set_language(lang)) {
+                LOGI("Canary has no prompt token for '%s', keeping the bundle default",
+                     lang.c_str());
+            }
+            h->stt = std::move(m);
         } else if (sttModel == STT_PARAKEET_EOU) {
             // beamSize > 1 enables modified beam search, which contextual
             // biasing (nativeSetContextPhrases) rides on; <= 1 stays greedy.

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -85,6 +85,21 @@ object ModelManager {
                 ModelFile("Parakeet-TDT-v3-ONNX", "parakeet-decoder-joint${suffix}.onnx"),
                 ModelFile("Parakeet-TDT-v3-ONNX", "vocab.json"),
             )
+            // Canary 180M Flash: offline attention-encoder-decoder, en/de/es/fr
+            // with punctuation, and translation between those four from the same
+            // graphs. INT8-only here — [precision] does not alter the filenames.
+            // The quantization covers MatMul/Gemm and leaves the convolutions in
+            // FP32 on purpose: an encoder quantized with ConvInteger does not run
+            // on the mobile onnxruntime build, which is the same limitation
+            // documented for Nemotron below.
+            // config.json is required, not optional: the wrapper reads the decode
+            // prompt, cache dimensions and end-of-text id out of the bundle.
+            SttModel.CANARY -> files += listOf(
+                ModelFile("Canary-180M-Flash-ONNX", "canary-encoder-int8.onnx"),
+                ModelFile("Canary-180M-Flash-ONNX", "canary-decoder-int8.onnx"),
+                ModelFile("Canary-180M-Flash-ONNX", "vocab.json"),
+                ModelFile("Canary-180M-Flash-ONNX", "config.json"),
+            )
             SttModel.NEMOTRON_MULTILINGUAL -> {
                 val base = "Nemotron-3.5-ASR-Streaming-Multilingual-0.6B"
                 files += when (sttBackend) {

--- a/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
@@ -10,7 +10,8 @@ internal object NativeBridge {
         modelDir: String,
         useNnapi: Boolean,
         useInt8: Boolean,
-        sttModel: Int,    // SttModel.ordinal: 0=PARAKEET, 1=NEMOTRON_MULTILINGUAL, 2=PARAKEET_EOU
+        sttModel: Int,    // SttModel.ordinal: 0=PARAKEET, 1=NEMOTRON_MULTILINGUAL,
+                          //                  2=PARAKEET_EOU, 3=CANARY
         sttBackend: Int,  // SttBackend.ordinal: 0=ONNX, 1=LITERT
         ttsModel: Int,    // 0=KOKORO, 1=SUPERTONIC, 2=KOKORO_SHORT_TURN, 3=POCKET
         pipelineMode: Int, // PipelineMode.ordinal: 0=ECHO, 1=TRANSCRIBE_ONLY

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
@@ -5,7 +5,7 @@ enum class ModelPrecision { FP32, INT8 }
 /** On-device STT model. PARAKEET_EOU is the low-memory streaming default.
  *  PARAKEET is the larger TDT v3 model with language-token detection;
  *  NEMOTRON_MULTILINGUAL is prompt-conditioned and uses [SpeechConfig.language]. */
-enum class SttModel { PARAKEET, NEMOTRON_MULTILINGUAL, PARAKEET_EOU }
+enum class SttModel { PARAKEET, NEMOTRON_MULTILINGUAL, PARAKEET_EOU, CANARY }
 
 /** Native inference backend for the STT model. Only Nemotron multilingual
  *  ships both; Parakeet is ONNX-only. */

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
@@ -52,6 +52,35 @@ class ModelManagerManifestTest {
     }
 
     @Test
+    fun `canary manifest ships the int8 pair and its decode contract`() {
+        val canaryFiles = modelFiles(sttModel = SttModel.CANARY)
+            .filter { it.repo == "Canary-180M-Flash-ONNX" }
+
+        // config.json is not optional here: the wrapper reads the decode
+        // prompt, cache dimensions and end-of-text id out of the bundle, and
+        // refuses to construct without them.
+        val expected = listOf(
+            ModelManager.ModelFile("Canary-180M-Flash-ONNX", "canary-encoder-int8.onnx"),
+            ModelManager.ModelFile("Canary-180M-Flash-ONNX", "canary-decoder-int8.onnx"),
+            ModelManager.ModelFile("Canary-180M-Flash-ONNX", "vocab.json"),
+            ModelManager.ModelFile("Canary-180M-Flash-ONNX", "config.json"),
+        )
+
+        assertEquals(expected, canaryFiles)
+    }
+
+    @Test
+    fun `canary keeps its int8 filenames at fp32 precision`() {
+        // The bundle publishes one quantization, so precision must not rewrite
+        // the filenames the way it does for Parakeet.
+        assertEquals(
+            modelFiles(sttModel = SttModel.CANARY).filter { it.repo == "Canary-180M-Flash-ONNX" },
+            modelFiles(precision = ModelPrecision.FP32, sttModel = SttModel.CANARY)
+                .filter { it.repo == "Canary-180M-Flash-ONNX" },
+        )
+    }
+
+    @Test
     fun `model set key changes when stt model changes`() {
         assertNotEquals(
             modelSetKey(sttModel = SttModel.PARAKEET_EOU),


### PR DESCRIPTION
## Summary

`SttModel.CANARY` selects NVIDIA Canary 180M Flash — an offline
attention-encoder-decoder covering en/de/es/fr with punctuation, and translation
between those four from the same graphs. Submodule moves to
[v0.0.12](https://github.com/soniqo/speech-core/releases/tag/v0.0.12), which
carries the wrapper.

Offline per utterance: the encoder consumes the whole VAD segment before the
first token, so there is no streaming or partial-result behaviour on this path.

## What changed

- `SpeechConfig.kt` — `SttModel.CANARY` (ordinal 3)
- `jni_bridge.cpp` — `STT_CANARY` branch constructing `OnnxCanaryStt`. The
  wrapper reads its prompt, decoder cache dimensions and end-of-text id from
  the bundle's ONNX metadata, so the bridge configures nothing beyond the
  language; an unrecognised code keeps the bundle default rather than failing
  construction.
- `ModelManager.kt` — bundle manifest from
  [soniqo/Canary-180M-Flash-ONNX](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX):
  INT8 encoder/decoder, `vocab.json`, `config.json`. `config.json` is required,
  not optional — the wrapper will not construct without the decode contract.
- README model row, mirrored across all nine translations
- `ModelManagerManifestTest` — manifest contents, and that precision does not
  rewrite the filenames (the bundle publishes one quantization)
- `CanarySttTest` — instrumented suite: state transitions, every supported
  language plus an unknown one, a synthesized-speech transcription, and silence

## On the quantization

The bundle quantizes MatMul/Gemm and leaves the convolutions in FP32. That is
deliberate: an encoder quantized with `ConvInteger` does not run on the mobile
onnxruntime build — the same limitation already documented in `ModelManager` for
the Nemotron ONNX path. It costs ~40 MB of download and buys a bundle that
actually loads.

## Test plan

- `./gradlew :sdk:test` — BUILD SUCCESSFUL, including the two new
  `ModelManagerManifestTest` cases
- `./gradlew :sdk:assembleDebug` — BUILD SUCCESSFUL; the JNI bridge compiles
  against speech-core v0.0.12 for arm64-v8a and x86_64. Verified in the built
  `libspeech_android.so` rather than from the task list:

  ```
  N11speech_core13OnnxCanarySttE
  /canary-encoder-int8.onnx
  /canary-decoder-int8.onnx
  Canary has no prompt token for '%s', keeping the bundle default
  ```

- `CanarySttTest` has **not** been run — it needs a device or an arm64 emulator.
- The README peak-memory column is deliberately blank: the only figure measured
  so far is from a desktop ONNX Runtime process, not this SDK on hardware.