### PR TITLE
feat(vad): add VadDetector for VAD-only use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,8 @@ for the full model-file inventory.
 - `sdk/src/main/cpp/CMakeLists.txt` — pulls speech-core in via `add_subdirectory` with `SPEECH_CORE_WITH_ONNX=ON`; the speech_core_models target provides every model wrapper.
 - `sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt` — main public Kotlin API.
 - `sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt` — JNI surface (must stay in lockstep with `jni_bridge.cpp`).
-- `sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt` — model download + caching.
+- `sdk/src/main/kotlin/audio/soniqo/speech/VadDetector.kt` — VAD-only public API (Silero + speech-core `TurnDetector`, no pipeline). The listening counterpart to `SpeechSynthesizer`.
+- `sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt` — model download + caching. Three profiles: full pipeline (`models/`), TTS-only (`models_tts/`), VAD-only (`models_vad/`).
 
 Native code that used to live here (`models/*.{cpp,h}`, `audio/{fft,mel,stft}.cpp`,
 `util/json.h`, `onnx_engine.h`) is now under speech-core. Modify it via a

--- a/README.md
+++ b/README.md
@@ -118,6 +118,40 @@ pipeline.start()
 pipeline.pushAudio(samples)
 ```
 
+### Voice activity detection only
+
+Apps that only need to know *when* someone is speaking — push-to-talk
+gating, recording segmentation, wake-on-voice — can load Silero on its own:
+a 2 MB download and under 10 MB of RAM instead of the ~500 MB default set.
+No STT, no TTS, no pipeline.
+
+```kotlin
+val detector = VadDetector(
+    VadConfig(
+        modelDir = ModelManager.ensureVadModels(context),
+        emitUtteranceAudio = true, // opt in to receive the captured segment
+    )
+)
+
+detector.events.collect { event ->
+    when (event) {
+        is VadEvent.SpeechStarted -> startRecordingUi()
+        is VadEvent.SpeechEnded -> saveSegment(event.audio) // 16 kHz float32
+    }
+}
+
+// 16 kHz mono float32, 512-sample frames
+detector.pushAudio(samples)
+// close an open segment when the stream ends
+detector.flush()
+```
+
+`VadConfig` exposes the same turn detection the pipeline uses internally:
+onset and offset thresholds, minimum speech duration, end-of-speech silence,
+and the pre-speech buffer that keeps the first syllable. This path uses
+`ModelManager.ensureVadModels()` and a separate `models_vad/` cache, so it
+never pulls the STT/TTS bundles.
+
 ### FunctionGemma 270M (on-device tool-calling LLM)
 
 The SDK ships the prompt formatter (`FunctionGemmaPrompt`), parser

--- a/README_de.md
+++ b/README_de.md
@@ -99,6 +99,40 @@ pipeline.start()
 pipeline.pushAudio(samples)
 ```
 
+### Nur Sprachaktivitätserkennung
+
+Apps, die nur wissen müssen, *wann* jemand spricht — Push-to-Talk-Steuerung,
+Aufnahme-Segmentierung, Aufwachen per Stimme —, können Silero allein laden:
+2 MB Download und unter 10 MB RAM statt der ~500 MB des Standard-Modellsatzes.
+Kein STT, kein TTS, keine Pipeline.
+
+```kotlin
+val detector = VadDetector(
+    VadConfig(
+        modelDir = ModelManager.ensureVadModels(context),
+        emitUtteranceAudio = true, // einschalten, um das erfasste Segment zu erhalten
+    )
+)
+
+detector.events.collect { event ->
+    when (event) {
+        is VadEvent.SpeechStarted -> startRecordingUi()
+        is VadEvent.SpeechEnded -> saveSegment(event.audio) // 16 kHz float32
+    }
+}
+
+// 16 kHz Mono float32, 512-Sample-Frames
+detector.pushAudio(samples)
+// offenes Segment am Ende des Streams schließen
+detector.flush()
+```
+
+`VadConfig` legt dieselbe Turn-Erkennung offen, die die Pipeline intern nutzt:
+Onset- und Offset-Schwellen, minimale Sprechdauer, Stille am Sprechende und den
+Pre-Speech-Puffer, der die erste Silbe erhält. Dieser Pfad nutzt
+`ModelManager.ensureVadModels()` und einen eigenen `models_vad/`-Cache und lädt
+daher nie die STT/TTS-Bundles.
+
 ## Aus dem Quellcode bauen
 
 ```bash

--- a/README_es.md
+++ b/README_es.md
@@ -99,6 +99,40 @@ pipeline.start()
 pipeline.pushAudio(samples)
 ```
 
+### Solo detección de actividad de voz
+
+Las apps que solo necesitan saber *cuándo* alguien está hablando —control de
+pulsar para hablar, segmentación de grabaciones, activación por voz— pueden
+cargar Silero por su cuenta: 2 MB de descarga y menos de 10 MB de RAM en lugar
+de los ~500 MB del conjunto por defecto. Sin STT, sin TTS, sin pipeline.
+
+```kotlin
+val detector = VadDetector(
+    VadConfig(
+        modelDir = ModelManager.ensureVadModels(context),
+        emitUtteranceAudio = true, // actívalo para recibir el segmento capturado
+    )
+)
+
+detector.events.collect { event ->
+    when (event) {
+        is VadEvent.SpeechStarted -> startRecordingUi()
+        is VadEvent.SpeechEnded -> saveSegment(event.audio) // 16 kHz float32
+    }
+}
+
+// 16 kHz mono float32, tramas de 512 muestras
+detector.pushAudio(samples)
+// cierra un segmento abierto al terminar el flujo
+detector.flush()
+```
+
+`VadConfig` expone la misma detección de turnos que el pipeline usa
+internamente: umbrales de inicio y fin, duración mínima de habla, silencio de
+fin de habla y el búfer previo que conserva la primera sílaba. Esta ruta usa
+`ModelManager.ensureVadModels()` y una caché `models_vad/` aparte, así que
+nunca descarga los paquetes de STT/TTS.
+
 ## Compilar desde fuente
 
 ```bash

--- a/README_fr.md
+++ b/README_fr.md
@@ -99,6 +99,41 @@ pipeline.start()
 pipeline.pushAudio(samples)
 ```
 
+### Détection d'activité vocale seule
+
+Les apps qui ont seulement besoin de savoir *quand* quelqu'un parle —
+activation push-to-talk, segmentation d'enregistrement, réveil à la voix —
+peuvent charger Silero seul : 2 Mo de téléchargement et moins de 10 Mo de RAM
+au lieu des ~500 Mo du jeu de modèles par défaut. Pas de STT, pas de TTS, pas
+de pipeline.
+
+```kotlin
+val detector = VadDetector(
+    VadConfig(
+        modelDir = ModelManager.ensureVadModels(context),
+        emitUtteranceAudio = true, // à activer pour recevoir le segment capturé
+    )
+)
+
+detector.events.collect { event ->
+    when (event) {
+        is VadEvent.SpeechStarted -> startRecordingUi()
+        is VadEvent.SpeechEnded -> saveSegment(event.audio) // 16 kHz float32
+    }
+}
+
+// 16 kHz mono float32, trames de 512 échantillons
+detector.pushAudio(samples)
+// ferme un segment ouvert à la fin du flux
+detector.flush()
+```
+
+`VadConfig` expose la même détection de tour que le pipeline utilise en
+interne : seuils d'attaque et de relâchement, durée minimale de parole, silence
+de fin de parole et le tampon pré-parole qui conserve la première syllabe. Ce
+chemin utilise `ModelManager.ensureVadModels()` et un cache `models_vad/`
+distinct, il ne télécharge donc jamais les bundles STT/TTS.
+
 ## Compiler depuis les sources
 
 ```bash

--- a/README_hi.md
+++ b/README_hi.md
@@ -99,6 +99,40 @@ pipeline.start()
 pipeline.pushAudio(samples)
 ```
 
+### केवल वॉइस ऐक्टिविटी डिटेक्शन
+
+जिन ऐप्स को सिर्फ़ यह जानना है कि कोई *कब* बोल रहा है — push-to-talk गेटिंग,
+रिकॉर्डिंग सेगमेंटेशन, आवाज़ से जगाना — वे अकेले Silero लोड कर सकती हैं: डिफ़ॉल्ट
+मॉडल सेट के ~500 MB की जगह 2 MB डाउनलोड और 10 MB से कम RAM। न STT, न TTS, न
+पाइपलाइन।
+
+```kotlin
+val detector = VadDetector(
+    VadConfig(
+        modelDir = ModelManager.ensureVadModels(context),
+        emitUtteranceAudio = true, // कैप्चर किया गया सेगमेंट पाने के लिए चालू करें
+    )
+)
+
+detector.events.collect { event ->
+    when (event) {
+        is VadEvent.SpeechStarted -> startRecordingUi()
+        is VadEvent.SpeechEnded -> saveSegment(event.audio) // 16 kHz float32
+    }
+}
+
+// 16 kHz मोनो float32, 512-सैंपल फ़्रेम
+detector.pushAudio(samples)
+// स्ट्रीम खत्म होने पर खुला सेगमेंट बंद करें
+detector.flush()
+```
+
+`VadConfig` वही टर्न डिटेक्शन उजागर करता है जो पाइपलाइन भीतर इस्तेमाल करती है:
+onset और offset थ्रेशोल्ड, न्यूनतम स्पीच अवधि, स्पीच-अंत की चुप्पी, और वह
+प्री-स्पीच बफ़र जो पहला अक्षर बचाए रखता है। यह पथ
+`ModelManager.ensureVadModels()` और अलग `models_vad/` कैश उपयोग करता है, इसलिए
+STT/TTS बंडल कभी डाउनलोड नहीं होते।
+
 ## स्रोत से बिल्ड करें
 
 ```bash

--- a/README_ja.md
+++ b/README_ja.md
@@ -99,6 +99,40 @@ pipeline.start()
 pipeline.pushAudio(samples)
 ```
 
+### 音声区間検出のみ
+
+誰かが話している*タイミング*だけを知りたいアプリ — プッシュトゥトークの制御、
+録音の分割、音声によるウェイクアップ — は Silero 単体を読み込めます。デフォルト
+のモデルセット約 500 MB に対し、ダウンロード 2 MB・メモリ 10 MB 未満です。STT も
+TTS もパイプラインも読み込みません。
+
+```kotlin
+val detector = VadDetector(
+    VadConfig(
+        modelDir = ModelManager.ensureVadModels(context),
+        emitUtteranceAudio = true, // 取得した区間を受け取る場合にオンにする
+    )
+)
+
+detector.events.collect { event ->
+    when (event) {
+        is VadEvent.SpeechStarted -> startRecordingUi()
+        is VadEvent.SpeechEnded -> saveSegment(event.audio) // 16 kHz float32
+    }
+}
+
+// 16 kHz モノラル float32、512 サンプル単位
+detector.pushAudio(samples)
+// ストリーム終了時に開いたままの区間を閉じる
+detector.flush()
+```
+
+`VadConfig` はパイプラインが内部で使うターン検出をそのまま公開します。オンセット /
+オフセットのしきい値、最短発話長、発話終了とみなす無音長、そして最初の音節を
+取りこぼさないプリスピーチバッファです。このパスは `ModelManager.ensureVadModels()`
+と専用の `models_vad/` キャッシュを使うため、STT/TTS のバンドルを取得することは
+ありません。
+
 ## ソースからビルド
 
 ```bash

--- a/README_ko.md
+++ b/README_ko.md
@@ -99,6 +99,38 @@ pipeline.start()
 pipeline.pushAudio(samples)
 ```
 
+### 음성 활동 감지 전용
+
+누군가 말하고 있는 *시점*만 알면 되는 앱 — 푸시투토크 게이팅, 녹음 분할, 음성
+웨이크업 — 은 Silero만 로드할 수 있습니다. 기본 모델 세트 약 500 MB 대신 다운로드
+2 MB, 메모리 10 MB 미만입니다. STT도 TTS도 파이프라인도 없습니다.
+
+```kotlin
+val detector = VadDetector(
+    VadConfig(
+        modelDir = ModelManager.ensureVadModels(context),
+        emitUtteranceAudio = true, // 캡처한 구간을 받으려면 켠다
+    )
+)
+
+detector.events.collect { event ->
+    when (event) {
+        is VadEvent.SpeechStarted -> startRecordingUi()
+        is VadEvent.SpeechEnded -> saveSegment(event.audio) // 16 kHz float32
+    }
+}
+
+// 16 kHz 모노 float32, 512 샘플 프레임
+detector.pushAudio(samples)
+// 스트림이 끝날 때 열린 구간을 닫는다
+detector.flush()
+```
+
+`VadConfig`는 파이프라인이 내부에서 쓰는 턴 감지를 그대로 노출합니다. 시작/종료
+임계값, 최소 발화 길이, 발화 종료 무음 길이, 그리고 첫 음절을 지켜 주는 프리스피치
+버퍼입니다. 이 경로는 `ModelManager.ensureVadModels()`와 별도의 `models_vad/`
+캐시를 사용하므로 STT/TTS 번들을 내려받지 않습니다.
+
 ## 소스에서 빌드
 
 ```bash

--- a/README_pt.md
+++ b/README_pt.md
@@ -99,6 +99,40 @@ pipeline.start()
 pipeline.pushAudio(samples)
 ```
 
+### Apenas detecção de atividade de voz
+
+Apps que só precisam saber *quando* alguém está falando — controle de
+push-to-talk, segmentação de gravação, ativação por voz — podem carregar o
+Silero sozinho: 2 MB de download e menos de 10 MB de RAM em vez dos ~500 MB do
+conjunto padrão. Sem STT, sem TTS, sem pipeline.
+
+```kotlin
+val detector = VadDetector(
+    VadConfig(
+        modelDir = ModelManager.ensureVadModels(context),
+        emitUtteranceAudio = true, // ative para receber o segmento capturado
+    )
+)
+
+detector.events.collect { event ->
+    when (event) {
+        is VadEvent.SpeechStarted -> startRecordingUi()
+        is VadEvent.SpeechEnded -> saveSegment(event.audio) // 16 kHz float32
+    }
+}
+
+// 16 kHz mono float32, quadros de 512 amostras
+detector.pushAudio(samples)
+// fecha um segmento aberto quando o fluxo termina
+detector.flush()
+```
+
+`VadConfig` expõe a mesma detecção de turno que o pipeline usa internamente:
+limiares de início e fim, duração mínima de fala, silêncio de fim de fala e o
+buffer de pré-fala que preserva a primeira sílaba. Esse caminho usa
+`ModelManager.ensureVadModels()` e um cache `models_vad/` separado, então nunca
+baixa os pacotes de STT/TTS.
+
 ## Compilar a partir do código-fonte
 
 ```bash

--- a/README_ru.md
+++ b/README_ru.md
@@ -99,6 +99,40 @@ pipeline.start()
 pipeline.pushAudio(samples)
 ```
 
+### Только детекция речевой активности
+
+Приложениям, которым нужно знать лишь *когда* человек говорит — управление
+push-to-talk, нарезка записи, пробуждение по голосу, — достаточно загрузить
+один Silero: 2 МБ загрузки и меньше 10 МБ памяти вместо ~500 МБ набора по
+умолчанию. Без STT, без TTS, без конвейера.
+
+```kotlin
+val detector = VadDetector(
+    VadConfig(
+        modelDir = ModelManager.ensureVadModels(context),
+        emitUtteranceAudio = true, // включите, чтобы получать записанный фрагмент
+    )
+)
+
+detector.events.collect { event ->
+    when (event) {
+        is VadEvent.SpeechStarted -> startRecordingUi()
+        is VadEvent.SpeechEnded -> saveSegment(event.audio) // 16 кГц float32
+    }
+}
+
+// 16 кГц моно float32, кадры по 512 отсчётов
+detector.pushAudio(samples)
+// закрывает открытый фрагмент в конце потока
+detector.flush()
+```
+
+`VadConfig` открывает ту же детекцию реплик, что конвейер использует внутри:
+пороги начала и конца, минимальную длительность речи, тишину конца реплики и
+пред-речевой буфер, сохраняющий первый слог. Этот путь использует
+`ModelManager.ensureVadModels()` и отдельный кеш `models_vad/`, поэтому пакеты
+STT/TTS не скачиваются никогда.
+
 ## Сборка из исходного кода
 
 ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -99,6 +99,38 @@ pipeline.start()
 pipeline.pushAudio(samples)
 ```
 
+### 仅语音活动检测
+
+只需知道*何时*有人说话的应用——按住说话门控、录音分段、语音唤醒——可以单独加载
+Silero:下载 2 MB、占用不到 10 MB 内存,而非默认模型集的约 500 MB。不加载 STT、
+TTS 或管线。
+
+```kotlin
+val detector = VadDetector(
+    VadConfig(
+        modelDir = ModelManager.ensureVadModels(context),
+        emitUtteranceAudio = true, // 选择接收捕获到的片段
+    )
+)
+
+detector.events.collect { event ->
+    when (event) {
+        is VadEvent.SpeechStarted -> startRecordingUi()
+        is VadEvent.SpeechEnded -> saveSegment(event.audio) // 16 kHz float32
+    }
+}
+
+// 16 kHz 单声道 float32,512 采样一帧
+detector.pushAudio(samples)
+// 流结束时关闭仍打开的片段
+detector.flush()
+```
+
+`VadConfig` 暴露管线内部使用的同一套轮次检测:起始与结束阈值、最短语音时长、
+语音结束静音时长,以及保留首个音节的前置语音缓冲。该路径使用
+`ModelManager.ensureVadModels()` 和独立的 `models_vad/` 缓存,因此永远不会拉取
+STT/TTS 模型包。
+
 ## 从源代码构建
 
 ```bash

--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/VadDetectorTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/VadDetectorTest.kt
@@ -1,0 +1,190 @@
+package audio.soniqo.speech
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Standalone VAD-only detection: the same speech-boundary behavior
+ * [SileroVadTest] covers through the full pipeline, with no STT or TTS model
+ * loaded and only Silero on disk.
+ */
+@RunWith(AndroidJUnit4::class)
+class VadDetectorTest {
+
+    private lateinit var vadModelDir: String
+    private lateinit var ttsModelDir: String
+
+    @Before
+    fun setup() = runBlocking {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        vadModelDir = ModelManager.ensureVadModels(ctx)
+        // Fixture speech comes from the TTS-only profile and its own cache, so
+        // this suite never touches the ~1.2 GB pipeline model set.
+        ttsModelDir = ModelManager.ensureTtsModels(ctx)
+    }
+
+    @Test
+    fun vadOnlyCacheHoldsSileroAndNothingElse() {
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        assertTrue(ModelManager.areVadModelsReady(ctx))
+
+        val files = File(vadModelDir).listFiles().orEmpty()
+            .filter { it.isFile && it.name.endsWith(".onnx") }
+            .map { it.name }
+
+        assertEquals(listOf("silero-vad.onnx"), files)
+    }
+
+    @Test
+    fun silenceDoesNotTriggerSpeechStarted() = runBlocking {
+        VadDetector(VadConfig(modelDir = vadModelDir)).use { detector ->
+            val started = async(start = CoroutineStart.UNDISPATCHED) {
+                withTimeoutOrNull(10_000) {
+                    detector.events.first { it is VadEvent.SpeechStarted }
+                }
+            }
+
+            repeat(94) { detector.pushAudio(FloatArray(512)) } // ~3 s of silence
+
+            assertNull("silence must not trigger SpeechStarted", started.await())
+            assertFalse(detector.isSpeaking)
+        }
+    }
+
+    @Test
+    fun synthesizedSpeechTriggersSpeechStartedAndEnded() = runBlocking {
+        // Fixture generation is deliberately outside the event timeouts: the
+        // detector has received no audio yet and has nothing to detect.
+        val audio = synthesize("The quick brown fox jumps over the lazy dog.")
+
+        VadDetector(
+            VadConfig(modelDir = vadModelDir, emitUtteranceAudio = true),
+        ).use { detector ->
+            val started = async(start = CoroutineStart.UNDISPATCHED) {
+                withTimeout(30_000) {
+                    detector.events.first { it is VadEvent.SpeechStarted }
+                }
+            }
+            val ended = async(start = CoroutineStart.UNDISPATCHED) {
+                withTimeout(60_000) {
+                    detector.events.first { it is VadEvent.SpeechEnded }
+                }
+            }
+
+            pushRealtime(detector, audio)
+            repeat(47) { // ~1.5 s of trailing silence closes the segment
+                detector.pushAudio(FloatArray(512))
+                delay(32)
+            }
+
+            assertNotNull(started.await())
+            val end = ended.await() as VadEvent.SpeechEnded
+            assertNotNull("emitUtteranceAudio was on", end.audio)
+            assertTrue(
+                "captured utterance should carry the speech",
+                end.audio!!.size > 16000 / 2,
+            )
+            assertFalse(detector.isSpeaking)
+        }
+    }
+
+    @Test
+    fun utteranceAudioIsOmittedByDefault() = runBlocking {
+        val audio = synthesize("Hello there.")
+
+        VadDetector(VadConfig(modelDir = vadModelDir)).use { detector ->
+            val ended = async(start = CoroutineStart.UNDISPATCHED) {
+                withTimeout(60_000) {
+                    detector.events.first { it is VadEvent.SpeechEnded }
+                }
+            }
+
+            pushRealtime(detector, audio)
+            repeat(47) {
+                detector.pushAudio(FloatArray(512))
+                delay(32)
+            }
+
+            assertNull((ended.await() as VadEvent.SpeechEnded).audio)
+        }
+    }
+
+    @Test
+    fun flushClosesAnOpenSegmentAtEndOfStream() = runBlocking {
+        val audio = synthesize("Testing one two three.")
+
+        VadDetector(VadConfig(modelDir = vadModelDir)).use { detector ->
+            val ended = async(start = CoroutineStart.UNDISPATCHED) {
+                withTimeout(60_000) {
+                    detector.events.first { it is VadEvent.SpeechEnded }
+                }
+            }
+
+            // No trailing silence: without flush() the segment stays open and
+            // a recording that stops mid-utterance loses its final event.
+            pushRealtime(detector, audio)
+            detector.flush()
+
+            assertNotNull(ended.await())
+        }
+    }
+
+    @Test
+    fun detectorCreatesAndDestroys() {
+        val detector = VadDetector(VadConfig(modelDir = vadModelDir))
+        assertFalse(detector.isSpeaking)
+        detector.reset()
+        detector.close()
+    }
+
+    private suspend fun pushRealtime(detector: VadDetector, audio: FloatArray) {
+        for (offset in audio.indices step 512) {
+            val end = minOf(offset + 512, audio.size)
+            val chunk = audio.sliceArray(offset until end)
+            if (chunk.size == 512) {
+                detector.pushAudio(chunk)
+                delay(32) // real-time pace: 512 samples @ 16 kHz
+            }
+        }
+    }
+
+    private fun synthesize(text: String): FloatArray =
+        SpeechSynthesizer(SpeechSynthesizerConfig(modelDir = ttsModelDir, useNnapi = false)).use {
+            val spoken = it.synthesize(text, "en")
+            assertTrue("synthesized fixture should not be empty", spoken.pcm16.isNotEmpty())
+            pcm16ToFloat16k(spoken.pcm16, spoken.sampleRate)
+        }
+
+    private fun pcm16ToFloat16k(pcm16: ByteArray, sourceSampleRate: Int): FloatArray {
+        val shorts = ShortArray(pcm16.size / 2)
+        ByteBuffer.wrap(pcm16)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .asShortBuffer()
+            .get(shorts)
+        val source = FloatArray(shorts.size) { i -> shorts[i] / 32768.0f }
+        if (sourceSampleRate == 16000) return source
+
+        val outputSize = ((source.size.toLong() * 16000L) / sourceSampleRate).toInt()
+        return FloatArray(outputSize) { i ->
+            val src = i.toDouble() * sourceSampleRate.toDouble() / 16000.0
+            val lo = src.toInt().coerceIn(0, source.lastIndex)
+            val hi = minOf(lo + 1, source.lastIndex)
+            val frac = (src - lo).toFloat()
+            source[lo] * (1.0f - frac) + source[hi] * frac
+        }
+    }
+}

--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/VadDetectorTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/VadDetectorTest.kt
@@ -26,15 +26,17 @@ import java.nio.ByteOrder
 class VadDetectorTest {
 
     private lateinit var vadModelDir: String
-    private lateinit var ttsModelDir: String
+    private lateinit var fixtureModelDir: String
 
     @Before
     fun setup() = runBlocking {
         val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        // The detector under test loads from the VAD-only cache — 2 MB, its own
+        // directory, no STT/TTS files. Fixture speech comes from the shared
+        // pipeline cache the rest of the suite already downloads; asking for a
+        // TTS-only copy here would duplicate ~330 MB of Kokoro on every device.
         vadModelDir = ModelManager.ensureVadModels(ctx)
-        // Fixture speech comes from the TTS-only profile and its own cache, so
-        // this suite never touches the ~1.2 GB pipeline model set.
-        ttsModelDir = ModelManager.ensureTtsModels(ctx)
+        fixtureModelDir = ModelManager.ensureModels(ctx)
     }
 
     @Test
@@ -163,7 +165,7 @@ class VadDetectorTest {
     }
 
     private fun synthesize(text: String): FloatArray =
-        SpeechSynthesizer(SpeechSynthesizerConfig(modelDir = ttsModelDir, useNnapi = false)).use {
+        SpeechSynthesizer(SpeechSynthesizerConfig(modelDir = fixtureModelDir, useNnapi = false)).use {
             val spoken = it.synthesize(text, "en")
             assertTrue("synthesized fixture should not be empty", spoken.pcm16.isNotEmpty())
             pcm16ToFloat16k(spoken.pcm16, spoken.sampleRate)

--- a/sdk/src/main/cpp/jni_bridge.cpp
+++ b/sdk/src/main/cpp/jni_bridge.cpp
@@ -16,6 +16,7 @@
 #endif
 #include <speech_core/interfaces.h>
 #include <speech_core/pipeline/agent_config.h>
+#include <speech_core/pipeline/turn_detector.h>
 #include <speech_core/pipeline/voice_pipeline.h>
 
 #include <algorithm>
@@ -67,6 +68,29 @@ struct PipelineHandle {
 struct SynthesizerHandle {
     std::unique_ptr<speech_core::TTSInterface> tts;
     std::mutex mutex;
+};
+
+// VAD-only handle: Silero + speech_core::TurnDetector, no VoicePipeline and
+// therefore no STT/TTS model. The counterpart of SynthesizerHandle at the
+// other end of the pipeline — an app that only needs to know when someone is
+// talking loads 2 MB instead of the ~500 MB model set.
+struct VadHandle {
+    std::unique_ptr<speech_core::SileroVad> vad;
+    std::unique_ptr<speech_core::TurnDetector> detector;
+
+    // TurnDetector mutates VAD, hysteresis and utterance state on every push
+    // and is not thread-safe; VoicePipeline guards its own instance the same
+    // way. Turn callbacks run inside push_audio with this held, so the Kotlin
+    // callback must not re-enter the detector.
+    std::mutex mutex;
+
+    // Copying the utterance out costs a JNI array per turn, so callers that
+    // only want the speech boundaries opt out.
+    bool emit_audio = false;
+
+    JavaVM* jvm = nullptr;
+    jobject callback = nullptr;
+    jmethodID on_turn_mid = nullptr;
 };
 
 static constexpr int STT_PARAKEET = 0;
@@ -205,6 +229,42 @@ static void dispatch_event(PipelineHandle* h,
 
     if (audio) env->DeleteLocalRef(audio);
     if (text) env->DeleteLocalRef(text);
+}
+
+// ---------------------------------------------------------------------------
+// TurnEvent -> Kotlin onTurn
+//
+//   void onTurn(int type, float timeSec, float[] audio)
+//
+// Only the two speech-boundary events can reach Kotlin. Interruption and
+// InterruptionRecovered need set_agent_speaking(), which nothing calls on a
+// standalone detector — there is no agent playback to barge into.
+// ---------------------------------------------------------------------------
+static void dispatch_turn(VadHandle* h, const speech_core::TurnEvent& event) {
+    jint type;
+    switch (event.type) {
+        case speech_core::TurnEvent::UserSpeechStarted: type = 0; break;
+        case speech_core::TurnEvent::UserSpeechEnded:   type = 1; break;
+        default: return;
+    }
+
+    if (!h->callback) return;
+
+    JNIEnv* env = get_env(h->jvm);
+    if (!env) return;
+
+    jfloatArray audio = nullptr;
+    if (h->emit_audio && !event.audio.empty()) {
+        audio = env->NewFloatArray(static_cast<jsize>(event.audio.size()));
+        if (audio) {
+            env->SetFloatArrayRegion(audio, 0,
+                static_cast<jsize>(event.audio.size()), event.audio.data());
+        }
+    }
+
+    env->CallVoidMethod(h->callback, h->on_turn_mid, type, event.time, audio);
+
+    if (audio) env->DeleteLocalRef(audio);
 }
 
 // ---------------------------------------------------------------------------
@@ -756,6 +816,127 @@ Java_audio_soniqo_speech_NativeBridge_nativePipelineCancelSynthesis(
 {
     auto* h = reinterpret_cast<PipelineHandle*>(handle);
     if (h && h->tts) h->tts->cancel();
+}
+
+// ---------------------------------------------------------------------------
+// VAD-only detector
+// ---------------------------------------------------------------------------
+
+JNIEXPORT jlong JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativeCreateVad(
+    JNIEnv* env, jobject /*thiz*/,
+    jstring modelDir,
+    jfloat onsetThreshold, jfloat offsetThreshold,
+    jfloat minSpeechDurationSec, jfloat endOfSpeechSilenceSec,
+    jfloat preSpeechBufferSec, jfloat maxUtteranceDurationSec,
+    jboolean emitUtteranceAudio, jobject callback)
+{
+    auto dir = jstring_to_string(env, modelDir);
+
+    auto h = std::make_unique<VadHandle>();
+    env->GetJavaVM(&h->jvm);
+    h->emit_audio = emitUtteranceAudio;
+    h->callback = env->NewGlobalRef(callback);
+
+    jclass cls = env->GetObjectClass(callback);
+    h->on_turn_mid = env->GetMethodID(cls, "onTurn", "(IF[F)V");
+
+    try {
+        // hw_accel=false to match the pipeline: Silero is 2 MB and runs a
+        // 32 ms chunk in under a millisecond on CPU, so a hardware provider
+        // only adds a conversion path that can fail.
+        h->vad = std::make_unique<speech_core::SileroVad>(
+            dir + "/silero-vad.onnx", /*hw_accel=*/false);
+
+        speech_core::AgentConfig cfg;
+        cfg.vad.onset = onsetThreshold;
+        cfg.vad.offset = offsetThreshold;
+        cfg.vad.min_speech_duration = minSpeechDurationSec;
+        cfg.vad.min_silence_duration = endOfSpeechSilenceSec;
+        cfg.vad.pre_speech_buffer_duration = preSpeechBufferSec;
+        cfg.max_utterance_duration = maxUtteranceDurationSec;
+        // No STT to run early and no agent playback to interrupt: both would
+        // only split turns the caller never asked to have split.
+        cfg.eager_stt = false;
+        cfg.allow_interruptions = false;
+
+        VadHandle* raw = h.get();
+        h->detector = std::make_unique<speech_core::TurnDetector>(
+            *h->vad, cfg,
+            [raw](const speech_core::TurnEvent& e) { dispatch_turn(raw, e); });
+
+        LOGI("VAD detector created");
+    } catch (const std::exception& e) {
+        LOGE("VAD detector creation failed: %s", e.what());
+        if (h->callback) env->DeleteGlobalRef(h->callback);
+        jclass ex_cls = env->FindClass("java/lang/RuntimeException");
+        if (ex_cls) {
+            std::string msg = std::string("Native VAD detector failed: ") + e.what();
+            env->ThrowNew(ex_cls, msg.c_str());
+        }
+        return 0;
+    }
+
+    return reinterpret_cast<jlong>(h.release());
+}
+
+JNIEXPORT void JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativeDestroyVad(
+    JNIEnv* env, jobject /*thiz*/, jlong handle)
+{
+    auto* h = reinterpret_cast<VadHandle*>(handle);
+    if (h) {
+        if (h->callback) env->DeleteGlobalRef(h->callback);
+        delete h;
+    }
+}
+
+JNIEXPORT void JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativePushVadAudio(
+    JNIEnv* env, jobject /*thiz*/, jlong handle,
+    jfloatArray samples, jint count)
+{
+    auto* h = reinterpret_cast<VadHandle*>(handle);
+    if (!h || !h->detector) return;
+
+    float* data = env->GetFloatArrayElements(samples, nullptr);
+    {
+        std::lock_guard<std::mutex> lock(h->mutex);
+        h->detector->push_audio(data, static_cast<size_t>(count));
+    }
+    env->ReleaseFloatArrayElements(samples, data, JNI_ABORT);
+}
+
+JNIEXPORT void JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativeFlushVad(
+    JNIEnv* /*env*/, jobject /*thiz*/, jlong handle)
+{
+    auto* h = reinterpret_cast<VadHandle*>(handle);
+    if (!h || !h->detector) return;
+    std::lock_guard<std::mutex> lock(h->mutex);
+    h->detector->flush();
+}
+
+JNIEXPORT void JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativeResetVad(
+    JNIEnv* /*env*/, jobject /*thiz*/, jlong handle)
+{
+    auto* h = reinterpret_cast<VadHandle*>(handle);
+    if (!h || !h->detector) return;
+    std::lock_guard<std::mutex> lock(h->mutex);
+    // Independent audio session: also drops the pre-speech ring and the
+    // model's recurrent state so the next stream starts clean.
+    h->detector->reset_for_new_stream();
+}
+
+JNIEXPORT jboolean JNICALL
+Java_audio_soniqo_speech_NativeBridge_nativeVadInSpeech(
+    JNIEnv* /*env*/, jobject /*thiz*/, jlong handle)
+{
+    auto* h = reinterpret_cast<VadHandle*>(handle);
+    if (!h || !h->detector) return JNI_FALSE;
+    std::lock_guard<std::mutex> lock(h->mutex);
+    return h->detector->in_speech() ? JNI_TRUE : JNI_FALSE;
 }
 
 } // extern "C"

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -59,10 +59,7 @@ object ModelManager {
         ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
     ): List<ModelFile> {
         val suffix = if (precision == ModelPrecision.INT8) "-int8" else ""
-        val files = mutableListOf(
-            // VAD (no quantized variant — already 2 MB)
-            ModelFile("Silero-VAD-v5-ONNX", "silero-vad.onnx"),
-        )
+        val files = vadModels().toMutableList()
 
         // STT — Parakeet-EOU low-memory streaming, Parakeet TDT v3, or
         // Nemotron-3.5 multilingual.
@@ -145,6 +142,13 @@ object ModelManager {
         return files
         // Note: FP32 Parakeet encoder also needs parakeet-encoder.onnx.data.
     }
+
+    /** VAD (no quantized variant — already 2 MB). Shared by the full pipeline
+     *  set and the VAD-only profile so both name one file. */
+    @VisibleForTesting
+    internal fun vadModels(): List<ModelFile> = listOf(
+        ModelFile("Silero-VAD-v5-ONNX", "silero-vad.onnx"),
+    )
 
     @VisibleForTesting
     internal fun ttsModels(ttsModel: TtsModel): List<ModelFile> = when (ttsModel) {
@@ -317,6 +321,26 @@ object ModelManager {
     }
 
     /**
+     * True iff the VAD-only cache contains Silero. Used by the [VadDetector]
+     * path, where downloading STT/TTS/enhancer assets would be ~500 MB of
+     * overhead for a 2 MB model.
+     */
+    fun areVadModelsReady(context: Context): Boolean {
+        val dir = File(vadModelDir(context))
+        if (!dir.exists()) return false
+
+        val versionFile = File(dir, "version.txt")
+        val cached = versionFile.takeIf { it.exists() }?.readText()?.trim()?.toIntOrNull() ?: 0
+        if (cached < MODEL_VERSION) return false
+        if (cachedModelSet(dir) != vadModelSetKey()) return false
+
+        return vadModels().all { model ->
+            val dest = File(dir, model.localFilename)
+            dest.exists() && isValidModel(dest, model.filename)
+        }
+    }
+
+    /**
      * True iff the LLM cache contains a valid FunctionGemma bundle.
      * Cheap and side-effect free — does not start a download.
      */
@@ -350,6 +374,10 @@ object ModelManager {
     /** Path to the TTS-only model directory, without downloading. */
     fun ttsModelDir(context: Context): String =
         File(context.filesDir, "models_tts").absolutePath
+
+    /** Path to the VAD-only model directory, without downloading. */
+    fun vadModelDir(context: Context): String =
+        File(context.filesDir, "models_vad").absolutePath
 
     /** Path to the LLM model directory, without downloading. */
     fun llmModelDir(
@@ -444,6 +472,34 @@ object ModelManager {
         downloadMissingModels(dir, ttsModels(ttsModel), onProgress)
 
         File(dir, "precision.txt").writeText("TTS")
+        versionFile.writeText(MODEL_VERSION.toString())
+        File(dir, MODEL_SET_FILENAME).writeText(requestedModelSet)
+
+        dir.absolutePath
+    }
+
+    /**
+     * Returns the VAD-only model directory path, downloading Silero if needed.
+     * Separate from [ensureModels] so an app that only detects speech never
+     * pulls the STT/TTS bundles.
+     */
+    suspend fun ensureVadModels(
+        context: Context,
+        onProgress: ((Progress) -> Unit)? = null,
+    ): String = withContext(Dispatchers.IO) {
+        val dir = File(vadModelDir(context))
+        dir.mkdirs()
+
+        val versionFile = File(dir, "version.txt")
+        val cached = versionFile.takeIf { it.exists() }?.readText()?.trim()?.toIntOrNull() ?: 0
+        val requestedModelSet = vadModelSetKey()
+        if (cached < MODEL_VERSION || cachedModelSet(dir) != requestedModelSet) {
+            clearModelCache(dir)
+        }
+
+        downloadMissingModels(dir, vadModels(), onProgress)
+
+        File(dir, "precision.txt").writeText("VAD")
         versionFile.writeText(MODEL_VERSION.toString())
         File(dir, MODEL_SET_FILENAME).writeText(requestedModelSet)
 
@@ -669,6 +725,12 @@ object ModelManager {
         "v$MODEL_VERSION",
         "profile=TTS",
         "tts=${ttsCacheName(ttsModel)}",
+    ).joinToString("|")
+
+    @VisibleForTesting
+    internal fun vadModelSetKey(): String = listOf(
+        "v$MODEL_VERSION",
+        "profile=VAD",
     ).joinToString("|")
 
     private fun ttsCacheName(ttsModel: TtsModel): String =

--- a/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
@@ -72,6 +72,35 @@ internal object NativeBridge {
         voice: String,
     ): ByteArray
 
+    // VAD-only detector: Silero + speech_core::TurnDetector, no STT/TTS model
+    // and no VoicePipeline. Must stay in lockstep with the VadHandle section
+    // of jni_bridge.cpp.
+    external fun nativeCreateVad(
+        modelDir: String,
+        onsetThreshold: Float,
+        offsetThreshold: Float,
+        minSpeechDurationSec: Float,
+        endOfSpeechSilenceSec: Float,
+        preSpeechBufferSec: Float,
+        maxUtteranceDurationSec: Float,
+        emitUtteranceAudio: Boolean,
+        callback: VadCallback,
+    ): Long
+
+    external fun nativeDestroyVad(handle: Long)
+    external fun nativePushVadAudio(handle: Long, samples: FloatArray, count: Int)
+    external fun nativeFlushVad(handle: Long)
+    external fun nativeResetVad(handle: Long)
+    external fun nativeVadInSpeech(handle: Long): Boolean
+
+    /** Called from native code on the thread that pushed the audio. */
+    fun interface VadCallback {
+        // type: 0=SpeechStarted, 1=SpeechEnded. `audio` is the utterance
+        // (with its pre-speech head) on SpeechEnded, null when the detector
+        // was created with emitUtteranceAudio = false.
+        fun onTurn(type: Int, timeSec: Float, audio: FloatArray?)
+    }
+
     /** Called from native code on the pipeline worker thread. */
     interface EventCallback {
         fun onEvent(

--- a/sdk/src/main/kotlin/audio/soniqo/speech/VadDetector.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/VadDetector.kt
@@ -1,0 +1,205 @@
+package audio.soniqo.speech
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * Configuration for standalone voice activity detection.
+ *
+ * This is the VAD-only counterpart to [SpeechConfig]. It loads Silero VAD and
+ * nothing else — no STT, no TTS, no pipeline — so the download is ~2 MB
+ * instead of the ~500 MB default model set.
+ */
+data class VadConfig(
+    /** Path to the directory containing `silero-vad.onnx`. */
+    val modelDir: String = "",
+
+    /** Speech starts once the frame probability rises above this. */
+    val onsetThreshold: Float = 0.5f,
+
+    /** Speech ends once the frame probability falls below this. Kept under
+     *  [onsetThreshold] on purpose: the gap is the hysteresis that stops a
+     *  probability hovering at the threshold from chattering. */
+    val offsetThreshold: Float = 0.35f,
+
+    /** Speech shorter than this never opens a segment — filters coughs, door
+     *  clicks and mic bumps. */
+    val minSpeechDurationSec: Float = 0.25f,
+
+    /** Seconds of detected silence that end a segment. The 0.5 s default
+     *  matches [SpeechConfig.endOfSpeechSilenceSec]; raise it (0.8–1.2 s) when
+     *  speakers pause mid-utterance and get cut off early. */
+    val endOfSpeechSilenceSec: Float = 0.5f,
+
+    /** Seconds of audio kept before onset and prepended to the segment. Speech
+     *  is already under way by the time the probability crosses the threshold,
+     *  so without this the first syllable is missing from
+     *  [VadEvent.SpeechEnded]. 0 disables the ring. */
+    val preSpeechBufferSec: Float = 0.6f,
+
+    /** A segment this long is closed and a new one opened, so a speaker who
+     *  never pauses still produces bounded events. 0 = unbounded. */
+    val maxUtteranceDurationSec: Float = 15f,
+
+    /** Deliver the captured samples with [VadEvent.SpeechEnded]. Off by
+     *  default: a listener that only needs the speech boundaries should not
+     *  pay for a copy of every utterance. */
+    val emitUtteranceAudio: Boolean = false,
+)
+
+/** Speech-boundary events from [VadDetector]. Times are seconds since the
+ *  detector was created, counted over the audio pushed into it. */
+sealed class VadEvent {
+    data class SpeechStarted(val timeSec: Float) : VadEvent()
+
+    /**
+     * A segment closed. [audio] holds the utterance at 16 kHz including its
+     * pre-speech head, or null when [VadConfig.emitUtteranceAudio] is off.
+     */
+    data class SpeechEnded(val timeSec: Float, val audio: FloatArray?) : VadEvent()
+}
+
+/**
+ * On-device voice activity detection — Silero VAD v5 with turn detection, and
+ * nothing else loaded.
+ *
+ * The VAD-only counterpart to [SpeechSynthesizer]: where that one speaks
+ * without a pipeline, this one listens without one. Use it when the app needs
+ * to know that someone is talking — push-to-talk gating, recording
+ * segmentation, wake-on-voice — and never needs a transcript.
+ *
+ * Construct via `VadDetector(config)` after downloading the model with
+ * [ModelManager.ensureVadModels]. Tests can supply their own implementation
+ * of this interface to avoid loading the native library.
+ *
+ * Usage:
+ * ```
+ * val detector = VadDetector(VadConfig(modelDir = ModelManager.ensureVadModels(context)))
+ * detector.events.collect { event -> ... }
+ * detector.pushAudio(micSamples)
+ * detector.close()
+ * ```
+ */
+interface VadDetector : AutoCloseable {
+
+    /** Stream of speech-boundary events. */
+    val events: SharedFlow<VadEvent>
+
+    /** True between [VadEvent.SpeechStarted] and [VadEvent.SpeechEnded]. */
+    val isSpeaking: Boolean
+
+    /**
+     * Feed PCM Float32 microphone samples at 16 kHz. Events are emitted from
+     * the calling thread, so do not push audio from the main thread.
+     *
+     * Samples are consumed in 512-sample chunks; a trailing partial chunk is
+     * dropped rather than buffered, so push whole 512-sample frames.
+     */
+    fun pushAudio(samples: FloatArray)
+
+    /**
+     * Close an open segment at end of stream. Without this a recording that
+     * stops mid-utterance never emits its final [VadEvent.SpeechEnded].
+     */
+    fun flush() {}
+
+    /**
+     * Reset for an independent audio stream: drops the pre-speech ring and the
+     * model's recurrent state so audio cannot cross the boundary. Call it
+     * between recordings, not between utterances.
+     */
+    fun reset() {}
+
+    companion object {
+        operator fun invoke(config: VadConfig): VadDetector {
+            config.requireValidThresholds()
+            return VadDetectorImpl(config)
+        }
+    }
+}
+
+/** Validate the hysteresis before JNI loads the model or starts native work. */
+internal fun VadConfig.requireValidThresholds() {
+    require(onsetThreshold > 0f && onsetThreshold <= 1f) {
+        "VadConfig.onsetThreshold must be in (0, 1], was $onsetThreshold"
+    }
+    require(offsetThreshold > 0f && offsetThreshold <= onsetThreshold) {
+        "VadConfig.offsetThreshold must be in (0, onsetThreshold], was " +
+            "$offsetThreshold with onsetThreshold=$onsetThreshold. An offset " +
+            "above the onset inverts the hysteresis and chatters on every frame."
+    }
+    require(minSpeechDurationSec >= 0f) {
+        "VadConfig.minSpeechDurationSec must be >= 0, was $minSpeechDurationSec"
+    }
+    require(endOfSpeechSilenceSec > 0f) {
+        "VadConfig.endOfSpeechSilenceSec must be > 0, was $endOfSpeechSilenceSec. " +
+            "Zero silence ends a segment on the first non-speech frame."
+    }
+    require(preSpeechBufferSec >= 0f) {
+        "VadConfig.preSpeechBufferSec must be >= 0, was $preSpeechBufferSec"
+    }
+    require(maxUtteranceDurationSec >= 0f) {
+        "VadConfig.maxUtteranceDurationSec must be >= 0, was $maxUtteranceDurationSec"
+    }
+}
+
+internal class VadDetectorImpl(config: VadConfig) : VadDetector {
+
+    private val _events = MutableSharedFlow<VadEvent>(
+        extraBufferCapacity = 64,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    override val events: SharedFlow<VadEvent> = _events.asSharedFlow()
+
+    private val nativeCallback = NativeBridge.VadCallback { type, timeSec, audio ->
+        val event = when (type) {
+            0 -> VadEvent.SpeechStarted(timeSec)
+            1 -> VadEvent.SpeechEnded(timeSec, audio)
+            else -> null
+        }
+        if (event != null) _events.tryEmit(event)
+    }
+
+    private var handle: Long = NativeBridge.nativeCreateVad(
+        config.modelDir,
+        config.onsetThreshold,
+        config.offsetThreshold,
+        config.minSpeechDurationSec,
+        config.endOfSpeechSilenceSec,
+        config.preSpeechBufferSec,
+        config.maxUtteranceDurationSec,
+        config.emitUtteranceAudio,
+        nativeCallback,
+    ).also { h ->
+        if (h == 0L) throw IllegalStateException(
+            "Failed to create native VAD detector. The model may be corrupt — " +
+                "try clearing app data and reinstalling."
+        )
+    }
+
+    override val isSpeaking: Boolean
+        get() = handle != 0L && NativeBridge.nativeVadInSpeech(handle)
+
+    override fun pushAudio(samples: FloatArray) {
+        check(handle != 0L) { "VadDetector is closed" }
+        NativeBridge.nativePushVadAudio(handle, samples, samples.size)
+    }
+
+    override fun flush() {
+        if (handle != 0L) NativeBridge.nativeFlushVad(handle)
+    }
+
+    override fun reset() {
+        if (handle != 0L) NativeBridge.nativeResetVad(handle)
+    }
+
+    override fun close() {
+        if (handle != 0L) {
+            NativeBridge.nativeDestroyVad(handle)
+            handle = 0
+        }
+    }
+}

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
@@ -208,6 +208,39 @@ class ModelManagerManifestTest {
     }
 
     @Test
+    fun `vad-only manifest is silero alone`() {
+        assertEquals(
+            listOf(ModelManager.ModelFile("Silero-VAD-v5-ONNX", "silero-vad.onnx")),
+            ModelManager.vadModels(),
+        )
+    }
+
+    @Test
+    fun `vad-only manifest is a subset of every pipeline set`() {
+        // The two profiles must name the same file: a device that already has
+        // the full set and one that only ever ran the detector are validated
+        // against one entry, and models() reuses vadModels() to guarantee it.
+        for (stt in SttModel.entries) {
+            for (tts in TtsModel.entries) {
+                assertTrue(
+                    "$stt/$tts pipeline set must contain the VAD manifest",
+                    modelFiles(sttModel = stt, ttsModel = tts)
+                        .containsAll(ModelManager.vadModels()),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `vad-only model set key is separate from the pipeline and tts caches`() {
+        assertNotEquals(ModelManager.vadModelSetKey(), modelSetKey())
+        assertNotEquals(
+            ModelManager.vadModelSetKey(),
+            ModelManager.ttsModelSetKey(TtsModel.KOKORO_SHORT_TURN),
+        )
+    }
+
+    @Test
     fun `supertonic manifest includes complete voice catalog from LiteRT repo`() {
         val styleFiles = modelFiles(ttsModel = TtsModel.SUPERTONIC)
             .filter { it.filename.startsWith("voice_styles/") }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/VadConfigTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/VadConfigTest.kt
@@ -1,0 +1,74 @@
+package audio.soniqo.speech
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VadConfigTest {
+
+    @Test
+    fun `defaults match the pipeline's turn detection`() {
+        val config = VadConfig()
+        assertEquals(0.5f, config.onsetThreshold, 0f)
+        assertEquals(0.35f, config.offsetThreshold, 0f)
+        assertEquals(0.25f, config.minSpeechDurationSec, 0f)
+        // Same value SpeechConfig uses, so a caller moving between the two
+        // does not silently get different segment boundaries.
+        assertEquals(
+            SpeechConfig().endOfSpeechSilenceSec,
+            config.endOfSpeechSilenceSec,
+            0f,
+        )
+    }
+
+    @Test
+    fun `utterance audio is opt-in`() {
+        assertEquals(false, VadConfig().emitUtteranceAudio)
+    }
+
+    @Test
+    fun `an offset above the onset is rejected instead of chattering`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            VadConfig(onsetThreshold = 0.4f, offsetThreshold = 0.6f)
+                .requireValidThresholds()
+        }
+
+        assertTrue(error.message.orEmpty().contains("offsetThreshold"))
+        assertTrue(error.message.orEmpty().contains("hysteresis"))
+    }
+
+    @Test
+    fun `zero end-of-speech silence is rejected`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            VadConfig(endOfSpeechSilenceSec = 0f).requireValidThresholds()
+        }
+
+        assertTrue(error.message.orEmpty().contains("endOfSpeechSilenceSec"))
+    }
+
+    @Test
+    fun `an onset above one can never fire`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            VadConfig(onsetThreshold = 1.5f).requireValidThresholds()
+        }
+    }
+
+    @Test
+    fun `negative durations are rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            VadConfig(minSpeechDurationSec = -1f).requireValidThresholds()
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            VadConfig(preSpeechBufferSec = -1f).requireValidThresholds()
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            VadConfig(maxUtteranceDurationSec = -1f).requireValidThresholds()
+        }
+    }
+
+    @Test
+    fun `equal onset and offset is allowed`() {
+        VadConfig(onsetThreshold = 0.5f, offsetThreshold = 0.5f).requireValidThresholds()
+    }
+}


### PR DESCRIPTION
## Summary

Adds `VadDetector` — a standalone voice-activity path that loads Silero and
nothing else. Apps that only need to know *when* someone is speaking
(push-to-talk gating, recording segmentation, wake-on-voice) had to build the
full `SpeechPipeline`, which loads STT and TTS and downloads ~500 MB before the
first frame reaches the VAD. This is 2 MB and under 10 MB of RAM.

The design mirrors the existing TTS-only path (`SpeechSynthesizer` +
`models_tts/`): `VadDetector` drives speech-core's `TurnDetector` directly, so
there is no `VoicePipeline` and no STT/TTS instance to keep alive. No
speech-core change — `TurnDetector` is already public and already linked in.

```kotlin
val detector = VadDetector(
    VadConfig(
        modelDir = ModelManager.ensureVadModels(context),
        emitUtteranceAudio = true, // opt in to receive the captured segment
    )
)

detector.events.collect { event ->
    when (event) {
        is VadEvent.SpeechStarted -> startRecordingUi()
        is VadEvent.SpeechEnded -> saveSegment(event.audio) // 16 kHz float32
    }
}

detector.pushAudio(samples)
detector.flush()
```

### Notes on the approach

The issue proposed `SttModel.NONE` / `TtsModel.NONE` on `SpeechConfig` instead.
Two things ruled that out, both covered in
https://github.com/soniqo/speech-android/issues/87#issuecomment-5494009722:

- `VoicePipeline` takes `STTInterface&` / `TTSInterface&` — references, not
  pointers — and `stop()` / `cancel_current_turn()` dereference both
  unconditionally. Passing null needs a speech-core change first.
- `SttModel` has no explicit native id; `SpeechPipeline` sends
  `sttModel.ordinal` and the bridge matches `STT_PARAKEET=0 … STT_CANARY=3`.
  Prepending `NONE` shifts every value by one, so `PARAKEET` would silently
  load Nemotron with no compile error and no failing test.

### What changed

- **`jni_bridge.cpp`** — `VadHandle` (Silero + `TurnDetector`) and six entry
  points. A mutex guards the detector; `TurnDetector::push_audio` is not
  thread-safe and `VoicePipeline` guards its own the same way. Only the two
  speech-boundary events can reach Kotlin — interruption events need
  `set_agent_speaking()`, which nothing calls without agent playback.
  `hw_accel=false` to match the pipeline, so there is no dead NNAPI knob on a
  2 MB model that runs a 32 ms chunk in under a millisecond on CPU.
- **`VadDetector.kt`** — `VadConfig` / `VadEvent` / `VadDetector`, shaped like
  `SpeechSynthesizer`. `VadConfig` exposes the hysteresis the pipeline sets
  internally and validates it before JNI: an offset above the onset inverts the
  hysteresis and chatters on every frame, so it is rejected with that reason
  rather than shipped. Utterance audio is opt-in — a boundary-only listener
  should not pay for a copy of every segment.
- **`ModelManager`** — `vadModels()` / `ensureVadModels()` /
  `areVadModelsReady()` / `vadModelDir()` / `vadModelSetKey()`, cached under
  `models_vad/`. `models()` now reuses `vadModels()` so both profiles name one
  file.
- **Docs** — VAD-only section in `README.md` and all nine translations;
  `AGENTS.md` key-files list.

## Test plan

- `./gradlew :sdk:test` — passes. 10 new unit tests: `VadConfigTest` (7) covers
  the threshold validation, and `ModelManagerManifestTest` gains three,
  including one asserting the VAD manifest is a subset of all 16 STT × TTS
  pipeline sets.
- `./gradlew :sdk:assembleDebug` — native builds for arm64-v8a and x86_64; all
  six JNI symbols confirmed exported in `libspeech_android.so`.
- `./gradlew :app:compileDebugKotlin :control-demo:compileDebugKotlin` — pass.
- `VadDetectorTest` (6 e2e tests) is written and compiles but **has not been
  run** — no device or emulator was available. It pulls speech fixtures from the
  TTS-only cache, so it never downloads the 1.2 GB pipeline set. Needs a run on
  an arm64 device before merge.

Closes #87
