### PR TITLE
Prepare v0.0.17 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Download the [signed APK](https://github.com/soniqo/speech-android/releases/late
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.16")
+    implementation("audio.soniqo:speech:0.0.17")
 }
 ```
 

--- a/README_de.md
+++ b/README_de.md
@@ -70,7 +70,7 @@ Lade das [signierte APK](https://github.com/soniqo/speech-android/releases/lates
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.16")
+    implementation("audio.soniqo:speech:0.0.17")
 }
 ```
 

--- a/README_es.md
+++ b/README_es.md
@@ -70,7 +70,7 @@ Descarga el [APK firmado](https://github.com/soniqo/speech-android/releases/late
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.16")
+    implementation("audio.soniqo:speech:0.0.17")
 }
 ```
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -70,7 +70,7 @@ Téléchargez l'[APK signé](https://github.com/soniqo/speech-android/releases/l
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.16")
+    implementation("audio.soniqo:speech:0.0.17")
 }
 ```
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -70,7 +70,7 @@ val config = SpeechConfig(
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.16")
+    implementation("audio.soniqo:speech:0.0.17")
 }
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -70,7 +70,7 @@ val config = SpeechConfig(
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.16")
+    implementation("audio.soniqo:speech:0.0.17")
 }
 ```
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -70,7 +70,7 @@ val config = SpeechConfig(
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.16")
+    implementation("audio.soniqo:speech:0.0.17")
 }
 ```
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -70,7 +70,7 @@ Baixe o [APK assinado](https://github.com/soniqo/speech-android/releases/latest/
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.16")
+    implementation("audio.soniqo:speech:0.0.17")
 }
 ```
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -70,7 +70,7 @@ val config = SpeechConfig(
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.16")
+    implementation("audio.soniqo:speech:0.0.17")
 }
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -70,7 +70,7 @@ val config = SpeechConfig(
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.16")
+    implementation("audio.soniqo:speech:0.0.17")
 }
 ```
 


### PR DESCRIPTION
## Summary

- update the documented Maven dependency to 0.0.17
- keep all README translations synchronized
- prepare the tag-triggered release for the Control demo crash fix from #77 and the E2E timeout correction from #78

## Test plan

- ./gradlew :sdk:test
- verify all ten README dependency snippets use 0.0.17
- git diff --check

Related: #74, #77, #78