### PR TITLE
feat(models): opt-in download of the Supertonic L=128 latent bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ val config = SpeechConfig(
 `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (requires the LiteRT backend). The host runs its four
 non-autoregressive flow-matching graphs on-device at 44.1 kHz; the front-end is G2P-free (NFKD +
 Unicode index — no phonemizer), so all 31 languages go through one path.
+Long sentences: the bundle also ships an optional L=128 latent-window graph pair
+(`vector_estimator_L128.tflite` + `vocoder_L128.tflite`, +341 MB). Download it with
+`ModelDownloadWorker.enqueue(context, ttsModel = TtsModel.SUPERTONIC, supertonicLatentBuckets = true)`
+(or the same flag on `ModelManager.ensureTtsModels`) and speech-core synthesizes a sentence longer
+than the 4.5 s base window in one pass instead of splitting it; the pair is loaded on first use
+(+~360 MB RSS). Off by default.
 
 Both Kokoro and Supertonic take a per-call voice preset on direct synthesis —
 `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`; Kokoro `af_heart`,

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
@@ -76,6 +76,7 @@ class ModelDownloadWorker(
         // whole ~800 MB setup runs in this foreground worker — surviving doze
         // and Wi-Fi power-save that would kill an in-app download.
         val includeLlm = inputData.getBoolean(KEY_INCLUDE_LLM, false)
+        val supertonicLatentBuckets = inputData.getBoolean(KEY_SUPERTONIC_LATENT_BUCKETS, false)
 
         runCatching { setForeground(buildForegroundInfo(0, "Preparing speech models…")) }
 
@@ -169,6 +170,7 @@ class ModelDownloadWorker(
                 sttBackend = sttBackend,
                 ttsModel = ttsModel,
                 onProgress = report,
+                supertonicLatentBuckets = supertonicLatentBuckets,
             )
             if (includeLlm) {
                 // Hand the bar over to the LLM phase: what the pipeline phase
@@ -311,6 +313,7 @@ class ModelDownloadWorker(
         const val KEY_STT_BACKEND = "sttBackend"
         const val KEY_TTS_MODEL = "ttsModel"
         const val KEY_INCLUDE_LLM = "includeLlm"
+        const val KEY_SUPERTONIC_LATENT_BUCKETS = "supertonicLatentBuckets"
         const val KEY_LLM_MODEL = "llmModel"
 
         // Output keys
@@ -354,6 +357,7 @@ class ModelDownloadWorker(
             ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
             includeLlm: Boolean = false,
             llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
+            supertonicLatentBuckets: Boolean = false,
         ): String {
             if (
                 precision == ModelPrecision.INT8 &&
@@ -364,13 +368,14 @@ class ModelDownloadWorker(
             ) {
                 return UNIQUE_NAME
             }
+            val buckets = if (supertonicLatentBuckets && ttsModel == TtsModel.SUPERTONIC) ".buckets" else ""
             val llm = when {
                 !includeLlm -> ""
                 llmModel == LlmModel.FUNCTIONGEMMA -> ".llm"
                 else -> ".llm.${llmModel.name}"
             }
             val ttsName = if (ttsModel.isKokoro) TtsModel.KOKORO.name else ttsModel.name
-            return "$UNIQUE_NAME.${precision.name}.${sttModel.name}.${sttBackend.name}.$ttsName$llm"
+            return "$UNIQUE_NAME.${precision.name}.${sttModel.name}.${sttBackend.name}.$ttsName$buckets$llm"
         }
 
         fun request(
@@ -380,6 +385,7 @@ class ModelDownloadWorker(
             ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
             includeLlm: Boolean = false,
             llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
+            supertonicLatentBuckets: Boolean = false,
         ) =
             OneTimeWorkRequestBuilder<ModelDownloadWorker>()
                 .setInputData(workDataOf(
@@ -389,6 +395,7 @@ class ModelDownloadWorker(
                     KEY_TTS_MODEL to ttsModel.name,
                     KEY_INCLUDE_LLM to includeLlm,
                     KEY_LLM_MODEL to llmModel.name,
+                    KEY_SUPERTONIC_LATENT_BUCKETS to supertonicLatentBuckets,
                 ))
                 .build()
 
@@ -405,6 +412,7 @@ class ModelDownloadWorker(
             ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
             includeLlm: Boolean = false,
             llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
+            supertonicLatentBuckets: Boolean = false,
         ): java.util.UUID {
             val req = request(
                 precision = precision,
@@ -413,6 +421,7 @@ class ModelDownloadWorker(
                 ttsModel = ttsModel,
                 includeLlm = includeLlm,
                 llmModel = llmModel,
+                supertonicLatentBuckets = supertonicLatentBuckets,
             )
             WorkManager.getInstance(context).enqueueUniqueWork(
                 uniqueName(
@@ -422,6 +431,7 @@ class ModelDownloadWorker(
                     ttsModel = ttsModel,
                     includeLlm = includeLlm,
                     llmModel = llmModel,
+                    supertonicLatentBuckets = supertonicLatentBuckets,
                 ),
                 ExistingWorkPolicy.KEEP, req,
             )

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -52,11 +52,16 @@ object ModelManager {
         .build()
 
     @VisibleForTesting
+    /** L=128 latent-window graph pair shipped next to the Supertonic base graphs. */
+    internal val SUPERTONIC_LATENT_BUCKET_FILES =
+        listOf("vector_estimator_L128.tflite", "vocoder_L128.tflite")
+
     internal fun models(
         precision: ModelPrecision,
         sttModel: SttModel = SttModel.PARAKEET_EOU,
         sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
+        supertonicLatentBuckets: Boolean = false,
     ): List<ModelFile> {
         val suffix = if (precision == ModelPrecision.INT8) "-int8" else ""
         val files = mutableListOf(
@@ -138,7 +143,7 @@ object ModelManager {
             }
         }
 
-        files += ttsModels(ttsModel)
+        files += ttsModels(ttsModel, supertonicLatentBuckets)
 
         // Noise cancellation
         files += ModelFile("DeepFilterNet3-ONNX", "deepfilter-auxiliary.bin")
@@ -147,7 +152,20 @@ object ModelManager {
     }
 
     @VisibleForTesting
-    internal fun ttsModels(ttsModel: TtsModel): List<ModelFile> = when (ttsModel) {
+    /**
+     * @param supertonicLatentBuckets Supertonic only: also list the L=128
+     *   latent-window graph pair (`vector_estimator_L128.tflite` +
+     *   `vocoder_L128.tflite`, +341 MB), which lets a sentence longer than the
+     *   4.5 s base window be synthesized in one pass instead of split.
+     *   speech-core discovers the pair next to the base graphs and loads it on
+     *   first use (+~360 MB RSS). Off by default; ignored by other TTS models.
+     *   The pair shares the Supertonic cache set, so enabling it later
+     *   downloads only the two extra files.
+     */
+    internal fun ttsModels(
+        ttsModel: TtsModel,
+        supertonicLatentBuckets: Boolean = false,
+    ): List<ModelFile> = when (ttsModel) {
         TtsModel.KOKORO, TtsModel.KOKORO_SHORT_TURN -> listOf(
             // Both graph profiles share one external weight blob. Keeping both
             // protos in the same cache makes profile switches a ~2.6 MB fetch,
@@ -172,8 +190,9 @@ object ModelManager {
             ModelFile("Kokoro-82M-ONNX", "voices/jf_alpha.bin"),
             ModelFile("Kokoro-82M-ONNX", "voices/zf_xiaobei.bin"),
         )
-        // Four LiteRT graphs + the G2P-free tokenizer assets + the 10-voice catalog.
-        TtsModel.SUPERTONIC -> listOf(
+        // Four LiteRT graphs + the G2P-free tokenizer assets + the 10-voice catalog,
+        // plus the optional L=128 latent bucket (see [supertonicLatentBuckets]).
+        TtsModel.SUPERTONIC -> (listOf(
             "duration_predictor.tflite", "text_encoder.tflite",
             "vector_estimator.tflite", "vocoder.tflite",
             "tts.json", "unicode_indexer.json",
@@ -181,7 +200,8 @@ object ModelManager {
             "voice_styles/F4.json", "voice_styles/F5.json",
             "voice_styles/M1.json", "voice_styles/M2.json", "voice_styles/M3.json",
             "voice_styles/M4.json", "voice_styles/M5.json",
-        ).map { ModelFile("Supertonic-3-LiteRT", it) }
+        ) + if (supertonicLatentBuckets) SUPERTONIC_LATENT_BUCKET_FILES else emptyList())
+            .map { ModelFile("Supertonic-3-LiteRT", it) }
         TtsModel.POCKET -> listOf(
             // Runtime files from the immutable public fixed-Alba bundle. Keep
             // them below pocket_tts/: Parakeet and Pocket both ship vocab.json.
@@ -272,6 +292,7 @@ object ModelManager {
         sttModel: SttModel = SttModel.PARAKEET_EOU,
         sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
+        supertonicLatentBuckets: Boolean = false,
     ): Boolean {
         val dir = modelDirFile(context, precision, sttModel, sttBackend, ttsModel)
         if (!dir.exists()) return false
@@ -281,7 +302,7 @@ object ModelManager {
         if (cached < MODEL_VERSION) return false
         if (cachedModelSet(dir) != modelSetKey(precision, sttModel, sttBackend, ttsModel)) return false
 
-        val fileList = models(precision, sttModel, sttBackend, ttsModel)
+        val fileList = models(precision, sttModel, sttBackend, ttsModel, supertonicLatentBuckets)
         val allFiles = if (precision == ModelPrecision.FP32 && sttModel == SttModel.PARAKEET) {
             fileList + ModelFile("Parakeet-TDT-0.6B-ONNX", "parakeet-encoder.onnx.data")
         } else {
@@ -301,6 +322,7 @@ object ModelManager {
     fun areTtsModelsReady(
         context: Context,
         ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
+        supertonicLatentBuckets: Boolean = false,
     ): Boolean {
         val dir = File(context.filesDir, "models_tts")
         if (!dir.exists()) return false
@@ -310,7 +332,7 @@ object ModelManager {
         if (cached < MODEL_VERSION) return false
         if (cachedModelSet(dir) != ttsModelSetKey(ttsModel)) return false
 
-        return ttsModels(ttsModel).all { model ->
+        return ttsModels(ttsModel, supertonicLatentBuckets).all { model ->
             val dest = File(dir, model.localFilename)
             dest.exists() && isValidModel(dest, model.filename)
         }
@@ -385,6 +407,7 @@ object ModelManager {
         sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
         onProgress: ((Progress) -> Unit)? = null,
+        supertonicLatentBuckets: Boolean = false,
     ): String = withContext(Dispatchers.IO) {
         val dir = modelDirFile(context, precision, sttModel, sttBackend, ttsModel)
         dir.mkdirs()
@@ -403,7 +426,7 @@ object ModelManager {
         // bytes=N- on the next attempt. Stale .tmp from an old MODEL_VERSION
         // or from a different model set are already wiped above.
 
-        val fileList = models(precision, sttModel, sttBackend, ttsModel)
+        val fileList = models(precision, sttModel, sttBackend, ttsModel, supertonicLatentBuckets)
         // FP32 Parakeet encoder needs the external data file.
         val allFiles = if (precision == ModelPrecision.FP32 && sttModel == SttModel.PARAKEET) {
             fileList + ModelFile("Parakeet-TDT-0.6B-ONNX", "parakeet-encoder.onnx.data")
@@ -426,6 +449,7 @@ object ModelManager {
         context: Context,
         ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
         onProgress: ((Progress) -> Unit)? = null,
+        supertonicLatentBuckets: Boolean = false,
     ): String = withContext(Dispatchers.IO) {
         val dir = File(context.filesDir, "models_tts")
         dir.mkdirs()
@@ -441,7 +465,7 @@ object ModelManager {
             File(dir, "voice_styles").mkdirs()
         }
 
-        downloadMissingModels(dir, ttsModels(ttsModel), onProgress)
+        downloadMissingModels(dir, ttsModels(ttsModel, supertonicLatentBuckets), onProgress)
 
         File(dir, "precision.txt").writeText("TTS")
         versionFile.writeText(MODEL_VERSION.toString())

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
@@ -229,6 +229,45 @@ class ModelManagerManifestTest {
     }
 
     @Test
+    fun `supertonic manifest leaves the latent bucket out by default`() {
+        val files = ModelManager.ttsModels(TtsModel.SUPERTONIC)
+        assertTrue(files.none { it.filename.endsWith("_L128.tflite") })
+        assertEquals(files, ModelManager.ttsModels(TtsModel.SUPERTONIC, supertonicLatentBuckets = false))
+        assertTrue(
+            modelFiles(ttsModel = TtsModel.SUPERTONIC).none { it.filename.endsWith("_L128.tflite") },
+        )
+    }
+
+    @Test
+    fun `supertonic latent bucket option appends the L128 pair`() {
+        val base = ModelManager.ttsModels(TtsModel.SUPERTONIC)
+        val withBuckets = ModelManager.ttsModels(TtsModel.SUPERTONIC, supertonicLatentBuckets = true)
+        assertEquals(
+            base + listOf(
+                ModelManager.ModelFile("Supertonic-3-LiteRT", "vector_estimator_L128.tflite"),
+                ModelManager.ModelFile("Supertonic-3-LiteRT", "vocoder_L128.tflite"),
+            ),
+            withBuckets,
+        )
+        // Same cache set as the base bundle: enabling the option later only adds the two files.
+        assertEquals(
+            base.map { it.localFilename.substringBeforeLast('/', "") }.toSet(),
+            withBuckets.map { it.localFilename.substringBeforeLast('/', "") }.toSet(),
+        )
+        // Only Supertonic has a bucket; other TTS models ignore the flag.
+        assertEquals(
+            ModelManager.ttsModels(TtsModel.KOKORO),
+            ModelManager.ttsModels(TtsModel.KOKORO, supertonicLatentBuckets = true),
+        )
+        assertEquals(
+            2,
+            ModelManager.models(
+                ModelPrecision.INT8, ttsModel = TtsModel.SUPERTONIC, supertonicLatentBuckets = true,
+            ).count { it.filename.endsWith("_L128.tflite") },
+        )
+    }
+
+    @Test
     fun `pocket manifest is pinned and namespaced away from stt assets`() {
         val files = ModelManager.ttsModels(TtsModel.POCKET)
 


### PR DESCRIPTION
## Summary

`soniqo/Supertonic-3-LiteRT` now ships an L=128 latent-window graph pair (`vector_estimator_L128.tflite` + `vocoder_L128.tflite`, +341 MB). speech-core v0.0.13 (#84) discovers the pair next to the base graphs, loads it on first use, and synthesizes a sentence longer than the 4.5 s base window in one pass instead of splitting it (speech-core #140/#141/#144). `ModelManager` lists each bundle file explicitly, so the pair has to be downloaded on purpose.

## What changed

- `supertonicLatentBuckets: Boolean = false` on `ModelManager.models` / `areModelsReady` / `areTtsModelsReady` / `ensureModels` / `ensureTtsModels` (appended after existing parameters, so positional callers are unaffected), and on `ModelDownloadWorker.enqueue` / `request` / `uniqueName` with a new input key `KEY_SUPERTONIC_LATENT_BUCKETS`. A bucket download gets its own unique work name (`….SUPERTONIC.buckets`) so it is not deduplicated against a running base download.
- `TtsModel.SUPERTONIC` appends the two files when the flag is set; other TTS models ignore it. The pair shares the Supertonic cache set (same `ttsModelSetKey`), so enabling the flag later downloads only the two files, and disabling it leaves them in place.
- README: one paragraph on the option under the Supertonic section (English only; the translated mirrors are unchanged).

Runtime needs nothing: the JNI bridge passes the bundle directory to `LiteRTSupertonicTts`, which finds the `_L128` siblings by itself.

## Test plan

- [x] `ModelManagerManifestTest`: default Supertonic manifest has no `_L128` file; with the flag it is the base list plus exactly the two files, in the same cache directory; Kokoro ignores the flag; the full pipeline manifest carries the pair only when asked. 21/21 locally.
- [x] `:sdk:testDebugUnitTest :app:testDebugUnitTest :control-demo:testDebugUnitTest` locally.
- [ ] CI.
