### PR TITLE
chore: release 0.0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Download the [signed APK](https://github.com/soniqo/speech-android/releases/late
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.18")
+    implementation("audio.soniqo:speech:0.0.19")
 }
 ```
 

--- a/README_de.md
+++ b/README_de.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** ist ein optionales, höherwertiges mehrsprachiges TTS — wähle es mit `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` aus (erfordert das LiteRT-Backend). Der Host führt seine vier nicht-autoregressiven Flow-Matching-Graphen mit 44,1 kHz auf dem Gerät aus; das Front-End ist G2P-frei (NFKD + Unicode-Index — kein Phonemizer), sodass alle 31 Sprachen über einen einzigen Pfad laufen.
 
+Lange Sätze: Das Bundle enthält zusätzlich ein optionales Graphenpaar mit L=128-Latenzfenster (`vector_estimator_L128.tflite` + `vocoder_L128.tflite`, +341 MB). Lade es mit `ModelDownloadWorker.enqueue(context, ttsModel = TtsModel.SUPERTONIC, supertonicLatentBuckets = true)` (oder demselben Flag bei `ModelManager.ensureTtsModels`) herunter, dann synthetisiert speech-core einen Satz, der länger als das 4,5-s-Basisfenster ist, in einem Durchgang, statt ihn aufzuteilen; das Paar wird bei der ersten Verwendung geladen (+~360 MB RSS). Standardmäßig deaktiviert.
+
 Kokoro und Supertonic nehmen bei der direkten Synthese pro Aufruf ein Stimm-Preset entgegen — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`; Kokoro `af_heart`, `ff_siwis`, …) — dasselbe Argument gibt es auch bei `synthesizeStreaming` und `SpeechSynthesizer`. Das Preset gilt nur für diesen Aufruf; lässt man es weg (oder übergibt `""`), bleibt die Standardstimme der Engine erhalten, und eine unbekannte id wirft eine Exception.
 
 ## Demo ausprobieren

--- a/README_de.md
+++ b/README_de.md
@@ -74,7 +74,7 @@ Lade das [signierte APK](https://github.com/soniqo/speech-android/releases/lates
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.18")
+    implementation("audio.soniqo:speech:0.0.19")
 }
 ```
 

--- a/README_es.md
+++ b/README_es.md
@@ -74,7 +74,7 @@ Descarga el [APK firmado](https://github.com/soniqo/speech-android/releases/late
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.18")
+    implementation("audio.soniqo:speech:0.0.19")
 }
 ```
 

--- a/README_es.md
+++ b/README_es.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** es un TTS multilingüe opcional de mayor calidad — selecciónalo con `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (requiere el backend LiteRT). El host ejecuta sus cuatro grafos de flow-matching no autorregresivos en el dispositivo a 44.1 kHz; el front-end es G2P-free (NFKD + índice Unicode — sin fonemizador), por lo que los 31 idiomas pasan por una sola ruta.
 
+Frases largas: el paquete también incluye un par opcional de grafos con ventana latente L=128 (`vector_estimator_L128.tflite` + `vocoder_L128.tflite`, +341 MB). Descárgalo con `ModelDownloadWorker.enqueue(context, ttsModel = TtsModel.SUPERTONIC, supertonicLatentBuckets = true)` (o el mismo flag en `ModelManager.ensureTtsModels`) y speech-core sintetiza una frase más larga que la ventana base de 4.5 s en una sola pasada en lugar de dividirla; el par se carga en el primer uso (+~360 MB de RSS). Desactivado por defecto.
+
 Tanto Kokoro como Supertonic aceptan un preset de voz por llamada en la síntesis directa — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`; Kokoro `af_heart`, `ff_siwis`, …) — y el mismo argumento existe en `synthesizeStreaming` y `SpeechSynthesizer`. El preset se aplica solo a esa llamada; omítelo (o pasa `""`) para mantener la voz por defecto del motor, y un id desconocido lanza una excepción.
 
 ## Prueba la demo

--- a/README_fr.md
+++ b/README_fr.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** est une synthèse vocale multilingue de meilleure qualité, activable en option — sélectionnez-la avec `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (nécessite le backend LiteRT). L'hôte exécute ses quatre graphes de flow-matching non autorégressifs en local à 44,1 kHz ; le front-end est G2P-free (NFKD + index Unicode — aucun phonémiseur), de sorte que les 31 langues passent par un seul chemin.
 
+Phrases longues : le bundle inclut aussi une paire optionnelle de graphes à fenêtre latente L=128 (`vector_estimator_L128.tflite` + `vocoder_L128.tflite`, +341 Mo). Téléchargez-la avec `ModelDownloadWorker.enqueue(context, ttsModel = TtsModel.SUPERTONIC, supertonicLatentBuckets = true)` (ou le même flag sur `ModelManager.ensureTtsModels`) et speech-core synthétise une phrase plus longue que la fenêtre de base de 4,5 s en une seule passe au lieu de la découper ; la paire est chargée à la première utilisation (+~360 Mo de RSS). Désactivé par défaut.
+
 Kokoro et Supertonic acceptent un préréglage de voix par appel lors de la synthèse directe — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5` ; Kokoro `af_heart`, `ff_siwis`, …) — et le même argument existe sur `synthesizeStreaming` et `SpeechSynthesizer`. Le préréglage ne s'applique qu'à cet appel ; omettez-le (ou passez `""`) pour conserver la voix par défaut du moteur, et un id inconnu lève une exception.
 
 ## Essayer la démo

--- a/README_fr.md
+++ b/README_fr.md
@@ -74,7 +74,7 @@ Téléchargez l'[APK signé](https://github.com/soniqo/speech-android/releases/l
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.18")
+    implementation("audio.soniqo:speech:0.0.19")
 }
 ```
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -74,7 +74,7 @@ Kokoro और Supertonic दोनों डायरेक्ट सिंथ�
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.18")
+    implementation("audio.soniqo:speech:0.0.19")
 }
 ```
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** एक ऑप्ट-इन उच्च-गुणवत्ता वाला बहुभाषी TTS है — इसे `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` के साथ चुनें (LiteRT बैकएंड आवश्यक)। होस्ट इसके चार नॉन-ऑटोरिग्रेसिव फ़्लो-मैचिंग ग्राफ़ ऑन-डिवाइस 44.1 kHz पर चलाता है; फ़्रंट-एंड G2P-free है (NFKD + Unicode इंडेक्स — कोई फ़ोनेमाइज़र नहीं), इसलिए सभी 31 भाषाएँ एक ही पथ से होकर गुजरती हैं।
 
+लंबे वाक्य: बंडल में L=128 लेटेंट-विंडो वाले ग्राफ़ की एक वैकल्पिक जोड़ी भी शामिल है (`vector_estimator_L128.tflite` + `vocoder_L128.tflite`, +341 MB)। इसे `ModelDownloadWorker.enqueue(context, ttsModel = TtsModel.SUPERTONIC, supertonicLatentBuckets = true)` (या `ModelManager.ensureTtsModels` पर उसी फ़्लैग) से डाउनलोड करें, तो speech-core 4.5 s की बेस विंडो से लंबे वाक्य को विभाजित करने के बजाय एक ही पास में सिंथेसाइज़ करता है; यह जोड़ी पहले उपयोग पर लोड होती है (+~360 MB RSS)। डिफ़ॉल्ट रूप से बंद।
+
 Kokoro और Supertonic दोनों डायरेक्ट सिंथेसिस में प्रति-कॉल वॉइस प्रीसेट स्वीकार करते हैं — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`; Kokoro `af_heart`, `ff_siwis`, …) — और यही आर्ग्युमेंट `synthesizeStreaming` और `SpeechSynthesizer` पर भी मौजूद है। प्रीसेट केवल उसी कॉल पर लागू होता है; इसे छोड़ दें (या `""` पास करें) तो इंजन की डिफ़ॉल्ट आवाज़ बनी रहती है, और अज्ञात id पर अपवाद (exception) फेंका जाता है।
 
 ## डेमो आज़माएँ

--- a/README_ja.md
+++ b/README_ja.md
@@ -74,7 +74,7 @@ Kokoro と Supertonic はどちらも、直接合成の呼び出しごとに音�
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.18")
+    implementation("audio.soniqo:speech:0.0.19")
 }
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** はオプトインの高品質な多言語 TTS です — `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` で選択します(LiteRT バックエンドが必要)。ホストはその 4 つの非自己回帰 flow-matching グラフを 44.1 kHz でオンデバイス実行します。フロントエンドは G2P-free(NFKD + Unicode インデックス — phonemizer なし)なので、31 言語すべてが単一のパスを通ります。
 
+長い文: バンドルには、L=128 の潜在ウィンドウを持つオプションのグラフペア(`vector_estimator_L128.tflite` + `vocoder_L128.tflite`、+341 MB)も含まれています。`ModelDownloadWorker.enqueue(context, ttsModel = TtsModel.SUPERTONIC, supertonicLatentBuckets = true)`(または `ModelManager.ensureTtsModels` の同じフラグ)でダウンロードすると、speech-core は 4.5 秒の基本ウィンドウより長い文を分割せずに一度で合成します。このペアは初回使用時に読み込まれます(+~360 MB RSS)。デフォルトではオフです。
+
 Kokoro と Supertonic はどちらも、直接合成の呼び出しごとに音声プリセットを指定できます — `pipeline.synthesize("Hello", "en", "M1")`(Supertonic は `F1`…`F5` / `M1`…`M5`、Kokoro は `af_heart`、`ff_siwis` など)。同じ引数は `synthesizeStreaming` と `SpeechSynthesizer` にもあります。プリセットはその呼び出しにのみ適用され、省略(または `""` を指定)するとエンジンのデフォルト音声のままになります。未知の id は例外を投げます。
 
 ## デモを試す

--- a/README_ko.md
+++ b/README_ko.md
@@ -74,7 +74,7 @@ Kokoro와 Supertonic 모두 직접 합성 시 호출 단위로 음성 프리셋�
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.18")
+    implementation("audio.soniqo:speech:0.0.19")
 }
 ```
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3**는 옵트인 방식의 더 높은 품질의 다국어 TTS입니다 — `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)`로 선택하세요(LiteRT 백엔드가 필요합니다). 호스트는 4개의 비자기회귀(non-autoregressive) flow-matching 그래프를 44.1 kHz로 온디바이스에서 실행합니다. 프런트엔드는 G2P-free(NFKD + 유니코드 인덱스 — 음소 변환기 없음)이므로 31개 언어 모두 하나의 경로를 통과합니다.
 
+긴 문장: 번들에는 L=128 잠재 윈도우 그래프 쌍(`vector_estimator_L128.tflite` + `vocoder_L128.tflite`, +341 MB)도 선택 사항으로 포함되어 있습니다. `ModelDownloadWorker.enqueue(context, ttsModel = TtsModel.SUPERTONIC, supertonicLatentBuckets = true)`(또는 `ModelManager.ensureTtsModels`의 같은 플래그)로 다운로드하면 speech-core가 4.5초 기본 윈도우보다 긴 문장을 분할하지 않고 한 번에 합성합니다. 이 쌍은 처음 사용할 때 로드됩니다(+~360 MB RSS). 기본값은 꺼짐입니다.
+
 Kokoro와 Supertonic 모두 직접 합성 시 호출 단위로 음성 프리셋을 지정할 수 있습니다 — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`, Kokoro `af_heart`, `ff_siwis` 등). 같은 인자가 `synthesizeStreaming`과 `SpeechSynthesizer`에도 있습니다. 프리셋은 해당 호출에만 적용되며, 생략하거나 `""`를 전달하면 엔진 기본 음성이 유지되고, 알 수 없는 id는 예외를 던집니다.
 
 ## 데모 사용해보기

--- a/README_pt.md
+++ b/README_pt.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 O **Supertonic-3** é um TTS multilíngue opcional de maior qualidade — selecione-o com `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (requer o backend LiteRT). O host executa seus quatro grafos de flow-matching não autorregressivos no dispositivo a 44,1 kHz; o front-end é G2P-free (NFKD + índice Unicode — sem phonemizer), de modo que todos os 31 idiomas seguem um único caminho.
 
+Frases longas: o pacote também inclui um par opcional de grafos com janela latente L=128 (`vector_estimator_L128.tflite` + `vocoder_L128.tflite`, +341 MB). Baixe-o com `ModelDownloadWorker.enqueue(context, ttsModel = TtsModel.SUPERTONIC, supertonicLatentBuckets = true)` (ou a mesma flag em `ModelManager.ensureTtsModels`) e o speech-core sintetiza uma frase mais longa que a janela base de 4,5 s em uma única passagem em vez de dividi-la; o par é carregado no primeiro uso (+~360 MB de RSS). Desativado por padrão.
+
 Tanto o Kokoro quanto o Supertonic aceitam um preset de voz por chamada na síntese direta — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`; Kokoro `af_heart`, `ff_siwis`, …) — e o mesmo argumento existe em `synthesizeStreaming` e `SpeechSynthesizer`. O preset vale apenas para essa chamada; omita-o (ou passe `""`) para manter a voz padrão do motor, e um id desconhecido lança uma exceção.
 
 ## Experimente a demo

--- a/README_pt.md
+++ b/README_pt.md
@@ -74,7 +74,7 @@ Baixe o [APK assinado](https://github.com/soniqo/speech-android/releases/latest/
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.18")
+    implementation("audio.soniqo:speech:0.0.19")
 }
 ```
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** — это опциональный многоязычный TTS повышенного качества: выберите его через `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` (требуется бэкенд LiteRT). Хост выполняет его четыре неавторегрессионных flow-matching-графа на устройстве на частоте 44,1 кГц; фронтенд работает G2P-free (NFKD + индекс Unicode — без фонемизатора), поэтому все 31 язык проходят через один путь.
 
+Длинные предложения: в бандл также входит опциональная пара графов с латентным окном L=128 (`vector_estimator_L128.tflite` + `vocoder_L128.tflite`, +341 МБ). Скачайте её через `ModelDownloadWorker.enqueue(context, ttsModel = TtsModel.SUPERTONIC, supertonicLatentBuckets = true)` (или тот же флаг у `ModelManager.ensureTtsModels`), и speech-core синтезирует предложение длиннее базового окна в 4,5 с за один проход, не разбивая его; пара загружается при первом использовании (+~360 МБ RSS). По умолчанию выключено.
+
 Kokoro и Supertonic принимают пресет голоса на каждый вызов прямого синтеза — `pipeline.synthesize("Hello", "en", "M1")` (Supertonic `F1`…`F5` / `M1`…`M5`; Kokoro `af_heart`, `ff_siwis`, …) — тот же аргумент есть у `synthesizeStreaming` и `SpeechSynthesizer`. Пресет действует только для этого вызова; опустите его (или передайте `""`), чтобы сохранить голос движка по умолчанию, а неизвестный id вызывает исключение.
 
 ## Попробовать демо

--- a/README_ru.md
+++ b/README_ru.md
@@ -74,7 +74,7 @@ Kokoro и Supertonic принимают пресет голоса на кажд�
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.18")
+    implementation("audio.soniqo:speech:0.0.19")
 }
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -62,6 +62,8 @@ val config = SpeechConfig(
 
 **Supertonic-3** 是可选启用的更高质量多语言 TTS — 通过 `SpeechConfig(ttsModel = TtsModel.SUPERTONIC)` 选用(需要 LiteRT 后端)。宿主在设备端以 44.1 kHz 运行其四个非自回归流匹配图;前端免 G2P(NFKD + Unicode 索引 — 无音素转换器),因此全部 31 种语言走同一条路径。
 
+长句:模型包还附带一对可选的 L=128 潜在窗口图(`vector_estimator_L128.tflite` + `vocoder_L128.tflite`,+341 MB)。通过 `ModelDownloadWorker.enqueue(context, ttsModel = TtsModel.SUPERTONIC, supertonicLatentBuckets = true)`(或 `ModelManager.ensureTtsModels` 上的同名标志)下载后,speech-core 会把超过 4.5 s 基础窗口的句子一次合成,而不是拆开;这对图在首次使用时加载(+~360 MB RSS)。默认关闭。
+
 Kokoro 与 Supertonic 都支持在直接合成时按调用指定音色预设 — `pipeline.synthesize("Hello", "en", "M1")`(Supertonic:`F1`…`F5` / `M1`…`M5`;Kokoro:`af_heart`、`ff_siwis` 等)— `synthesizeStreaming` 和 `SpeechSynthesizer` 也有同样的参数。该预设仅对本次调用生效;省略它(或传 `""`)则沿用引擎默认音色,未知 id 会抛出异常。
 
 ## 试用演示

--- a/README_zh.md
+++ b/README_zh.md
@@ -74,7 +74,7 @@ Kokoro 与 Supertonic 都支持在直接合成时按调用指定音色预设 —
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.18")
+    implementation("audio.soniqo:speech:0.0.19")
 }
 ```
 


### PR DESCRIPTION
## Summary

Release 0.0.19: speech-core **v0.0.13** (Supertonic-3 chunking fix for speech-core #140 and the L=128 latent buckets, #84) plus the opt-in download of the Supertonic L=128 bucket (#85).

## What changed

- Documented dependency version `audio.soniqo:speech:0.0.18` → `0.0.19` in README.md and the 9 mirrors (`release.yml` verifies it against the tag).
- The Supertonic latent-bucket paragraph added in #85 is now translated in all 9 README mirrors (de, es, fr, hi, ja, ko, pt, ru, zh); code identifiers and sizes are kept verbatim.

## Test plan

- [ ] CI (unit tests, assemble, submodule ancestry).
- After merge: tag `v0.0.19` → `release.yml` publishes to Maven Central and attaches the APK.