### PR TITLE
Prepare v0.0.18 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Download the [signed APK](https://github.com/soniqo/speech-android/releases/late
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.17")
+    implementation("audio.soniqo:speech:0.0.18")
 }
 ```
 

--- a/README_de.md
+++ b/README_de.md
@@ -72,7 +72,7 @@ Lade das [signierte APK](https://github.com/soniqo/speech-android/releases/lates
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.17")
+    implementation("audio.soniqo:speech:0.0.18")
 }
 ```
 

--- a/README_es.md
+++ b/README_es.md
@@ -72,7 +72,7 @@ Descarga el [APK firmado](https://github.com/soniqo/speech-android/releases/late
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.17")
+    implementation("audio.soniqo:speech:0.0.18")
 }
 ```
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -72,7 +72,7 @@ Téléchargez l'[APK signé](https://github.com/soniqo/speech-android/releases/l
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.17")
+    implementation("audio.soniqo:speech:0.0.18")
 }
 ```
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -72,7 +72,7 @@ Kokoro और Supertonic दोनों डायरेक्ट सिंथ�
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.17")
+    implementation("audio.soniqo:speech:0.0.18")
 }
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -72,7 +72,7 @@ Kokoro と Supertonic はどちらも、直接合成の呼び出しごとに音�
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.17")
+    implementation("audio.soniqo:speech:0.0.18")
 }
 ```
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -72,7 +72,7 @@ Kokoro와 Supertonic 모두 직접 합성 시 호출 단위로 음성 프리셋�
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.17")
+    implementation("audio.soniqo:speech:0.0.18")
 }
 ```
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -72,7 +72,7 @@ Baixe o [APK assinado](https://github.com/soniqo/speech-android/releases/latest/
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.17")
+    implementation("audio.soniqo:speech:0.0.18")
 }
 ```
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -72,7 +72,7 @@ Kokoro и Supertonic принимают пресет голоса на кажд�
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.17")
+    implementation("audio.soniqo:speech:0.0.18")
 }
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -72,7 +72,7 @@ Kokoro 与 Supertonic 都支持在直接合成时按调用指定音色预设 —
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.17")
+    implementation("audio.soniqo:speech:0.0.18")
 }
 ```
 


### PR DESCRIPTION
## Summary

Prepare the v0.0.18 release: point the documented dependency at `audio.soniqo:speech:0.0.18` in `README.md` and all translations (`release.yml` verifies this snippet against the tag).

## What ships in v0.0.18

- Per-call TTS voice preset on `SpeechPipeline.synthesize` / `synthesizeStreaming` and `SpeechSynthesizer.synthesize` — Supertonic `F1`–`F5` / `M1`–`M5`, Kokoro `af_heart`, `ff_siwis`, … (#80, #81)
- speech-core `8e3dc56`: `TTSInterface::set_voice` with empty-id reset, Kokoro throws on unknown voices and can re-arm language auto-switch, Supertonic default-voice reset (soniqo/speech-core#142); bogus Korean Kokoro voice mapping removed (soniqo/speech-core#143) (#82)

## Test plan

- [x] `./gradlew :sdk:test`, `:sdk:assembleDebug` on `main`
- [ ] Full `./gradlew :sdk:connectedAndroidTest` on the arm64 emulator before tagging
