### PR TITLE
Add Smart Turn end-of-turn detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Download the [signed APK](https://github.com/soniqo/speech-android/releases/late
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.19")
+    implementation("audio.soniqo:speech:0.0.20")
 }
 ```
 
@@ -123,6 +123,31 @@ pipeline.start()
 // Feed 16kHz mono float32 PCM from microphone
 pipeline.pushAudio(samples)
 ```
+
+### End-of-turn detection
+
+A VAD hears silence, but cannot tell whether a pause finishes the speaker's
+thought. Smart Turn v3.2 is an optional audio-native classifier that considers
+the last eight seconds of the current turn and keeps an incomplete turn open.
+
+```kotlin
+val modelDir = ModelManager.ensureModels(context, enableSmartTurn = true)
+
+val pipeline = SpeechPipeline(
+    SpeechConfig(
+        modelDir = modelDir,
+        enableSmartTurn = true,
+        turnCompletionThreshold = 0.5f,
+        turnCompletionMaxSilenceSec = 2.0f,
+    )
+)
+```
+
+The opt-in download adds the pinned 11.1 MB int8 graph. Inference runs once
+after each confirmed VAD pause, not on every audio frame. A vetoed pause stays
+in the same turn if speech resumes; the maximum-silence setting guarantees that
+a trailing speaker still reaches an endpoint. Smart Turn is created by
+Pipecat/Daily and distributed under BSD-2-Clause.
 
 ### Voice activity detection only
 

--- a/README_de.md
+++ b/README_de.md
@@ -74,7 +74,7 @@ Lade das [signierte APK](https://github.com/soniqo/speech-android/releases/lates
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.19")
+    implementation("audio.soniqo:speech:0.0.20")
 }
 ```
 
@@ -100,6 +100,32 @@ pipeline.start()
 // Speise 16kHz Mono float32 PCM vom Mikrofon ein
 pipeline.pushAudio(samples)
 ```
+
+### Erkennung des Gesprächsendes
+
+Ein VAD erkennt Stille, kann aber nicht entscheiden, ob eine Pause den Gedanken
+des Sprechers abschließt. Smart Turn v3.2 ist ein optionaler, audiobasierter
+Klassifikator. Er betrachtet die letzten acht Sekunden des aktuellen Turns und
+hält einen unvollständigen Turn offen.
+
+```kotlin
+val modelDir = ModelManager.ensureModels(context, enableSmartTurn = true)
+
+val pipeline = SpeechPipeline(
+    SpeechConfig(
+        modelDir = modelDir,
+        enableSmartTurn = true,
+        turnCompletionThreshold = 0.5f,
+        turnCompletionMaxSilenceSec = 2.0f,
+    )
+)
+```
+
+Der optionale Download fügt das fest versionierte 11,1-MB-INT8-Modell hinzu.
+Die Inferenz läuft einmal nach jeder bestätigten VAD-Pause, nicht für jeden
+Audio-Frame. Wird die Pause abgelehnt, bleibt fortgesetzte Sprache im selben
+Turn; das maximale Stillelimit garantiert trotzdem einen Endpunkt. Smart Turn
+wurde von Pipecat/Daily entwickelt und steht unter BSD-2-Clause.
 
 ### Nur Sprachaktivitätserkennung
 

--- a/README_es.md
+++ b/README_es.md
@@ -74,7 +74,7 @@ Descarga el [APK firmado](https://github.com/soniqo/speech-android/releases/late
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.19")
+    implementation("audio.soniqo:speech:0.0.20")
 }
 ```
 
@@ -100,6 +100,32 @@ pipeline.start()
 // Alimenta PCM float32 mono 16kHz desde el micrófono
 pipeline.pushAudio(samples)
 ```
+
+### Detección de fin de turno
+
+Un VAD detecta silencio, pero no sabe si una pausa completa la idea del
+hablante. Smart Turn v3.2 es un clasificador opcional basado en audio que
+considera los últimos ocho segundos del turno y mantiene abierto un turno
+incompleto.
+
+```kotlin
+val modelDir = ModelManager.ensureModels(context, enableSmartTurn = true)
+
+val pipeline = SpeechPipeline(
+    SpeechConfig(
+        modelDir = modelDir,
+        enableSmartTurn = true,
+        turnCompletionThreshold = 0.5f,
+        turnCompletionMaxSilenceSec = 2.0f,
+    )
+)
+```
+
+La descarga opcional añade el grafo INT8 fijado de 11,1 MB. La inferencia se
+ejecuta una vez después de cada pausa confirmada por VAD, no en cada frame de
+audio. Si se rechaza la pausa, el habla reanudada continúa en el mismo turno;
+el límite máximo de silencio garantiza un final. Smart Turn fue creado por
+Pipecat/Daily y se distribuye bajo BSD-2-Clause.
 
 ### Solo detección de actividad de voz
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -74,7 +74,7 @@ Téléchargez l'[APK signé](https://github.com/soniqo/speech-android/releases/l
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.19")
+    implementation("audio.soniqo:speech:0.0.20")
 }
 ```
 
@@ -100,6 +100,31 @@ pipeline.start()
 // Alimente avec du PCM float32 mono 16 kHz depuis le micro
 pipeline.pushAudio(samples)
 ```
+
+### Détection de fin de tour
+
+Un VAD détecte le silence, mais ne sait pas si une pause termine la pensée du
+locuteur. Smart Turn v3.2 est un classifieur audio facultatif qui examine les
+huit dernières secondes du tour et garde un tour incomplet ouvert.
+
+```kotlin
+val modelDir = ModelManager.ensureModels(context, enableSmartTurn = true)
+
+val pipeline = SpeechPipeline(
+    SpeechConfig(
+        modelDir = modelDir,
+        enableSmartTurn = true,
+        turnCompletionThreshold = 0.5f,
+        turnCompletionMaxSilenceSec = 2.0f,
+    )
+)
+```
+
+Le téléchargement facultatif ajoute le graphe INT8 épinglé de 11,1 Mo.
+L'inférence s'exécute une fois après chaque pause confirmée par le VAD, et non
+sur chaque trame audio. Si la pause est refusée, la parole reprise reste dans
+le même tour ; la durée maximale de silence garantit tout de même une fin.
+Smart Turn est créé par Pipecat/Daily et distribué sous BSD-2-Clause.
 
 ### Détection d'activité vocale seule
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -74,7 +74,7 @@ Kokoro और Supertonic दोनों डायरेक्ट सिंथ�
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.19")
+    implementation("audio.soniqo:speech:0.0.20")
 }
 ```
 
@@ -100,6 +100,31 @@ pipeline.start()
 // माइक्रोफ़ोन से 16kHz मोनो float32 PCM फ़ीड करें
 pipeline.pushAudio(samples)
 ```
+
+### टर्न समाप्ति डिटेक्शन
+
+VAD मौन पहचानता है, लेकिन यह नहीं बता सकता कि कोई विराम वक्ता की बात पूरी
+करता है या नहीं। Smart Turn v3.2 एक वैकल्पिक ऑडियो-आधारित क्लासिफ़ायर है जो
+मौजूदा टर्न के अंतिम आठ सेकंड देखकर अधूरे टर्न को खुला रखता है।
+
+```kotlin
+val modelDir = ModelManager.ensureModels(context, enableSmartTurn = true)
+
+val pipeline = SpeechPipeline(
+    SpeechConfig(
+        modelDir = modelDir,
+        enableSmartTurn = true,
+        turnCompletionThreshold = 0.5f,
+        turnCompletionMaxSilenceSec = 2.0f,
+    )
+)
+```
+
+यह वैकल्पिक डाउनलोड स्थिर संस्करण वाला 11.1 MB INT8 ग्राफ़ जोड़ता है। हर
+ऑडियो फ़्रेम पर नहीं, बल्कि VAD द्वारा पुष्टि किए गए प्रत्येक विराम के बाद एक
+बार इनफ़रेंस चलता है। विराम अस्वीकार होने पर दोबारा शुरू हुई आवाज़ उसी टर्न में
+रहती है; अधिकतम मौन सीमा अंत सुनिश्चित करती है। Smart Turn को Pipecat/Daily ने
+बनाया है और यह BSD-2-Clause के तहत वितरित है।
 
 ### केवल वॉइस ऐक्टिविटी डिटेक्शन
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -74,7 +74,7 @@ Kokoro と Supertonic はどちらも、直接合成の呼び出しごとに音�
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.19")
+    implementation("audio.soniqo:speech:0.0.20")
 }
 ```
 
@@ -100,6 +100,31 @@ pipeline.start()
 // マイクから 16kHz モノラル float32 PCM を入力
 pipeline.pushAudio(samples)
 ```
+
+### ターン終了検出
+
+VAD は無音を検出できますが、その間が話者の発話完了を意味するかは判断できません。
+Smart Turn v3.2 は、現在のターンの直近 8 秒を確認し、未完了のターンを開いたままに
+するオプションの音声ベース分類器です。
+
+```kotlin
+val modelDir = ModelManager.ensureModels(context, enableSmartTurn = true)
+
+val pipeline = SpeechPipeline(
+    SpeechConfig(
+        modelDir = modelDir,
+        enableSmartTurn = true,
+        turnCompletionThreshold = 0.5f,
+        turnCompletionMaxSilenceSec = 2.0f,
+    )
+)
+```
+
+有効にすると、固定リビジョンの 11.1 MB INT8 グラフが追加でダウンロードされます。
+推論は全音声フレームではなく、VAD が確定した各ポーズの後に 1 回だけ実行されます。
+ポーズが却下されて発話が再開すると同じターンが継続し、最大無音時間によって最終的な
+終了も保証されます。Smart Turn は Pipecat/Daily が開発し、BSD-2-Clause で配布
+されています。
 
 ### 音声区間検出のみ
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -74,7 +74,7 @@ Kokoro와 Supertonic 모두 직접 합성 시 호출 단위로 음성 프리셋�
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.19")
+    implementation("audio.soniqo:speech:0.0.20")
 }
 ```
 
@@ -100,6 +100,30 @@ pipeline.start()
 // 마이크에서 16kHz 모노 float32 PCM 입력
 pipeline.pushAudio(samples)
 ```
+
+### 턴 종료 감지
+
+VAD는 침묵을 감지하지만, 그 멈춤이 화자의 생각이 끝났다는 의미인지는 판단할 수
+없습니다. Smart Turn v3.2는 현재 턴의 마지막 8초를 살펴보고 미완성 턴을 열린
+상태로 유지하는 선택적 오디오 기반 분류기입니다.
+
+```kotlin
+val modelDir = ModelManager.ensureModels(context, enableSmartTurn = true)
+
+val pipeline = SpeechPipeline(
+    SpeechConfig(
+        modelDir = modelDir,
+        enableSmartTurn = true,
+        turnCompletionThreshold = 0.5f,
+        turnCompletionMaxSilenceSec = 2.0f,
+    )
+)
+```
+
+옵트인 다운로드는 고정된 리비전의 11.1 MB INT8 그래프를 추가합니다. 추론은 모든
+오디오 프레임이 아니라 VAD가 확인한 각 멈춤 뒤에 한 번 실행됩니다. 멈춤이 거부된
+뒤 말이 재개되면 같은 턴이 이어지며, 최대 침묵 제한이 최종 종료를 보장합니다.
+Smart Turn은 Pipecat/Daily가 만들었으며 BSD-2-Clause로 배포됩니다.
 
 ### 음성 활동 감지 전용
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -74,7 +74,7 @@ Baixe o [APK assinado](https://github.com/soniqo/speech-android/releases/latest/
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.19")
+    implementation("audio.soniqo:speech:0.0.20")
 }
 ```
 
@@ -100,6 +100,32 @@ pipeline.start()
 // Alimente PCM float32 mono 16kHz do microfone
 pipeline.pushAudio(samples)
 ```
+
+### Detecção de fim de turno
+
+Um VAD detecta silêncio, mas não sabe se uma pausa conclui o pensamento do
+falante. O Smart Turn v3.2 é um classificador opcional baseado em áudio que
+analisa os últimos oito segundos do turno atual e mantém aberto um turno
+incompleto.
+
+```kotlin
+val modelDir = ModelManager.ensureModels(context, enableSmartTurn = true)
+
+val pipeline = SpeechPipeline(
+    SpeechConfig(
+        modelDir = modelDir,
+        enableSmartTurn = true,
+        turnCompletionThreshold = 0.5f,
+        turnCompletionMaxSilenceSec = 2.0f,
+    )
+)
+```
+
+O download opcional adiciona o grafo INT8 fixado de 11,1 MB. A inferência roda
+uma vez após cada pausa confirmada pelo VAD, e não em cada frame de áudio. Se a
+pausa for rejeitada, a fala retomada continua no mesmo turno; o limite máximo
+de silêncio ainda garante um fim. O Smart Turn foi criado pela Pipecat/Daily e
+é distribuído sob BSD-2-Clause.
 
 ### Apenas detecção de atividade de voz
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -74,7 +74,7 @@ Kokoro и Supertonic принимают пресет голоса на кажд�
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.19")
+    implementation("audio.soniqo:speech:0.0.20")
 }
 ```
 
@@ -100,6 +100,32 @@ pipeline.start()
 // Подавайте 16 кГц моно float32 PCM с микрофона
 pipeline.pushAudio(samples)
 ```
+
+### Определение конца реплики
+
+VAD распознаёт тишину, но не может понять, завершает ли пауза мысль говорящего.
+Smart Turn v3.2 — необязательный аудиоклассификатор, который анализирует
+последние восемь секунд текущей реплики и оставляет незавершённую реплику
+открытой.
+
+```kotlin
+val modelDir = ModelManager.ensureModels(context, enableSmartTurn = true)
+
+val pipeline = SpeechPipeline(
+    SpeechConfig(
+        modelDir = modelDir,
+        enableSmartTurn = true,
+        turnCompletionThreshold = 0.5f,
+        turnCompletionMaxSilenceSec = 2.0f,
+    )
+)
+```
+
+При включении загружается закреплённый INT8-граф размером 11,1 МБ. Инференс
+выполняется один раз после каждой подтверждённой VAD паузы, а не на каждом
+аудиофрейме. Если пауза отклонена, возобновлённая речь остаётся в той же
+реплике; ограничение максимальной тишины всё равно гарантирует завершение.
+Smart Turn создан Pipecat/Daily и распространяется по BSD-2-Clause.
 
 ### Только детекция речевой активности
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -74,7 +74,7 @@ Kokoro 与 Supertonic 都支持在直接合成时按调用指定音色预设 —
 
 ```kotlin
 dependencies {
-    implementation("audio.soniqo:speech:0.0.19")
+    implementation("audio.soniqo:speech:0.0.20")
 }
 ```
 
@@ -100,6 +100,29 @@ pipeline.start()
 // 从麦克风输入 16kHz 单声道 float32 PCM
 pipeline.pushAudio(samples)
 ```
+
+### 轮次结束检测
+
+VAD 能检测静音，但无法判断一次停顿是否意味着说话者已经表达完毕。Smart Turn v3.2
+是可选的原生音频分类器；它分析当前轮次的最后 8 秒，并在话语未完成时保持轮次开放。
+
+```kotlin
+val modelDir = ModelManager.ensureModels(context, enableSmartTurn = true)
+
+val pipeline = SpeechPipeline(
+    SpeechConfig(
+        modelDir = modelDir,
+        enableSmartTurn = true,
+        turnCompletionThreshold = 0.5f,
+        turnCompletionMaxSilenceSec = 2.0f,
+    )
+)
+```
+
+启用后会额外下载固定版本的 11.1 MB INT8 模型。推理只在 VAD 确认每次停顿后运行
+一次，而不是对每个音频帧运行。若模型否决该停顿，恢复的语音仍属于同一轮次；最大静音
+时长则保证轮次最终会结束。Smart Turn 由 Pipecat/Daily 创建，并以 BSD-2-Clause
+许可证发布。
 
 ### 仅语音活动检测
 

--- a/sdk/src/androidTest/kotlin/audio/soniqo/speech/SmartTurnTest.kt
+++ b/sdk/src/androidTest/kotlin/audio/soniqo/speech/SmartTurnTest.kt
@@ -1,0 +1,116 @@
+package audio.soniqo.speech
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/** Android integration coverage for speech-core's Smart Turn ONNX backend. */
+@RunWith(AndroidJUnit4::class)
+class SmartTurnTest {
+
+    private lateinit var modelDir: String
+
+    @Before
+    fun setup() = runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        modelDir = ModelManager.ensureModels(context, enableSmartTurn = true)
+    }
+
+    @Test
+    fun smartTurnModelIsReadyAndLoadsThroughThePipeline() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        assertTrue(ModelManager.areModelsReady(context, enableSmartTurn = true))
+
+        SpeechPipeline(
+            SpeechConfig(
+                modelDir = modelDir,
+                useNnapi = false,
+                enableSmartTurn = true,
+            )
+        ).use { pipeline ->
+            assertEquals(PipelineState.Idle, pipeline.state)
+            pipeline.start()
+            pipeline.stop()
+        }
+    }
+
+    @Test
+    fun vetoedPauseWaitsForTheConfiguredSilenceCap() = runBlocking {
+        val audio = synthesize("Could you tell me the weather today?")
+        val pipeline = SpeechPipeline(
+            SpeechConfig(
+                modelDir = modelDir,
+                useNnapi = false,
+                enableSmartTurn = true,
+                // A sigmoid probability is below 1, so this deliberately makes
+                // every model decision exercise the hold path.
+                turnCompletionThreshold = 1f,
+                turnCompletionMaxSilenceSec = 2f,
+            )
+        )
+
+        try {
+            pipeline.start()
+            val ended = async(start = CoroutineStart.UNDISPATCHED) {
+                withTimeout(60_000) {
+                    pipeline.events.first { it is SpeechEvent.SpeechEnded }
+                }
+            }
+
+            pushFrames(pipeline, audio)
+            repeat(31) { pipeline.pushAudio(FloatArray(512)) } // ~1 s
+            delay(100)
+            assertFalse("Smart Turn should hold the first pause", ended.isCompleted)
+
+            repeat(47) { pipeline.pushAudio(FloatArray(512)) } // total silence ~2.5 s
+            assertNotNull("the maximum-silence cap must settle the turn", ended.await())
+        } finally {
+            pipeline.stop()
+            pipeline.close()
+        }
+    }
+
+    private fun synthesize(text: String): FloatArray =
+        SpeechSynthesizer(SpeechSynthesizerConfig(modelDir = modelDir, useNnapi = false)).use {
+            val result = it.synthesize(text, "en")
+            val shorts = ShortArray(result.pcm16.size / 2)
+            ByteBuffer.wrap(result.pcm16)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .asShortBuffer()
+                .get(shorts)
+            val source = FloatArray(shorts.size) { index -> shorts[index] / 32768f }
+            if (result.sampleRate == 16000) return@use source
+
+            val outputSize = ((source.size.toLong() * 16000L) / result.sampleRate).toInt()
+            FloatArray(outputSize) { index ->
+                val sourceIndex = index.toDouble() * result.sampleRate / 16000.0
+                val lower = sourceIndex.toInt().coerceIn(0, source.lastIndex)
+                val upper = minOf(lower + 1, source.lastIndex)
+                val fraction = (sourceIndex - lower).toFloat()
+                source[lower] * (1f - fraction) + source[upper] * fraction
+            }
+        }
+
+    private fun pushFrames(pipeline: SpeechPipeline, audio: FloatArray) {
+        for (offset in audio.indices step 512) {
+            val end = minOf(offset + 512, audio.size)
+            if (end - offset == 512) {
+                pipeline.pushAudio(audio.sliceArray(offset until end))
+            }
+        }
+    }
+}

--- a/sdk/src/main/cpp/jni_bridge.cpp
+++ b/sdk/src/main/cpp/jni_bridge.cpp
@@ -7,6 +7,7 @@
 #include <speech_core/models/onnx_canary_stt.h>
 #include <speech_core/models/onnx_nemotron_streaming_stt.h>
 #include <speech_core/models/onnx_pocket_tts.h>
+#include <speech_core/models/onnx_smart_turn.h>
 #include <speech_core/models/parakeet_stt.h>
 #include <speech_core/models/nemotron_multilingual_stt.h>
 #include <speech_core/models/silero_vad.h>
@@ -48,6 +49,7 @@ struct PipelineHandle {
     std::unique_ptr<speech_core::STTInterface> stt;  // Parakeet-EOU, Parakeet TDT, or Nemotron
     std::unique_ptr<speech_core::TTSInterface> tts;  // Kokoro/Pocket (ONNX) or Supertonic (LiteRT)
     std::unique_ptr<speech_core::DeepFilterEnhancer> enhancer;
+    std::unique_ptr<speech_core::OnnxSmartTurn> smart_turn;
     std::unique_ptr<speech_core::VoicePipeline> pipeline;
 
     // Non-owning typed view of `stt` when the Parakeet-EOU streaming model is
@@ -304,7 +306,9 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
     jobjectArray languageHints,
     jobject callback,
     jboolean emitPartialTranscriptions, jfloat partialTranscriptionInterval,
-    jfloat endOfSpeechSilenceSec, jint beamSize)
+    jfloat endOfSpeechSilenceSec, jint beamSize,
+    jboolean enableSmartTurn, jfloat turnCompletionThreshold,
+    jfloat turnCompletionMaxSilenceSec)
 {
     auto dir = jstring_to_string(env, modelDir);
     bool nnapi = useNnapi;
@@ -413,6 +417,14 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
         }
         // TTS — Kokoro (ONNX, 24 kHz) or Supertonic-3 (LiteRT flow-matching, 44.1 kHz, G2P-free).
         h->tts = create_tts(dir, nnapi, ttsModel);
+        if (enableSmartTurn) {
+            // Smart Turn runs once per confirmed VAD pause. Keep it on CPU:
+            // the mobile build's dynamic-int8 graph is small, while NNAPI
+            // partitioning and fallback would add device-specific variance.
+            h->smart_turn = std::make_unique<speech_core::OnnxSmartTurn>(
+                dir + "/smart-turn-v3.2-int8.onnx",
+                /*hardware_acceleration=*/false);
+        }
 
         speech_core::AgentConfig cfg;
         // App-tunable end-of-utterance silence; <=0 falls back to the
@@ -424,6 +436,8 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
         cfg.post_playback_guard = 0.15f;
         cfg.emit_partial_transcriptions = emitPartialTranscriptions;
         cfg.partial_transcription_interval = partialTranscriptionInterval;
+        cfg.turn_completion_threshold = turnCompletionThreshold;
+        cfg.turn_completion_max_silence = turnCompletionMaxSilenceSec;
         cfg.mode = (pipelineMode == MODE_TRANSCRIBE_ONLY)
             ? speech_core::AgentConfig::Mode::TranscribeOnly
             : speech_core::AgentConfig::Mode::Echo;
@@ -438,6 +452,9 @@ Java_audio_soniqo_speech_NativeBridge_nativeCreate(
         h->pipeline = std::make_unique<speech_core::VoicePipeline>(
             *h->stt, *h->tts, /*llm=*/nullptr, *h->vad, cfg,
             [raw](const speech_core::PipelineEvent& e) { dispatch_event(raw, e); });
+        if (h->smart_turn) {
+            h->pipeline->set_turn_completion(h->smart_turn.get());
+        }
 
         auto& engine = OnnxEngine::get();
         if (engine.had_nnapi_fallback()) {

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelDownloadWorker.kt
@@ -77,6 +77,7 @@ class ModelDownloadWorker(
         // and Wi-Fi power-save that would kill an in-app download.
         val includeLlm = inputData.getBoolean(KEY_INCLUDE_LLM, false)
         val supertonicLatentBuckets = inputData.getBoolean(KEY_SUPERTONIC_LATENT_BUCKETS, false)
+        val enableSmartTurn = inputData.getBoolean(KEY_ENABLE_SMART_TURN, false)
 
         runCatching { setForeground(buildForegroundInfo(0, "Preparing speech models…")) }
 
@@ -86,6 +87,7 @@ class ModelDownloadWorker(
         // of two sweeps that visibly reset to zero in the middle.
         val plannedPipeline = ModelManager.plannedModelBytes(
             applicationContext, precision, sttModel, sttBackend, ttsModel,
+            enableSmartTurn,
         )
         val plannedLlm =
             if (includeLlm) ModelManager.plannedLlmBytes(applicationContext, llmModel) else 0L
@@ -171,6 +173,7 @@ class ModelDownloadWorker(
                 ttsModel = ttsModel,
                 onProgress = report,
                 supertonicLatentBuckets = supertonicLatentBuckets,
+                enableSmartTurn = enableSmartTurn,
             )
             if (includeLlm) {
                 // Hand the bar over to the LLM phase: what the pipeline phase
@@ -314,6 +317,7 @@ class ModelDownloadWorker(
         const val KEY_TTS_MODEL = "ttsModel"
         const val KEY_INCLUDE_LLM = "includeLlm"
         const val KEY_SUPERTONIC_LATENT_BUCKETS = "supertonicLatentBuckets"
+        const val KEY_ENABLE_SMART_TURN = "enableSmartTurn"
         const val KEY_LLM_MODEL = "llmModel"
 
         // Output keys
@@ -358,13 +362,15 @@ class ModelDownloadWorker(
             includeLlm: Boolean = false,
             llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
             supertonicLatentBuckets: Boolean = false,
+            enableSmartTurn: Boolean = false,
         ): String {
             if (
                 precision == ModelPrecision.INT8 &&
                 sttModel == SttModel.PARAKEET_EOU &&
                 sttBackend == SttBackend.ONNX &&
                 ttsModel.isKokoro &&
-                !includeLlm
+                !includeLlm &&
+                !enableSmartTurn
             ) {
                 return UNIQUE_NAME
             }
@@ -375,7 +381,8 @@ class ModelDownloadWorker(
                 else -> ".llm.${llmModel.name}"
             }
             val ttsName = if (ttsModel.isKokoro) TtsModel.KOKORO.name else ttsModel.name
-            return "$UNIQUE_NAME.${precision.name}.${sttModel.name}.${sttBackend.name}.$ttsName$buckets$llm"
+            val smartTurn = if (enableSmartTurn) ".smartTurn" else ""
+            return "$UNIQUE_NAME.${precision.name}.${sttModel.name}.${sttBackend.name}.$ttsName$buckets$smartTurn$llm"
         }
 
         fun request(
@@ -386,6 +393,7 @@ class ModelDownloadWorker(
             includeLlm: Boolean = false,
             llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
             supertonicLatentBuckets: Boolean = false,
+            enableSmartTurn: Boolean = false,
         ) =
             OneTimeWorkRequestBuilder<ModelDownloadWorker>()
                 .setInputData(workDataOf(
@@ -396,6 +404,7 @@ class ModelDownloadWorker(
                     KEY_INCLUDE_LLM to includeLlm,
                     KEY_LLM_MODEL to llmModel.name,
                     KEY_SUPERTONIC_LATENT_BUCKETS to supertonicLatentBuckets,
+                    KEY_ENABLE_SMART_TURN to enableSmartTurn,
                 ))
                 .build()
 
@@ -413,6 +422,7 @@ class ModelDownloadWorker(
             includeLlm: Boolean = false,
             llmModel: LlmModel = LlmModel.FUNCTIONGEMMA,
             supertonicLatentBuckets: Boolean = false,
+            enableSmartTurn: Boolean = false,
         ): java.util.UUID {
             val req = request(
                 precision = precision,
@@ -422,6 +432,7 @@ class ModelDownloadWorker(
                 includeLlm = includeLlm,
                 llmModel = llmModel,
                 supertonicLatentBuckets = supertonicLatentBuckets,
+                enableSmartTurn = enableSmartTurn,
             )
             WorkManager.getInstance(context).enqueueUniqueWork(
                 uniqueName(
@@ -432,6 +443,7 @@ class ModelDownloadWorker(
                     includeLlm = includeLlm,
                     llmModel = llmModel,
                     supertonicLatentBuckets = supertonicLatentBuckets,
+                    enableSmartTurn = enableSmartTurn,
                 ),
                 ExistingWorkPolicy.KEEP, req,
             )

--- a/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/ModelManager.kt
@@ -33,6 +33,7 @@ object ModelManager {
     private const val NEMOTRON_LITERT_INT8_REVISION = "v1.0.0"
     private const val NEMOTRON_LITERT_FP16_REVISION =
         "1503a9a1eb75b813b83ba65bf5e9fecea4a46091"
+    private const val SMART_TURN_REVISION = "b48fdbe20772bcec1fef02f4a1a355236ef6359e"
 
     // Bump when models on HuggingFace are updated to trigger cache invalidation.
     // v6: default STT switched to Parakeet-EOU-120M-ONNX-INT8, the low-memory
@@ -62,6 +63,7 @@ object ModelManager {
         sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
         supertonicLatentBuckets: Boolean = false,
+        enableSmartTurn: Boolean = false,
     ): List<ModelFile> {
         val suffix = if (precision == ModelPrecision.INT8) "-int8" else ""
         val files = vadModels().toMutableList()
@@ -144,6 +146,9 @@ object ModelManager {
 
         // Noise cancellation
         files += ModelFile("DeepFilterNet3-ONNX", "deepfilter-auxiliary.bin")
+        if (enableSmartTurn) {
+            files += smartTurnModels()
+        }
         return files
         // Note: FP32 Parakeet encoder also needs parakeet-encoder.onnx.data.
     }
@@ -153,6 +158,19 @@ object ModelManager {
     @VisibleForTesting
     internal fun vadModels(): List<ModelFile> = listOf(
         ModelFile("Silero-VAD-v5-ONNX", "silero-vad.onnx"),
+    )
+
+    /** Optional end-of-turn classifier. Android always uses the dynamic-int8
+     *  graph: it saves about 22 MB over fp32 and keeps the same raw-audio I/O
+     *  contract. The immutable revision prevents a model re-export from
+     *  changing that contract underneath an installed SDK. */
+    @VisibleForTesting
+    internal fun smartTurnModels(): List<ModelFile> = listOf(
+        ModelFile(
+            repo = "Smart-Turn-v3.2-ONNX",
+            filename = "smart-turn-v3.2-int8.onnx",
+            revision = SMART_TURN_REVISION,
+        ),
     )
 
     @VisibleForTesting
@@ -297,6 +315,7 @@ object ModelManager {
         sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
         supertonicLatentBuckets: Boolean = false,
+        enableSmartTurn: Boolean = false,
     ): Boolean {
         val dir = modelDirFile(context, precision, sttModel, sttBackend, ttsModel)
         if (!dir.exists()) return false
@@ -306,7 +325,10 @@ object ModelManager {
         if (cached < MODEL_VERSION) return false
         if (cachedModelSet(dir) != modelSetKey(precision, sttModel, sttBackend, ttsModel)) return false
 
-        val fileList = models(precision, sttModel, sttBackend, ttsModel, supertonicLatentBuckets)
+        val fileList = models(
+            precision, sttModel, sttBackend, ttsModel,
+            supertonicLatentBuckets, enableSmartTurn,
+        )
         val allFiles = if (precision == ModelPrecision.FP32 && sttModel == SttModel.PARAKEET) {
             fileList + ModelFile("Parakeet-TDT-0.6B-ONNX", "parakeet-encoder.onnx.data")
         } else {
@@ -436,6 +458,7 @@ object ModelManager {
         ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
         onProgress: ((Progress) -> Unit)? = null,
         supertonicLatentBuckets: Boolean = false,
+        enableSmartTurn: Boolean = false,
     ): String = withContext(Dispatchers.IO) {
         val dir = modelDirFile(context, precision, sttModel, sttBackend, ttsModel)
         dir.mkdirs()
@@ -454,7 +477,10 @@ object ModelManager {
         // bytes=N- on the next attempt. Stale .tmp from an old MODEL_VERSION
         // or from a different model set are already wiped above.
 
-        val fileList = models(precision, sttModel, sttBackend, ttsModel, supertonicLatentBuckets)
+        val fileList = models(
+            precision, sttModel, sttBackend, ttsModel,
+            supertonicLatentBuckets, enableSmartTurn,
+        )
         // FP32 Parakeet encoder needs the external data file.
         val allFiles = if (precision == ModelPrecision.FP32 && sttModel == SttModel.PARAKEET) {
             fileList + ModelFile("Parakeet-TDT-0.6B-ONNX", "parakeet-encoder.onnx.data")
@@ -649,10 +675,18 @@ object ModelManager {
         sttModel: SttModel = SttModel.PARAKEET_EOU,
         sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO_SHORT_TURN,
+        enableSmartTurn: Boolean = false,
     ): Long {
         val dir = modelDirFile(context, precision, sttModel, sttBackend, ttsModel)
         val stale = cacheIsStale(dir, modelSetKey(precision, sttModel, sttBackend, ttsModel))
-        return plannedBytes(dir, models(precision, sttModel, sttBackend, ttsModel), stale)
+        return plannedBytes(
+            dir,
+            models(
+                precision, sttModel, sttBackend, ttsModel,
+                enableSmartTurn = enableSmartTurn,
+            ),
+            stale,
+        )
     }
 
     /** [plannedModelBytes] for the FunctionGemma bundle fetched by [ensureLlmModels]. */
@@ -959,6 +993,7 @@ object ModelManager {
         "kokoro-e2e.onnx" to 3_047_254L,
         "kokoro-e2e-realtime.onnx" to 2_413_312L,
         "kokoro-e2e.onnx.data" to 324_564_624L,
+        "smart-turn-v3.2-int8.onnx" to 11_123_370L,
         // Pocket TTS bundle — the Control demo's default TTS, so these matter
         // for its bar; without them the total under-counts by ~126 MB and then
         // visibly grows as the files self-correct to Content-Length.
@@ -1031,6 +1066,7 @@ object ModelManager {
         "text_conditioner.onnx" to 15_000_000L,          // Pocket text encoder, ~16.4 MB
         "token_scores.json" to 100_000L,                 // Pocket tokenizer scores
         "silero-vad.onnx" to 500_000L,                   // ~2 MB
+        "smart-turn-v3.2-int8.onnx" to 10_000_000L,      // ~11.1 MB
         "model.litertlm" to 200_000_000L,                // ~283 MB FunctionGemma bundle
         "model-lora16-android.litertlm" to 300_000_000L, // ~327 MB LoRA-capable base
         "control-r4-rank16.tflite" to 9_000_000L,        // ~9.5 MB Control adapter

--- a/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/NativeBridge.kt
@@ -22,6 +22,9 @@ internal object NativeBridge {
         partialTranscriptionInterval: Float,
         endOfSpeechSilenceSec: Float,  // seconds of silence ending an utterance
         beamSize: Int,                 // Parakeet-EOU RNN-T beam width; <=1 = greedy
+        enableSmartTurn: Boolean,      // attach Smart Turn v3.2 after VAD pauses
+        turnCompletionThreshold: Float,
+        turnCompletionMaxSilenceSec: Float,
     ): Long
 
     external fun nativeNnapiFallbackReason(): String?

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechConfig.kt
@@ -97,7 +97,31 @@ data class SpeechConfig(
      *  mid-utterance — dictating digit sequences, thinking through a
      *  sentence — and get cut off early. */
     val endOfSpeechSilenceSec: Float = 0.5f,
+
+    /** Use Pipecat Smart Turn v3.2 after VAD detects a pause. The classifier
+     *  considers the last eight seconds of the current turn and keeps the turn
+     *  open when the user's prosody sounds incomplete. Requires
+     *  [ModelManager.ensureModels] or [ModelDownloadWorker] to be called with
+     *  their matching `enableSmartTurn = true` option. */
+    val enableSmartTurn: Boolean = false,
+
+    /** Smart Turn probability that confirms the user has finished speaking. */
+    val turnCompletionThreshold: Float = 0.5f,
+
+    /** Maximum silence after Smart Turn vetoes an endpoint. Measured from the
+     *  start of the pause; `0` disables the silence cap. */
+    val turnCompletionMaxSilenceSec: Float = 2.0f,
 )
+
+internal fun SpeechConfig.requireValidConfiguration() {
+    requireValidLanguageConfiguration()
+    require(turnCompletionThreshold in 0f..1f) {
+        "SpeechConfig.turnCompletionThreshold must be between 0 and 1"
+    }
+    require(turnCompletionMaxSilenceSec.isFinite() && turnCompletionMaxSilenceSec >= 0f) {
+        "SpeechConfig.turnCompletionMaxSilenceSec must be finite and non-negative"
+    }
+}
 
 /** Validate language settings before JNI loads models or starts native work. */
 internal fun SpeechConfig.requireValidLanguageConfiguration() {

--- a/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
+++ b/sdk/src/main/kotlin/audio/soniqo/speech/SpeechPipeline.kt
@@ -123,7 +123,7 @@ interface SpeechPipeline : AutoCloseable {
 
     companion object {
         operator fun invoke(config: SpeechConfig): SpeechPipeline {
-            config.requireValidLanguageConfiguration()
+            config.requireValidConfiguration()
             return SpeechPipelineImpl(config)
         }
     }
@@ -171,6 +171,9 @@ internal class SpeechPipelineImpl(config: SpeechConfig) : SpeechPipeline {
         config.partialTranscriptionInterval,
         config.endOfSpeechSilenceSec,
         config.beamSize,
+        config.enableSmartTurn,
+        config.turnCompletionThreshold,
+        config.turnCompletionMaxSilenceSec,
     ).also { h ->
         if (h == 0L) throw IllegalStateException(
             "Failed to create native pipeline. Models may be corrupt — " +

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelDownloadWorkerTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelDownloadWorkerTest.kt
@@ -46,7 +46,7 @@ class ModelDownloadWorkerTest {
     @Test
     fun `success returns model dir in output data`() = runBlocking {
         coEvery {
-            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any(), any(), any())
         } returns "/fake/model/dir"
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context)
@@ -65,7 +65,7 @@ class ModelDownloadWorkerTest {
         // Transient network/disk failures go back to WorkManager so it
         // reschedules with exponential backoff.
         coEvery {
-            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any(), any(), any())
         } throws IOException("network down")
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context).build()
@@ -79,7 +79,7 @@ class ModelDownloadWorkerTest {
         // Non-IO exceptions are not transient — Failure carries the message so
         // the host activity can surface it.
         coEvery {
-            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any(), any(), any())
         } throws IllegalStateException("models corrupt")
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context).build()
@@ -93,7 +93,7 @@ class ModelDownloadWorkerTest {
     @Test
     fun `missing or invalid inputs fall back to INT8 and short-turn Kokoro`() = runBlocking {
         coEvery {
-            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any(), any(), any())
         } returns "/fake"
 
         TestListenableWorkerBuilder<ModelDownloadWorker>(context).build().doWork()
@@ -110,6 +110,8 @@ class ModelDownloadWorkerTest {
                 any(),
                 TtsModel.KOKORO_SHORT_TURN,
                 any(),
+                false,
+                false,
             )
         }
     }
@@ -117,7 +119,7 @@ class ModelDownloadWorkerTest {
     @Test
     fun `model inputs are passed to ModelManager`() = runBlocking {
         coEvery {
-            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any(), any(), any())
         } returns "/fake"
 
         val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context)
@@ -139,6 +141,27 @@ class ModelDownloadWorkerTest {
                 SttBackend.ONNX,
                 TtsModel.SUPERTONIC,
                 any(),
+                false,
+                false,
+            )
+        }
+    }
+
+    @Test
+    fun `Smart Turn input downloads the optional model`() = runBlocking {
+        coEvery {
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any(), any(), any())
+        } returns "/fake"
+
+        val worker = TestListenableWorkerBuilder<ModelDownloadWorker>(context)
+            .setInputData(workDataOf(ModelDownloadWorker.KEY_ENABLE_SMART_TURN to true))
+            .build()
+
+        worker.doWork()
+
+        coVerify(exactly = 1) {
+            ModelManager.ensureModels(
+                any(), any(), any(), any(), any(), any(), any(), true,
             )
         }
     }
@@ -146,7 +169,7 @@ class ModelDownloadWorkerTest {
     @Test
     fun `control lora input downloads selected llm profile`() = runBlocking {
         coEvery {
-            ModelManager.ensureModels(any(), any(), any(), any(), any(), any())
+            ModelManager.ensureModels(any(), any(), any(), any(), any(), any(), any(), any())
         } returns "/fake"
         coEvery {
             ModelManager.ensureLlmModels(any(), any(), any())
@@ -180,6 +203,7 @@ class ModelDownloadWorkerTest {
             ttsModel = TtsModel.KOKORO,
             includeLlm = true,
             llmModel = LlmModel.FUNCTIONGEMMA_CONTROL_LORA,
+            enableSmartTurn = true,
         )
 
         assertEquals(
@@ -199,6 +223,7 @@ class ModelDownloadWorkerTest {
             req.workSpec.input.getString(ModelDownloadWorker.KEY_TTS_MODEL),
         )
         assertTrue(req.workSpec.input.getBoolean(ModelDownloadWorker.KEY_INCLUDE_LLM, false))
+        assertTrue(req.workSpec.input.getBoolean(ModelDownloadWorker.KEY_ENABLE_SMART_TURN, false))
         assertEquals(
             "FUNCTIONGEMMA_CONTROL_LORA",
             req.workSpec.input.getString(ModelDownloadWorker.KEY_LLM_MODEL),
@@ -234,6 +259,10 @@ class ModelDownloadWorkerTest {
         assertNotEquals(
             ModelDownloadWorker.UNIQUE_NAME,
             ModelDownloadWorker.uniqueName(sttModel = SttModel.PARAKEET),
+        )
+        assertNotEquals(
+            ModelDownloadWorker.UNIQUE_NAME,
+            ModelDownloadWorker.uniqueName(enableSmartTurn = true),
         )
         assertNotEquals(
             ModelDownloadWorker.uniqueName(sttModel = SttModel.PARAKEET),

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerManifestTest.kt
@@ -23,6 +23,7 @@ class ModelManagerManifestTest {
         assertEquals(SttModel.PARAKEET_EOU, SpeechConfig().sttModel)
         assertEquals(TtsModel.KOKORO_SHORT_TURN, SpeechConfig().ttsModel)
         assertFalse(SpeechConfig().useNnapi)
+        assertFalse(SpeechConfig().enableSmartTurn)
         assertEquals(TtsModel.KOKORO_SHORT_TURN, SpeechSynthesizerConfig().ttsModel)
         assertFalse(SpeechSynthesizerConfig().useNnapi)
     }
@@ -212,6 +213,29 @@ class ModelManagerManifestTest {
         assertEquals(
             listOf(ModelManager.ModelFile("Silero-VAD-v5-ONNX", "silero-vad.onnx")),
             ModelManager.vadModels(),
+        )
+    }
+
+    @Test
+    fun `Smart Turn manifest is opt-in and pinned`() {
+        val expected = ModelManager.ModelFile(
+            repo = "Smart-Turn-v3.2-ONNX",
+            filename = "smart-turn-v3.2-int8.onnx",
+            revision = "b48fdbe20772bcec1fef02f4a1a355236ef6359e",
+        )
+
+        assertEquals(listOf(expected), ModelManager.smartTurnModels())
+        assertFalse(modelFiles().contains(expected))
+        assertTrue(modelFiles(enableSmartTurn = true).contains(expected))
+    }
+
+    @Test
+    fun `Smart Turn augments the existing pipeline cache`() {
+        // Enabling the optional model must not send an existing ~493 MB cache
+        // to a second directory or invalidate its already-downloaded files.
+        assertEquals(
+            modelFiles() + ModelManager.smartTurnModels(),
+            modelFiles(enableSmartTurn = true),
         )
     }
 
@@ -444,8 +468,12 @@ class ModelManagerManifestTest {
         sttModel: SttModel = SttModel.PARAKEET_EOU,
         sttBackend: SttBackend = SttBackend.ONNX,
         ttsModel: TtsModel = TtsModel.KOKORO,
+        enableSmartTurn: Boolean = false,
     ): List<ModelManager.ModelFile> =
-        ModelManager.models(precision, sttModel, sttBackend, ttsModel)
+        ModelManager.models(
+            precision, sttModel, sttBackend, ttsModel,
+            enableSmartTurn = enableSmartTurn,
+        )
 
     private fun modelSetKey(
         precision: ModelPrecision = ModelPrecision.INT8,

--- a/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerPlanningTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/ModelManagerPlanningTest.kt
@@ -55,6 +55,13 @@ class ModelManagerPlanningTest {
     }
 
     @Test
+    fun `Smart Turn adds its pinned int8 graph to the plan`() {
+        val without = ModelManager.plannedModelBytes(context)
+        val with = ModelManager.plannedModelBytes(context, enableSmartTurn = true)
+        assertEquals(11_123_370L, with - without)
+    }
+
+    @Test
     fun `fresh install plans the exact FunctionGemma bundle size`() {
         assertEquals(297_212_528L, ModelManager.plannedLlmBytes(context))
     }

--- a/sdk/src/test/kotlin/audio/soniqo/speech/SpeechConfigTest.kt
+++ b/sdk/src/test/kotlin/audio/soniqo/speech/SpeechConfigTest.kt
@@ -13,6 +13,39 @@ class SpeechConfigTest {
     }
 
     @Test
+    fun `Smart Turn is opt-in with speech-core policy defaults`() {
+        val config = SpeechConfig()
+        assertEquals(false, config.enableSmartTurn)
+        assertEquals(0.5f, config.turnCompletionThreshold, 0f)
+        assertEquals(2.0f, config.turnCompletionMaxSilenceSec, 0f)
+    }
+
+    @Test
+    fun `Smart Turn threshold must be a probability`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            SpeechConfig(turnCompletionThreshold = -0.01f).requireValidConfiguration()
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            SpeechConfig(turnCompletionThreshold = 1.01f).requireValidConfiguration()
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            SpeechConfig(turnCompletionThreshold = Float.NaN).requireValidConfiguration()
+        }
+    }
+
+    @Test
+    fun `Smart Turn silence cap accepts zero but rejects invalid durations`() {
+        SpeechConfig(turnCompletionMaxSilenceSec = 0f).requireValidConfiguration()
+        assertThrows(IllegalArgumentException::class.java) {
+            SpeechConfig(turnCompletionMaxSilenceSec = -0.01f).requireValidConfiguration()
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            SpeechConfig(turnCompletionMaxSilenceSec = Float.POSITIVE_INFINITY)
+                .requireValidConfiguration()
+        }
+    }
+
+    @Test
     fun `cn country code is rejected with Chinese language tags`() {
         val error = assertThrows(IllegalArgumentException::class.java) {
             SpeechConfig(


### PR DESCRIPTION
## Summary

- update speech-core to v0.0.14 and expose opt-in Smart Turn configuration through Kotlin and JNI
- download the pinned 11.1 MB int8 model without invalidating the existing pipeline cache
- propagate the option through WorkManager and validate configuration inputs
- document the API in every Android README translation
- add unit coverage and real Android model/pipeline tests

## Testing

- `./setup.sh`
- `./gradlew :sdk:test :sdk:assembleDebug`
- `./gradlew :sdk:connectedAndroidTest` on ARM64 API 35: 48 passed, 4 fixture-gated skips, 0 failures
- focused Smart Turn run from a clean checkout: 2 passed, 0 failures