### PR TITLE
Pin the Canary bundle to one revision

### DIFF
--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -23,6 +23,13 @@ object ModelManager {
     private const val BASE_URL = "https://huggingface.co/soniqo"
     private const val POCKET_TTS_REVISION = "v1.0.0"
     private const val POCKET_TTS_DIR = "pocket_tts"
+    // Canary publishes no tags, so this is the commit that the bundle in the
+    // README model table was measured against. Pinned rather than tracking
+    // main: the wrapper reads its decode prompt, cache dimensions and input
+    // signature out of the bundle, so a re-export changes what the native side
+    // must feed the graph. An unpinned fetch turns that into a runtime type
+    // mismatch on a device that happened to download after the change.
+    private const val CANARY_REVISION = "7e9f3f9cc47a877f47bda6ace292111c143be0fe"
     private const val NEMOTRON_LITERT_INT8_REVISION = "v1.0.0"
     private const val NEMOTRON_LITERT_FP16_REVISION =
         "1503a9a1eb75b813b83ba65bf5e9fecea4a46091"
@@ -95,10 +102,14 @@ object ModelManager {
             // config.json is required, not optional: the wrapper reads the decode
             // prompt, cache dimensions and end-of-text id out of the bundle.
             SttModel.CANARY -> files += listOf(
-                ModelFile("Canary-180M-Flash-ONNX", "canary-encoder-int8.onnx"),
-                ModelFile("Canary-180M-Flash-ONNX", "canary-decoder-int8.onnx"),
-                ModelFile("Canary-180M-Flash-ONNX", "vocab.json"),
-                ModelFile("Canary-180M-Flash-ONNX", "config.json"),
+                ModelFile("Canary-180M-Flash-ONNX", "canary-encoder-int8.onnx",
+                    revision = CANARY_REVISION),
+                ModelFile("Canary-180M-Flash-ONNX", "canary-decoder-int8.onnx",
+                    revision = CANARY_REVISION),
+                ModelFile("Canary-180M-Flash-ONNX", "vocab.json",
+                    revision = CANARY_REVISION),
+                ModelFile("Canary-180M-Flash-ONNX", "config.json",
+                    revision = CANARY_REVISION),
             )
             SttModel.NEMOTRON_MULTILINGUAL -> {
                 val base = "Nemotron-3.5-ASR-Streaming-Multilingual-0.6B"
@@ -605,6 +616,12 @@ object ModelManager {
         add("tts=${ttsCacheName(ttsModel)}")
         if (sttModel == SttModel.NEMOTRON_MULTILINGUAL && sttBackend == SttBackend.LITERT) {
             add("sttRevision=${nemotronLiteRtRevision(precision)}")
+        }
+        // Scoped to Canary rather than bumping MODEL_VERSION: an install that
+        // cached the bundle while it tracked main must discard it, but nothing
+        // else needs to re-download ~1.2 GB to get there.
+        if (sttModel == SttModel.CANARY) {
+            add("sttRevision=$CANARY_REVISION")
         }
     }.joinToString("|")
 

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
@@ -58,12 +58,18 @@ class ModelManagerManifestTest {
 
         // config.json is not optional here: the wrapper reads the decode
         // prompt, cache dimensions and end-of-text id out of the bundle, and
-        // refuses to construct without them.
+        // refuses to construct without them. Every file is pinned to one
+        // revision for the same reason — the bundle defines what the native
+        // side must feed the graph, so tracking main lets a re-export change
+        // the contract underneath an install.
+        val revision = "7e9f3f9cc47a877f47bda6ace292111c143be0fe"
         val expected = listOf(
-            ModelManager.ModelFile("Canary-180M-Flash-ONNX", "canary-encoder-int8.onnx"),
-            ModelManager.ModelFile("Canary-180M-Flash-ONNX", "canary-decoder-int8.onnx"),
-            ModelManager.ModelFile("Canary-180M-Flash-ONNX", "vocab.json"),
-            ModelManager.ModelFile("Canary-180M-Flash-ONNX", "config.json"),
+            ModelManager.ModelFile(
+                "Canary-180M-Flash-ONNX", "canary-encoder-int8.onnx", revision),
+            ModelManager.ModelFile(
+                "Canary-180M-Flash-ONNX", "canary-decoder-int8.onnx", revision),
+            ModelManager.ModelFile("Canary-180M-Flash-ONNX", "vocab.json", revision),
+            ModelManager.ModelFile("Canary-180M-Flash-ONNX", "config.json", revision),
         )
 
         assertEquals(expected, canaryFiles)


### PR DESCRIPTION
## What

Canary was the only model in the manifest still tracking `main`. Every other entry either pins a tag (`NEMOTRON_LITERT_INT8_REVISION = "v1.0.0"`) or a commit.

That matters more for this bundle than most. The wrapper reads its decode prompt, decoder cache dimensions and end-of-text id out of the bundle's ONNX metadata, so the published files *are* the contract for what the native side feeds the graph. A re-export changes that contract, and an unpinned fetch hands the new bundle to code expecting the old one — surfacing as a runtime tensor type mismatch on whichever device happened to download after the change.

That is a plausible reading of an abort seen once on an S23 Ultra during pipeline warm-up:

```
ORT: Unexpected input data type. Actual: (tensor(int64)) , expected: (tensor(float))
```

Stated honestly: this is not a confirmed diagnosis. The crash has not reproduced and the app data from the run that produced it is gone. Pinning removes it as a variable either way, and soniqo/speech-core#126 makes the same failure survivable rather than fatal.

## Choices

- The HF repository publishes no tags, so this pins the commit the README model table was measured against (`7e9f3f9`, 2026-08-01).
- The revision joins the model-set cache key **scoped to Canary**, matching what #69 did for Nemotron/LiteRT, rather than bumping `MODEL_VERSION`. Installs that cached the bundle while it tracked main must discard it; nothing else should re-download ~1.2 GB to get there.

## Verification

`./gradlew :sdk:test` — 101 tests, 0 failures. `ModelManagerManifestTest` updated to assert the pin, since the point of the test is that the manifest is exactly what we think it is.