### PR TITLE
Per-call TTS voice preset on synthesize() (Supertonic / Kokoro)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ val config = SpeechConfig(
 non-autoregressive flow-matching graphs on-device at 44.1 kHz; the front-end is G2P-free (NFKD +
 Unicode index — no phonemizer), so all 31 languages go through one path.
 
+Both Kokoro and Supertonic take a per-call voice preset on direct synthesis —
+`pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`; Kokoro `af_heart`,
+`ff_siwis`, …) — and the same argument exists on `synthesizeStreaming` and `SpeechSynthesizer`.
+The preset applies to that call only; omit it (or pass `""`) to keep the engine default, and an
+unknown id throws.
+
 **FunctionGemma 270M** is a Gemma 3 derivative trained for structured tool
 calls. The Kotlin wrapper (`audio.soniqo.speech.llm.FunctionGemma`) is a
 runtime-agnostic shell: bring your own LiteRT-LM runtime adapter (see the

--- a/README_de.md
+++ b/README_de.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** ist ein optionales, höherwertiges mehrsprachiges TTS — wähle es mit `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` aus (erfordert das LiteRT-Backend). Der Host führt seine vier nicht-autoregressiven Flow-Matching-Graphen mit 44,1 kHz auf dem Gerät aus; das Front-End ist G2P-frei (NFKD + Unicode-Index — kein Phonemizer), sodass alle 31 Sprachen über einen einzigen Pfad laufen.
 
+Kokoro und Supertonic nehmen bei der direkten Synthese pro Aufruf ein Stimm-Preset entgegen — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`; Kokoro `af_heart`, `ff_siwis`, …) — dasselbe Argument gibt es auch bei `synthesizeStreaming` und `SpeechSynthesizer`. Das Preset gilt nur für diesen Aufruf; lässt man es weg (oder übergibt `""`), bleibt die Standardstimme der Engine erhalten, und eine unbekannte id wirft eine Exception.
+
 ## Demo ausprobieren
 
 Lade das [signierte APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) herunter und installiere es auf einem beliebigen arm64-Android-Gerät (8+). Das standardmäßige speicherarme Modellpaket (~500 MB) wird beim ersten Start automatisch heruntergeladen.

--- a/README_es.md
+++ b/README_es.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** es un TTS multilingüe opcional de mayor calidad — selecciónalo con `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (requiere el backend LiteRT). El host ejecuta sus cuatro grafos de flow-matching no autorregresivos en el dispositivo a 44.1 kHz; el front-end es G2P-free (NFKD + índice Unicode — sin fonemizador), por lo que los 31 idiomas pasan por una sola ruta.
 
+Tanto Kokoro como Supertonic aceptan un preset de voz por llamada en la síntesis directa — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`; Kokoro `af_heart`, `ff_siwis`, …) — y el mismo argumento existe en `synthesizeStreaming` y `SpeechSynthesizer`. El preset se aplica solo a esa llamada; omítelo (o pasa `""`) para mantener la voz por defecto del motor, y un id desconocido lanza una excepción.
+
 ## Prueba la demo
 
 Descarga el [APK firmado](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) e instálalo en cualquier dispositivo Android arm64 (8+). El paquete de modelos de baja memoria por defecto (~500 MB) se descarga automáticamente en el primer inicio.

--- a/README_fr.md
+++ b/README_fr.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** est une synthèse vocale multilingue de meilleure qualité, activable en option — sélectionnez-la avec `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (nécessite le backend LiteRT). L'hôte exécute ses quatre graphes de flow-matching non autorégressifs en local à 44,1 kHz ; le front-end est G2P-free (NFKD + index Unicode — aucun phonémiseur), de sorte que les 31 langues passent par un seul chemin.
 
+Kokoro et Supertonic acceptent un préréglage de voix par appel lors de la synthèse directe — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5` ; Kokoro `af_heart`, `ff_siwis`, …) — et le même argument existe sur `synthesizeStreaming` et `SpeechSynthesizer`. Le préréglage ne s'applique qu'à cet appel ; omettez-le (ou passez `""`) pour conserver la voix par défaut du moteur, et un id inconnu lève une exception.
+
 ## Essayer la démo
 
 Téléchargez l'[APK signé](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) et installez-le sur n'importe quel appareil Android arm64 (8+). Le bundle de modèles faible mémoire par défaut (~500 Mo) est téléchargé automatiquement au premier lancement.

--- a/README_hi.md
+++ b/README_hi.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** एक ऑप्ट-इन उच्च-गुणवत्ता वाला बहुभाषी TTS है — इसे `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` के साथ चुनें (LiteRT बैकएंड आवश्यक)। होस्ट इसके चार नॉन-ऑटोरिग्रेसिव फ़्लो-मैचिंग ग्राफ़ ऑन-डिवाइस 44.1 kHz पर चलाता है; फ़्रंट-एंड G2P-free है (NFKD + Unicode इंडेक्स — कोई फ़ोनेमाइज़र नहीं), इसलिए सभी 31 भाषाएँ एक ही पथ से होकर गुजरती हैं।
 
+Kokoro और Supertonic दोनों डायरेक्ट सिंथेसिस में प्रति-कॉल वॉइस प्रीसेट स्वीकार करते हैं — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`; Kokoro `af_heart`, `ff_siwis`, …) — और यही आर्ग्युमेंट `synthesizeStreaming` और `SpeechSynthesizer` पर भी मौजूद है। प्रीसेट केवल उसी कॉल पर लागू होता है; इसे छोड़ दें (या `""` पास करें) तो इंजन की डिफ़ॉल्ट आवाज़ बनी रहती है, और अज्ञात id पर अपवाद (exception) फेंका जाता है।
+
 ## डेमो आज़माएँ
 
 [हस्ताक्षरित APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) डाउनलोड करें और किसी भी arm64 Android डिवाइस (8+) पर इंस्टॉल करें। डिफ़ॉल्ट कम-मेमोरी मॉडल बंडल (~500 MB) पहले लॉन्च पर स्वचालित रूप से डाउनलोड होता है।

--- a/README_ja.md
+++ b/README_ja.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** はオプトインの高品質な多言語 TTS です — `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` で選択します(LiteRT バックエンドが必要)。ホストはその 4 つの非自己回帰 flow-matching グラフを 44.1 kHz でオンデバイス実行します。フロントエンドは G2P-free(NFKD + Unicode インデックス — phonemizer なし)なので、31 言語すべてが単一のパスを通ります。
 
+Kokoro と Supertonic はどちらも、直接合成の呼び出しごとに音声プリセットを指定できます — `pipeline.synthesize("Hello", "en", "M1")`(Supertonic は `F1`…`F5` / `M1`…`M5`、Kokoro は `af_heart`、`ff_siwis` など)。同じ引数は `synthesizeStreaming` と `SpeechSynthesizer` にもあります。プリセットはその呼び出しにのみ適用され、省略(または `""` を指定)するとエンジンのデフォルト音声のままになります。未知の id は例外を投げます。
+
 ## デモを試す
 
 [署名済み APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) をダウンロードし、任意の arm64 Android デバイス(8 以降)にインストールします。既定の低メモリモデルバンドル(~500 MB)は初回起動時に自動ダウンロードされます。

--- a/README_ko.md
+++ b/README_ko.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3**는 옵트인 방식의 더 높은 품질의 다국어 TTS입니다 — `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)`로 선택하세요(LiteRT 백엔드가 필요합니다). 호스트는 4개의 비자기회귀(non-autoregressive) flow-matching 그래프를 44.1 kHz로 온디바이스에서 실행합니다. 프런트엔드는 G2P-free(NFKD + 유니코드 인덱스 — 음소 변환기 없음)이므로 31개 언어 모두 하나의 경로를 통과합니다.
 
+Kokoro와 Supertonic 모두 직접 합성 시 호출 단위로 음성 프리셋을 지정할 수 있습니다 — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`, Kokoro `af_heart`, `ff_siwis` 등). 같은 인자가 `synthesizeStreaming`과 `SpeechSynthesizer`에도 있습니다. 프리셋은 해당 호출에만 적용되며, 생략하거나 `""`를 전달하면 엔진 기본 음성이 유지되고, 알 수 없는 id는 예외를 던집니다.
+
 ## 데모 사용해보기
 
 [서명된 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk)를 다운로드하여 arm64 Android 기기(8 이상)에 설치하세요. 기본 저메모리 모델 번들(~500 MB)은 첫 실행 시 자동으로 다운로드됩니다.

--- a/README_pt.md
+++ b/README_pt.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 O **Supertonic-3** é um TTS multilíngue opcional de maior qualidade — selecione-o com `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (requer o backend LiteRT). O host executa seus quatro grafos de flow-matching não autorregressivos no dispositivo a 44,1 kHz; o front-end é G2P-free (NFKD + índice Unicode — sem phonemizer), de modo que todos os 31 idiomas seguem um único caminho.
 
+Tanto o Kokoro quanto o Supertonic aceitam um preset de voz por chamada na síntese direta — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`; Kokoro `af_heart`, `ff_siwis`, …) — e o mesmo argumento existe em `synthesizeStreaming` e `SpeechSynthesizer`. O preset vale apenas para essa chamada; omita-o (ou passe `""`) para manter a voz padrão do motor, e um id desconhecido lança uma exceção.
+
 ## Experimente a demo
 
 Baixe o [APK assinado](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) e instale em qualquer dispositivo Android arm64 (8+). O pacote padrão de modelos de baixa memória (~500 MB) é baixado automaticamente no primeiro lançamento.

--- a/README_ru.md
+++ b/README_ru.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** — это опциональный многоязычный TTS повышенного качества: выберите его через `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (требуется бэкенд LiteRT). Хост выполняет его четыре неавторегрессионных flow-matching-графа на устройстве на частоте 44,1 кГц; фронтенд работает G2P-free (NFKD + индекс Unicode — без фонемизатора), поэтому все 31 язык проходят через один путь.
 
+Kokoro и Supertonic принимают пресет голоса на каждый вызов прямого синтеза — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`; Kokoro `af_heart`, `ff_siwis`, …) — тот же аргумент есть у `synthesizeStreaming` и `SpeechSynthesizer`. Пресет действует только для этого вызова; опустите его (или передайте `""`), чтобы сохранить голос движка по умолчанию, а неизвестный id вызывает исключение.
+
 ## Попробовать демо
 
 Скачайте [подписанный APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) и установите на любое arm64-устройство Android (8+). Стандартный низкопамятный набор моделей (~500 МБ) загружается автоматически при первом запуске.

--- a/README_zh.md
+++ b/README_zh.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** 是可选启用的更高质量多语言 TTS — 通过 `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` 选用(需要 LiteRT 后端)。宿主在设备端以 44.1 kHz 运行其四个非自回归流匹配图;前端免 G2P(NFKD + Unicode 索引 — 无音素转换器),因此全部 31 种语言走同一条路径。
 
+Kokoro 与 Supertonic 都支持在直接合成时按调用指定音色预设 — `pipeline.synthesize("Hello", "en", "M1")`(Supertonic:`F1`…`F5` / `M1`…`M5`;Kokoro:`af_heart`、`ff_siwis` 等)— `synthesizeStreaming` 和 `SpeechSynthesizer` 也有同样的参数。该预设仅对本次调用生效;省略它(或传 `""`)则沿用引擎默认音色,未知 id 会抛出异常。
+
 ## 试用演示
 
 下载[已签名的 APK](https://github.com/soniqo/speech-android/releases/latest/download/app-release.apk) 并安装到任何 arm64 Android 设备(8 及以上)。默认低内存模型包(~500 MB)在首次启动时自动下载。

--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/KokoroTtsTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/KokoroTtsTest.kt
@@ -132,6 +132,59 @@ class KokoroTtsTest {
         pipeline.close()
     }
 
+    /**
+     * Direct synthesis with a per-call voice preset: a different Kokoro voice
+     * changes the predicted duration, the preset does not leak into the next
+     * default call, and an unknown id fails loudly without breaking later
+     * synthesis. Durations are compared rather than samples because Kokoro
+     * draws random vocoder phases on every call.
+     */
+    @Test
+    fun directSynthesisAppliesVoicePresetPerCall() {
+        val config = SpeechConfig(
+            modelDir = modelDir,
+            useNnapi = false,
+            pipelineMode = PipelineMode.TRANSCRIBE_ONLY,
+        )
+        SpeechPipeline(config).use { pipeline ->
+            val text = "The quick brown fox jumps over the lazy dog."
+            // One Kokoro frame is 600 samples = 1200 PCM16 bytes.
+            val frameBytes = 1200
+
+            val default1 = pipeline.synthesize(text, "en").pcm16
+            val voiced = pipeline.synthesize(text, "en", "ff_siwis").pcm16
+            val default2 = pipeline.synthesize(text, "en").pcm16
+
+            assertTrue("default synthesis too short (${default1.size} bytes)", default1.size >= 4800)
+            assertTrue("voiced synthesis too short (${voiced.size} bytes)", voiced.size >= 4800)
+            assertTrue(
+                "A different voice preset should change the predicted duration " +
+                    "(default=${default1.size} voiced=${voiced.size} bytes)",
+                Math.abs(voiced.size - default1.size) > frameBytes,
+            )
+            assertTrue(
+                "The voice preset must not leak into the next default call " +
+                    "(${default1.size} vs ${default2.size} bytes)",
+                Math.abs(default1.size - default2.size) <= frameBytes,
+            )
+
+            val error = runCatching { pipeline.synthesize(text, "en", "no_such_voice") }.exceptionOrNull()
+            assertTrue("Unknown voice should throw, got $error", error is RuntimeException)
+            assertTrue(
+                "Unknown-voice error should name the voice: ${error?.message}",
+                error?.message?.contains("no_such_voice") == true,
+            )
+
+            // The failed call must leave the engine usable and on its default voice.
+            val afterError = pipeline.synthesize(text, "en").pcm16
+            assertTrue(
+                "Default voice should survive a failed voice call " +
+                    "(${default1.size} vs ${afterError.size} bytes)",
+                Math.abs(default1.size - afterError.size) <= frameBytes,
+            )
+        }
+    }
+
     @Test
     fun pipelineHandlesEmptyAudio() {
         val config = SpeechConfig(modelDir = modelDir, useNnapi = false)

--- a/sdk/src/main/cpp/jni_bridge.cpp
+++ b/sdk/src/main/cpp/jni_bridge.cpp
@@ -546,17 +546,52 @@ Java_audio_soniqo_speech_NativeBridge_nativeSynthesizerSampleRate(
     return static_cast<jint>(h->tts->output_sample_rate());
 }
 
+// Applies a per-call voice preset for one synthesis and restores the engine
+// default afterwards — also when synthesis throws — so the preset never leaks
+// into later calls or into the pipeline's own ECHO responses. Construct only
+// while holding the TTS mutex; set_voice() is not synchronized on its own.
+// An unknown id throws std::invalid_argument from the constructor, before any
+// state changes.
+class ScopedVoice {
+public:
+    ScopedVoice(speech_core::TTSInterface& tts, const std::string& voice_id)
+        : tts_(tts), active_(!voice_id.empty())
+    {
+        if (active_) tts_.set_voice(voice_id);
+    }
+    ~ScopedVoice()
+    {
+        if (!active_) return;
+        try {
+            tts_.set_voice("");
+        } catch (const std::exception& e) {
+            LOGE("Failed to restore the default TTS voice: %s", e.what());
+        }
+    }
+    ScopedVoice(const ScopedVoice&) = delete;
+    ScopedVoice& operator=(const ScopedVoice&) = delete;
+
+private:
+    speech_core::TTSInterface& tts_;
+    bool active_;
+};
+
 // Synthesize with [tts] under [mutex], returning PCM16 mono little-endian
-// bytes. Throws a Java RuntimeException and returns nullptr on failure.
+// bytes. [voice] selects a preset for this call only ("" or null keeps the
+// engine default). Throws a Java RuntimeException and returns nullptr on
+// failure.
 static jbyteArray synthesize_pcm16(JNIEnv* env, speech_core::TTSInterface& tts,
-                                   std::mutex& mutex, jstring text, jstring language)
+                                   std::mutex& mutex, jstring text, jstring language,
+                                   jstring voice)
 {
     std::string input = jstring_to_string(env, text);
     std::string lang = jstring_to_string(env, language);
+    std::string voice_id = jstring_to_string(env, voice);
     std::vector<int16_t> pcm;
 
     try {
         std::lock_guard<std::mutex> lock(mutex);
+        ScopedVoice scoped_voice(tts, voice_id);
         tts.synthesize(input, lang, [&pcm](const float* samples, size_t length, bool /*is_final*/) {
             pcm.reserve(pcm.size() + length);
             for (size_t i = 0; i < length; ++i) {
@@ -589,7 +624,7 @@ static jbyteArray synthesize_pcm16(JNIEnv* env, speech_core::TTSInterface& tts,
 // callers can begin playback while the following inference is still running.
 static void synthesize_streaming_pcm16(
     JNIEnv* env, speech_core::TTSInterface& tts, std::mutex& mutex,
-    jstring text, jstring language, jobject callback)
+    jstring text, jstring language, jstring voice, jobject callback)
 {
     if (!callback) {
         jclass ex_cls = env->FindClass("java/lang/IllegalArgumentException");
@@ -607,9 +642,11 @@ static void synthesize_streaming_pcm16(
 
     std::string input = jstring_to_string(env, text);
     std::string lang = jstring_to_string(env, language);
+    std::string voice_id = jstring_to_string(env, voice);
     bool callback_failed = false;
     try {
         std::lock_guard<std::mutex> lock(mutex);
+        ScopedVoice scoped_voice(tts, voice_id);
         tts.synthesize(
             input, lang,
             [&](const float* samples, size_t length, bool is_final) {
@@ -663,7 +700,8 @@ static void synthesize_streaming_pcm16(
 
 JNIEXPORT jbyteArray JNICALL
 Java_audio_soniqo_speech_NativeBridge_nativeSynthesize(
-    JNIEnv* env, jobject /*thiz*/, jlong handle, jstring text, jstring language)
+    JNIEnv* env, jobject /*thiz*/, jlong handle, jstring text, jstring language,
+    jstring voice)
 {
     auto* h = reinterpret_cast<SynthesizerHandle*>(handle);
     if (!h || !h->tts) {
@@ -671,7 +709,7 @@ Java_audio_soniqo_speech_NativeBridge_nativeSynthesize(
         if (ex_cls) env->ThrowNew(ex_cls, "Native synthesizer is closed");
         return nullptr;
     }
-    return synthesize_pcm16(env, *h->tts, h->mutex, text, language);
+    return synthesize_pcm16(env, *h->tts, h->mutex, text, language, voice);
 }
 
 JNIEXPORT jint JNICALL
@@ -685,7 +723,8 @@ Java_audio_soniqo_speech_NativeBridge_nativePipelineTtsSampleRate(
 
 JNIEXPORT jbyteArray JNICALL
 Java_audio_soniqo_speech_NativeBridge_nativePipelineSynthesize(
-    JNIEnv* env, jobject /*thiz*/, jlong handle, jstring text, jstring language)
+    JNIEnv* env, jobject /*thiz*/, jlong handle, jstring text, jstring language,
+    jstring voice)
 {
     auto* h = reinterpret_cast<PipelineHandle*>(handle);
     if (!h || !h->tts) {
@@ -693,13 +732,13 @@ Java_audio_soniqo_speech_NativeBridge_nativePipelineSynthesize(
         if (ex_cls) env->ThrowNew(ex_cls, "Native pipeline is closed");
         return nullptr;
     }
-    return synthesize_pcm16(env, *h->tts, h->tts_mutex, text, language);
+    return synthesize_pcm16(env, *h->tts, h->tts_mutex, text, language, voice);
 }
 
 JNIEXPORT void JNICALL
 Java_audio_soniqo_speech_NativeBridge_nativePipelineSynthesizeStreaming(
     JNIEnv* env, jobject /*thiz*/, jlong handle, jstring text, jstring language,
-    jobject callback)
+    jstring voice, jobject callback)
 {
     auto* h = reinterpret_cast<PipelineHandle*>(handle);
     if (!h || !h->tts) {
@@ -708,7 +747,7 @@ Java_audio_soniqo_speech_NativeBridge_nativePipelineSynthesizeStreaming(
         return;
     }
     synthesize_streaming_pcm16(
-        env, *h->tts, h->tts_mutex, text, language, callback);
+        env, *h->tts, h->tts_mutex, text, language, voice, callback);
 }
 
 JNIEXPORT void JNICALL

--- a/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
@@ -40,11 +40,19 @@ internal object NativeBridge {
     // Direct synthesis with the pipeline's already-loaded TTS model — lets a
     // TRANSCRIBE_ONLY agent loop speak responses without a second TTS copy.
     external fun nativePipelineTtsSampleRate(handle: Long): Int
-    external fun nativePipelineSynthesize(handle: Long, text: String, language: String): ByteArray
+    // `voice` is a per-call preset ("" = engine default); the bridge restores
+    // the default after the call so it never leaks into later synthesis.
+    external fun nativePipelineSynthesize(
+        handle: Long,
+        text: String,
+        language: String,
+        voice: String,
+    ): ByteArray
     external fun nativePipelineSynthesizeStreaming(
         handle: Long,
         text: String,
         language: String,
+        voice: String,
         callback: SynthesisCallback,
     )
     external fun nativePipelineCancelSynthesis(handle: Long)
@@ -57,7 +65,12 @@ internal object NativeBridge {
     external fun nativeDestroySynthesizer(handle: Long)
     external fun nativeStopSynthesizer(handle: Long)
     external fun nativeSynthesizerSampleRate(handle: Long): Int
-    external fun nativeSynthesize(handle: Long, text: String, language: String): ByteArray
+    external fun nativeSynthesize(
+        handle: Long,
+        text: String,
+        language: String,
+        voice: String,
+    ): ByteArray
 
     /** Called from native code on the pipeline worker thread. */
     interface EventCallback {

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
@@ -82,6 +82,19 @@ interface SpeechPipeline : AutoCloseable {
         throw UnsupportedOperationException("This SpeechPipeline does not support direct synthesis")
 
     /**
+     * Like [synthesize], but renders this one call with the TTS voice preset
+     * [voice]: Supertonic `F1`…`F5` / `M1`…`M5`, Kokoro `af_heart`,
+     * `ff_siwis`, … The preset applies to this call only — later calls and
+     * the pipeline's own ECHO responses keep the engine default (for Kokoro
+     * that is the language-mapped voice). An empty [voice] behaves like
+     * [synthesize]; an unknown id throws [RuntimeException]; fixed-voice
+     * models (Pocket) ignore it. The default implementation ignores [voice]
+     * so custom pipelines keep compiling.
+     */
+    fun synthesize(text: String, language: String, voice: String): SpeechSynthesisResult =
+        synthesize(text, language)
+
+    /**
      * Synthesize [text] and deliver each safe native model chunk as soon as it
      * is available. The call is blocking; invoke it off the main thread. The
      * default preserves compatibility with custom pipelines by emitting one
@@ -93,6 +106,16 @@ interface SpeechPipeline : AutoCloseable {
         onChunk: (result: SpeechSynthesisResult, isFinal: Boolean) -> Unit,
     ) {
         onChunk(synthesize(text, language), true)
+    }
+
+    /** [synthesizeStreaming] with a per-call TTS voice preset; see [synthesize]. */
+    fun synthesizeStreaming(
+        text: String,
+        language: String,
+        voice: String,
+        onChunk: (result: SpeechSynthesisResult, isFinal: Boolean) -> Unit,
+    ) {
+        onChunk(synthesize(text, language, voice), true)
     }
 
     /** Cancel an in-progress [synthesize]. */
@@ -188,17 +211,27 @@ internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
     override val ttsSampleRate: Int
         get() = NativeBridge.nativePipelineTtsSampleRate(handle)
 
-    override fun synthesize(text: String, language: String): SpeechSynthesisResult {
+    override fun synthesize(text: String, language: String): SpeechSynthesisResult =
+        synthesize(text, language, voice = "")
+
+    override fun synthesize(text: String, language: String, voice: String): SpeechSynthesisResult {
         check(handle != 0L) { "SpeechPipeline is closed" }
         return SpeechSynthesisResult(
             sampleRate = ttsSampleRate,
-            pcm16 = NativeBridge.nativePipelineSynthesize(handle, text, language),
+            pcm16 = NativeBridge.nativePipelineSynthesize(handle, text, language, voice),
         )
     }
 
     override fun synthesizeStreaming(
         text: String,
         language: String,
+        onChunk: (result: SpeechSynthesisResult, isFinal: Boolean) -> Unit,
+    ) = synthesizeStreaming(text, language, voice = "", onChunk = onChunk)
+
+    override fun synthesizeStreaming(
+        text: String,
+        language: String,
+        voice: String,
         onChunk: (result: SpeechSynthesisResult, isFinal: Boolean) -> Unit,
     ) {
         check(handle != 0L) { "SpeechPipeline is closed" }
@@ -207,6 +240,7 @@ internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
             handle,
             text,
             language,
+            voice,
             NativeBridge.SynthesisCallback { audio, isFinal ->
                 onChunk(SpeechSynthesisResult(sampleRate, audio), isFinal)
             },

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechSynthesizer.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechSynthesizer.kt
@@ -38,6 +38,17 @@ interface SpeechSynthesizer : AutoCloseable {
     /** Synthesize [text] as PCM16 mono audio. */
     fun synthesize(text: String, language: String = "en"): SpeechSynthesisResult
 
+    /**
+     * Like [synthesize], but renders this one call with the TTS voice preset
+     * [voice] (Supertonic `F1`…`F5` / `M1`…`M5`, Kokoro `af_heart`,
+     * `ff_siwis`, …). The preset applies to this call only; an empty [voice]
+     * keeps the engine default, an unknown id throws [RuntimeException], and
+     * fixed-voice models (Pocket) ignore it. The default implementation
+     * ignores [voice] so test doubles keep compiling.
+     */
+    fun synthesize(text: String, language: String, voice: String): SpeechSynthesisResult =
+        synthesize(text, language)
+
     /** Cancel any in-progress synthesis. */
     fun stop()
 
@@ -62,11 +73,14 @@ internal class SpeechSynthesizerImpl(config: SpeechSynthesizerConfig) : SpeechSy
     override val sampleRate: Int
         get() = NativeBridge.nativeSynthesizerSampleRate(handle)
 
-    override fun synthesize(text: String, language: String): SpeechSynthesisResult {
+    override fun synthesize(text: String, language: String): SpeechSynthesisResult =
+        synthesize(text, language, voice = "")
+
+    override fun synthesize(text: String, language: String, voice: String): SpeechSynthesisResult {
         check(handle != 0L) { "SpeechSynthesizer is closed" }
         return SpeechSynthesisResult(
             sampleRate = sampleRate,
-            pcm16 = NativeBridge.nativeSynthesize(handle, text, language),
+            pcm16 = NativeBridge.nativeSynthesize(handle, text, language, voice),
         )
     }
 

--- a/sdk/src/test/kotlin/audio/soniqo/speech/SpeechSynthesisVoiceTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/SpeechSynthesisVoiceTest.kt
@@ -1,0 +1,86 @@
+package audio.soniqo.speech
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The voice-preset overloads must stay source-compatible with custom
+ * [SpeechPipeline] / [SpeechSynthesizer] implementations that only know the
+ * two-argument `synthesize`: the interface defaults route the voice variants
+ * through the voice-agnostic call.
+ */
+class SpeechSynthesisVoiceTest {
+
+    @Test
+    fun pipelineVoiceOverloadFallsBackToVoiceAgnosticSynthesis() {
+        val expected = byteArrayOf(9, 8, 7)
+        val pipeline = VoiceAgnosticPipeline(expected)
+
+        val result = pipeline.synthesize("hello", "en", "M1")
+
+        assertArrayEquals(expected, result.pcm16)
+        assertEquals(listOf("hello" to "en"), pipeline.calls)
+    }
+
+    @Test
+    fun pipelineVoiceStreamingOverloadEmitsOneFinalChunk() {
+        val expected = byteArrayOf(1, 2)
+        val pipeline = VoiceAgnosticPipeline(expected)
+        val chunks = mutableListOf<Pair<ByteArray, Boolean>>()
+
+        pipeline.synthesizeStreaming("hi", "fr", "ff_siwis") { result, isFinal ->
+            chunks += result.pcm16 to isFinal
+        }
+
+        assertEquals(1, chunks.size)
+        assertArrayEquals(expected, chunks.single().first)
+        assertEquals(true, chunks.single().second)
+        assertEquals(listOf("hi" to "fr"), pipeline.calls)
+    }
+
+    @Test
+    fun synthesizerVoiceOverloadFallsBackToVoiceAgnosticSynthesis() {
+        val expected = byteArrayOf(4, 4, 4, 4)
+        val synthesizer = VoiceAgnosticSynthesizer(expected)
+
+        val result = synthesizer.synthesize("hello", "en", "F2")
+
+        assertArrayEquals(expected, result.pcm16)
+        assertEquals(24_000, result.sampleRate)
+        assertEquals(listOf("hello" to "en"), synthesizer.calls)
+    }
+
+    private class VoiceAgnosticPipeline(private val audio: ByteArray) : SpeechPipeline {
+        val calls = mutableListOf<Pair<String, String>>()
+
+        override val events: SharedFlow<SpeechEvent> = MutableSharedFlow()
+        override val state: PipelineState = PipelineState.Idle
+        override val nnapiFallbackReason: String? = null
+
+        override fun start() = Unit
+        override fun stop() = Unit
+        override fun pushAudio(samples: FloatArray) = Unit
+        override fun resumeListening() = Unit
+        override fun synthesize(text: String, language: String): SpeechSynthesisResult {
+            calls += text to language
+            return SpeechSynthesisResult(sampleRate = 24_000, pcm16 = audio)
+        }
+        override fun close() = Unit
+    }
+
+    private class VoiceAgnosticSynthesizer(private val audio: ByteArray) : SpeechSynthesizer {
+        val calls = mutableListOf<Pair<String, String>>()
+
+        override val sampleRate: Int = 24_000
+
+        override fun synthesize(text: String, language: String): SpeechSynthesisResult {
+            calls += text to language
+            return SpeechSynthesisResult(sampleRate = sampleRate, pcm16 = audio)
+        }
+        override fun stop() = Unit
+        override fun close() = Unit
+    }
+}


### PR DESCRIPTION
## Summary

Closes #80. Exposes the Supertonic/Kokoro voice preset on direct synthesis as a source-compatible overload:

```kotlin
pipeline.synthesize("Hello", "en")          // unchanged
pipeline.synthesize("Hello", "en", "M1")    // Supertonic male, this call only
synthesizer.synthesize("Hello", "en", "F2")
```

The voice is **per call, not sticky** (matches speech-swift's `synthesize(text:voice:language:)`): the bridge selects the preset, synthesizes, and restores the engine default — also when synthesis throws — under the existing TTS mutex. So later two-argument calls and the pipeline's own ECHO responses keep the default, and for Kokoro the language-driven voice switch keeps working. Unknown ids throw `RuntimeException("Native synthesis failed: … unknown voice 'x'")` before any state changes; Pocket (fixed voice) ignores the argument.

## What changed

- `SpeechPipeline`: `synthesize(text, language, voice)` and `synthesizeStreaming(text, language, voice, onChunk)` with interface defaults that route to the voice-agnostic call, so custom pipelines/test doubles keep compiling.
- `SpeechSynthesizer`: same `synthesize(text, language, voice)` overload.
- `NativeBridge` / `jni_bridge.cpp`: `voice` argument on `nativePipelineSynthesize`, `nativePipelineSynthesizeStreaming`, `nativeSynthesize`; `ScopedVoice` RAII helper does the select/restore.
- speech-core submodule bumped `462d492` → `e53bc7c` to pick up `TTSInterface::set_voice` (soniqo/speech-core#142); this also brings in the 17 upstream commits since the previous pointer (ONNX external-data, Sortformer, Whisper FFT fixes).
- README + all translations: one paragraph after the Supertonic note.

## Test plan

- [x] `./gradlew :sdk:test` — new `SpeechSynthesisVoiceTest` (default-overload routing for pipeline + synthesizer, streaming variant).
- [x] `./gradlew :sdk:assembleDebug` — JNI + speech-core (ONNX + LiteRT, so Supertonic compiles) for arm64-v8a/x86_64.
- [x] `KokoroTtsTest` on the arm64 emulator (4/4) — new `directSynthesisAppliesVoicePresetPerCall`: `ff_siwis` changes the predicted duration, the next default call matches the first, unknown voice throws naming the id, engine stays usable afterwards.
