### PR TITLE
Manage dependencies using version catalogs.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
 }
 
 android {
@@ -56,14 +56,15 @@ android {
 
 dependencies {
     implementation(project(":sdk"))
-    implementation("androidx.core:core-ktx:1.15.0")
-    implementation("androidx.appcompat:appcompat:1.7.0")
-    implementation("com.google.android.material:material:1.12.0")
-    implementation("androidx.activity:activity-ktx:1.9.0")
-    implementation("androidx.work:work-runtime-ktx:2.11.2")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
 
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("org.robolectric:robolectric:4.13")
-    testImplementation("androidx.test:core:1.6.1")
+    implementation(libs.androidx.core)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.material)
+    implementation(libs.androidx.activity.ktx)
+    implementation(libs.androidx.work.runtime)
+    implementation(libs.kotlinx.coroutines.android)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
-    id("com.android.application") version "8.13.2" apply false
-    id("com.android.library") version "8.13.2" apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
     // LiteRT-LM 0.16.0 publishes Kotlin 2.3 metadata, which requires the
     // Kotlin 2.2 compiler used by the full-pipeline Compose demo.
-    id("org.jetbrains.kotlin.android") version "2.2.21" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.2.21" apply false
-    id("com.vanniktech.maven.publish") version "0.35.0" apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.compose) apply false
+    alias(libs.plugins.maven.publish) apply false
 }

--- a/control-demo/build.gradle.kts
+++ b/control-demo/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.compose")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose)
 }
 
 android {
@@ -64,25 +64,25 @@ dependencies {
 
     // FunctionGemma runs in the app rather than the SDK, keeping LiteRT-LM
     // out of the published speech artifact.
-    implementation("com.google.ai.edge.litertlm:litertlm-android:0.16.0")
-    implementation("androidx.core:core-ktx:1.15.0")
-    implementation("com.google.android.material:material:1.12.0")
-    implementation("androidx.activity:activity-ktx:1.9.0")
-    implementation("androidx.work:work-runtime-ktx:2.11.2")
+    implementation(libs.litertlm)
+    implementation(libs.androidx.core)
+    implementation(libs.material)
+    implementation(libs.androidx.activity.ktx)
+    implementation(libs.androidx.work.runtime)
     // LiteRT-LM's Kotlin bindings are compiled against the interface-default
     // layout introduced in coroutines 1.11.0. Its published POM still asks
     // for 1.9.0, which can terminate the app with NoSuchMethodError when a
     // binding callback completes (google-ai-edge/LiteRT-LM#2812).
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0")
+    implementation(libs.kotlinx.coroutines.android)
 
-    implementation(platform("androidx.compose:compose-bom:2024.12.01"))
-    implementation("androidx.activity:activity-compose:1.9.3")
-    implementation("androidx.compose.material3:material3")
-    implementation("androidx.compose.ui:ui")
-    implementation("androidx.compose.animation:animation")
-    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.animation)
+    implementation(libs.androidx.lifecycle.runtime.compose)
 
-    testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
-    androidTestImplementation("androidx.test:runner:1.6.2")
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.test.ext)
+    androidTestImplementation(libs.androidx.test.runner)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,54 @@
+[versions]
+androidGradlePlugin = "8.13.2"
+androidxActivity = "1.9.3"
+androidxAnnotation = "1.8.2"
+androidxAppCompat = "1.7.0"
+androidxComposeBom = "2024.12.01"
+androidxCore = "1.15.0"
+androidxLifecycle = "2.8.7"
+androidxTestCore = "1.6.1"
+androidxTestExt = "1.2.1"
+androidxTestRunner = "1.6.2"
+androidxWork = "2.11.2"
+junit4 = "4.13.2"
+kotlin = "2.2.21"
+kotlinxCoroutines = "1.11.0"
+litertlm = "0.16.0"
+material = "1.12.0"
+mavenPublish = "0.35.0"
+mockk = "1.13.13"
+okhttp = "4.12.0"
+robolectric = "4.13"
+
+[libraries]
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
+androidx-activity-ktx = { group = "androidx.activity", name = "activity", version.ref = "androidxActivity" }
+androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "androidxAnnotation" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
+androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-core = { group = "androidx.core", name = "core", version.ref = "androidxCore" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
+androidx-test-ext = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExt" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
+androidx-work-runtime = { group = "androidx.work", name = "work-runtime", version.ref = "androidxWork" }
+androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "androidxWork" }
+junit = { group = "junit", name = "junit", version.ref = "junit4" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
+litertlm = { group = "com.google.ai.edge.litertlm", name = "litertlm-android", version.ref = "litertlm" }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+okhttp3-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okhttp3-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    id("com.android.library")
-    id("org.jetbrains.kotlin.android")
-    id("com.vanniktech.maven.publish")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.maven.publish)
     id("maven-publish")
 }
 
@@ -116,22 +116,22 @@ publishing {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
-    implementation("androidx.annotation:annotation:1.8.2")
-    implementation("androidx.work:work-runtime-ktx:2.11.2")
-    implementation("androidx.core:core-ktx:1.13.1")
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.okhttp3.okhttp)
+    implementation(libs.androidx.annotation)
+    implementation(libs.androidx.work.runtime)
+    implementation(libs.androidx.core)
 
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
-    testImplementation("org.robolectric:robolectric:4.13")
-    testImplementation("androidx.test:core:1.6.1")
-    testImplementation("androidx.test.ext:junit:1.2.1")
-    testImplementation("io.mockk:mockk:1.13.13")
-    testImplementation("androidx.work:work-testing:2.11.2")
+    testImplementation(libs.junit)
+    testImplementation(libs.okhttp3.mockwebserver)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.androidx.test.ext)
+    testImplementation(libs.mockk)
+    testImplementation(libs.androidx.work.testing)
 
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
-    androidTestImplementation("androidx.test:runner:1.6.2")
-    androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+    androidTestImplementation(libs.androidx.test.ext)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
 }


### PR DESCRIPTION
Dependency and plugin coordinates are duplicated across the root build and the SDK and demo modules. Centralize them in `gradle/libs.versions.toml` and use catalog aliases throughout the build, aligning shared dependency versions in the process.

## Summary

- Move plugin and library declarations into the version catalog, including Compose BOM-managed libraries and test dependencies.
- Align SDK and app coroutines from 1.9.0 to 1.11.0. The control demo retains its existing 1.11.0 requirement for LiteRT-LM compatibility.
- Align the SDK's AndroidX Core dependency from 1.13.1 to 1.15.0 and direct Activity dependencies from 1.9.0 to 1.9.3.
- Replace direct `core-ktx`, `activity-ktx`, and `work-runtime-ktx` declarations with their base artifacts. These coordinate and version changes also affect the SDK's published dependency metadata.
- Keep AGP 8.13.2, Kotlin 2.2.21, and Gradle 8.13. The proposed build-tool upgrades are tracked separately in #91.

## Test plan

Validated commit `911e8a629c03a1e4a0c6127927d7c0d7b1926d57`:

- Passed `./gradlew :sdk:test :app:testDebugUnitTest :control-demo:testDebugUnitTest`: 320 test executions, with no failures or skips (129 SDK tests in each of debug and release, 20 app tests, and 42 control-demo tests).
- Passed release builds for the SDK and both demo apps, including native builds for arm64-v8a and x86_64 and R8 for both apps. Local builds reused the matching speech-core checkout and existing native dependency downloads.
- Passed SDK Maven POM generation and compared resolved compile/runtime dependencies against main to verify the changes above.
- Verified that the control demo's required LiteRT-LM JNI getters survive R8 and that the AAR and APKs contain the JNI library for both ABIs.
- GitHub CI unit/build checks and the submodule-ancestry check passed.

Device/model E2E tests were not run because no device was connected.

Reference: [Android's version catalog migration guide](https://developer.android.com/build/migrate-to-catalogs).
