### PR TITLE
Make the VAD device timeout measure VAD work

### DIFF
--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/SileroVadTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/SileroVadTest.kt
@@ -55,6 +55,10 @@ class SileroVadTest {
 
     @Test
     fun synthesizedSpeechTriggersSpeechStartedAndEnded() = runBlocking {
+        // Fixture generation is deliberately outside the event timeouts. On a
+        // loaded emulator Kokoro can take longer than 30 seconds, but VAD has
+        // not received any audio yet and therefore has nothing to detect.
+        val audio = synthesize("The quick brown fox jumps over the lazy dog.")
         val pipeline = SpeechPipeline(SpeechConfig(modelDir = modelDir, useNnapi = false))
         try {
             pipeline.start()
@@ -69,7 +73,6 @@ class SileroVadTest {
                 }
             }
 
-            val audio = synthesize("The quick brown fox jumps over the lazy dog.")
             for (offset in audio.indices step 512) {
                 val end = minOf(offset + 512, audio.size)
                 val chunk = audio.sliceArray(offset until end)


### PR DESCRIPTION
## Summary

Move synthesized fixture generation ahead of the Silero VAD event timeouts. The timeout now measures the interval after audio is ready, rather than including Kokoro fixture generation.

## Why

During the complete pre-release device suite, this test started its 30-second SpeechStarted timeout and then synchronously generated its audio fixture. On the loaded arm64 emulator, fixture synthesis took about 55 seconds. SpeechStarted was emitted correctly once audio was finally pushed, but the timer had already expired.

This is a test-only timing correction. SDK and runtime behavior are unchanged.

## Test plan

- ./gradlew :sdk:test
- Isolated arm64 Android 15 device test: SileroVadTest#synthesizedSpeechTriggersSpeechStartedAndEnded
- Result: 1/1 passed; BUILD SUCCESSFUL

## Related

Found while running the mandatory full connectedAndroidTest gate before the v0.0.17 release.